### PR TITLE
feat(common): models, interfaces, and DTOs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,17 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.backends.legacy:build"
+
+[project]
+name = "sozia-server"
+version = "0.1.0"
+requires-python = ">=3.11"
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]
+addopts = "--cov=sozia --cov-report=term-missing"
+
+[tool.coverage.run]
+source = ["sozia"]
+omit = ["sozia/__init__.py"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,9 @@ fastapi>=0.100.0
 uvicorn>=0.23.0
 websockets>=12.0
 torch>=2.0.0
-numpy>=1.24.0"
+numpy>=1.24.0
+
+# dev
+pytest>=8.0.0
+pytest-asyncio>=0.23.0
+pytest-cov>=5.0.0

--- a/sozia/common/__init__.py
+++ b/sozia/common/__init__.py
@@ -1,0 +1,55 @@
+"""sozia.common — shared types and interface contracts.
+
+This package is the dependency leaf of the Sozia system (rule R3): it imports
+from neither sozia.server nor sozia.client. Every other package may import
+from here.
+"""
+
+from sozia.common.interfaces import (
+    FeatureExtractor,
+    FusionStrategy,
+    InferenceEngine,
+    InferenceTimeoutError,
+    ModelNotLoadedError,
+)
+from sozia.common.models import (
+    FACE_LANDMARK_COUNT,
+    HAND_LANDMARK_COUNT,
+    POSE_LANDMARK_COUNT,
+    AudioFeatureChunk,
+    LandmarkFrame,
+    ModalityPath,
+    ModalityResult,
+    ModalityType,
+    ModelConfig,
+    PipelineHealth,
+    SegmentStatus,
+    SessionState,
+    TranscriptSegment,
+)
+
+__all__ = [
+    # Enums
+    "SessionState",
+    "ModalityPath",
+    "ModalityType",
+    "SegmentStatus",
+    # DTOs
+    "ModelConfig",
+    "ModalityResult",
+    "PipelineHealth",
+    "LandmarkFrame",
+    "AudioFeatureChunk",
+    "TranscriptSegment",
+    # Constants
+    "FACE_LANDMARK_COUNT",
+    "HAND_LANDMARK_COUNT",
+    "POSE_LANDMARK_COUNT",
+    # ABCs
+    "InferenceEngine",
+    "FusionStrategy",
+    "FeatureExtractor",
+    # Exceptions
+    "InferenceTimeoutError",
+    "ModelNotLoadedError",
+]

--- a/sozia/common/interfaces.py
+++ b/sozia/common/interfaces.py
@@ -1,0 +1,157 @@
+"""Abstract interface contracts for the Sozia system.
+
+These ABCs decouple consumers from concrete implementations. Defined here in
+sozia.common so both the server and client share the same contract.
+
+Dependency rule R3: this module must not import from sozia.server or sozia.client.
+"""
+
+from __future__ import annotations
+
+import abc
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sozia.common.models import (
+        ModalityResult,
+        ModelConfig,
+        PipelineHealth,
+        TranscriptSegment,
+    )
+
+
+# ===========================================================================
+# Custom exceptions
+# ===========================================================================
+
+
+class InferenceTimeoutError(Exception):
+    """Raised when an inference engine exceeds its allotted timeout_ms budget."""
+
+
+class ModelNotLoadedError(Exception):
+    """Raised when predict() is called before load_model() has completed."""
+
+
+# ===========================================================================
+# Abstract Base Classes
+# ===========================================================================
+
+
+class InferenceEngine(abc.ABC):
+    """Abstract contract for every AI inference component on the server.
+
+    Enables model-agnostic design (Trade-off 5) and hot-swap via ModelRegistry.
+    All four engine classes implement this interface:
+    WhisperAsrEngine, LipReadingEngine, TslRecognitionEngine, GlossToTextEngine.
+    """
+
+    @abc.abstractmethod
+    async def load_model(self, config: ModelConfig) -> None:
+        """Load model weights into memory or GPU.
+
+        Args:
+            config: ModelConfig containing model_id, weights_path, device, and
+                engine-specific params.
+
+        Raises:
+            ValueError: If config is invalid for this engine.
+        """
+
+    @abc.abstractmethod
+    async def predict(self, features, timeout_ms: int = 2200) -> ModalityResult:
+        """Run inference on preprocessed features.
+
+        Args:
+            features: Input features. Type varies by engine — numpy array for
+                most engines, plain string for GlossToTextEngine.
+            timeout_ms: Maximum wall-clock time allowed. Defaults to 2200 ms,
+                matching the cloud inference budget.
+
+        Returns:
+            A ModalityResult with predicted text, confidence, and timing info.
+
+        Raises:
+            InferenceTimeoutError: Inference did not complete within timeout_ms.
+            ModelNotLoadedError: No model is currently loaded.
+        """
+
+    @abc.abstractmethod
+    async def unload_model(self) -> None:
+        """Release model weights and free GPU memory."""
+
+    @abc.abstractmethod
+    def is_loaded(self) -> bool:
+        """Return True if a model is currently loaded and ready for inference."""
+
+    @abc.abstractmethod
+    def get_model_id(self) -> str:
+        """Return the identifier of the currently loaded model, or '' if none."""
+
+
+class FusionStrategy(abc.ABC):
+    """Abstract contract for fusion policies.
+
+    Allows different fusion algorithms for the Speech path vs. the Sign path,
+    and future experimentation with alternative strategies.
+    Implemented by SpeechFusionPolicy and SignFusionPolicy in sozia.server.fusion.
+    """
+
+    @abc.abstractmethod
+    def fuse(
+        self,
+        results: list[ModalityResult],
+        health: list[PipelineHealth],
+    ) -> list[TranscriptSegment]:
+        """Accept inference results and pipeline health signals, return segments.
+
+        Typically produces one PARTIAL segment immediately and one FINAL segment
+        when the slower modality completes.
+
+        Args:
+            results: Inference results from one or more engines.
+            health: Current pipeline health signals from the client.
+
+        Returns:
+            A list of TranscriptSegment objects to stream to the client.
+        """
+
+    @abc.abstractmethod
+    def should_suppress(self, result: ModalityResult) -> bool:
+        """Return True if the result's confidence is below the minimum threshold.
+
+        Suppressed results are excluded from fusion and not shown to the user.
+
+        Args:
+            result: A ModalityResult to evaluate.
+        """
+
+    @abc.abstractmethod
+    def get_confidence_threshold(self) -> float:
+        """Return the current minimum confidence threshold (typically 0.30)."""
+
+
+class FeatureExtractor(abc.ABC):
+    """Abstract contract for client-side feature extraction.
+
+    Ensures AudioFeatureExtractor and LandmarkExtractor share a uniform
+    interface. Implemented by client pipeline packages (sozia.client.pipeline.*).
+    Defined here so the server can reference the contract without importing
+    client code.
+    """
+
+    @abc.abstractmethod
+    def extract(self, raw_input) -> object | None:
+        """Process a raw media buffer and return extracted features.
+
+        Args:
+            raw_input: Raw media handle (audio buffer or video frame).
+
+        Returns:
+            Extracted feature array or None if extraction fails (e.g. no face
+            detected in the frame).
+        """
+
+    @abc.abstractmethod
+    def is_ready(self) -> bool:
+        """Return True if the extractor is initialised and ready to process input."""

--- a/sozia/common/models.py
+++ b/sozia/common/models.py
@@ -102,9 +102,7 @@ def _validate_landmark_array(
             z is always unconstrained (MediaPipe relative depth).
     """
     if len(arr) != expected_len:
-        raise ValueError(
-            f"{name} must have {expected_len} points, got {len(arr)}"
-        )
+        raise ValueError(f"{name} must have {expected_len} points, got {len(arr)}")
     for i, point in enumerate(arr):
         if len(point) != 3:
             raise ValueError(
@@ -113,13 +111,9 @@ def _validate_landmark_array(
         if check_xy_unit_range:
             x, y = point[0], point[1]
             if not (0.0 <= x <= 1.0):
-                raise ValueError(
-                    f"{name}[{i}].x must be in [0.0, 1.0], got {x}"
-                )
+                raise ValueError(f"{name}[{i}].x must be in [0.0, 1.0], got {x}")
             if not (0.0 <= y <= 1.0):
-                raise ValueError(
-                    f"{name}[{i}].y must be in [0.0, 1.0], got {y}"
-                )
+                raise ValueError(f"{name}[{i}].y must be in [0.0, 1.0], got {y}")
 
 
 def _validate_rectangular_2d(
@@ -238,7 +232,9 @@ class PipelineHealth:
     def __post_init__(self) -> None:
         _validate_non_empty_str(self.session_id, "session_id")
         if self.pipeline not in {"audio", "video"}:
-            raise ValueError(f"pipeline must be 'audio' or 'video', got '{self.pipeline}'")
+            raise ValueError(
+                f"pipeline must be 'audio' or 'video', got '{self.pipeline}'"
+            )
         _validate_non_negative_int(self.last_updated_ms, "last_updated_ms")
 
         if self.pipeline == "audio":
@@ -307,22 +303,30 @@ class LandmarkFrame:
 
         if self.face_landmarks is not None:
             _validate_landmark_array(
-                self.face_landmarks, FACE_LANDMARK_COUNT, "face_landmarks",
+                self.face_landmarks,
+                FACE_LANDMARK_COUNT,
+                "face_landmarks",
                 check_xy_unit_range=True,
             )
         if self.left_hand_landmarks is not None:
             _validate_landmark_array(
-                self.left_hand_landmarks, HAND_LANDMARK_COUNT, "left_hand_landmarks",
+                self.left_hand_landmarks,
+                HAND_LANDMARK_COUNT,
+                "left_hand_landmarks",
                 check_xy_unit_range=True,
             )
         if self.right_hand_landmarks is not None:
             _validate_landmark_array(
-                self.right_hand_landmarks, HAND_LANDMARK_COUNT, "right_hand_landmarks",
+                self.right_hand_landmarks,
+                HAND_LANDMARK_COUNT,
+                "right_hand_landmarks",
                 check_xy_unit_range=True,
             )
         if self.pose_landmarks is not None:
             _validate_landmark_array(
-                self.pose_landmarks, POSE_LANDMARK_COUNT, "pose_landmarks",
+                self.pose_landmarks,
+                POSE_LANDMARK_COUNT,
+                "pose_landmarks",
                 check_xy_unit_range=True,
             )
 
@@ -363,7 +367,9 @@ class AudioFeatureChunk:
                 f"got '{self.feature_type}'"
             )
         if self.sample_rate_hz <= 0:
-            raise ValueError(f"sample_rate_hz must be positive, got {self.sample_rate_hz}")
+            raise ValueError(
+                f"sample_rate_hz must be positive, got {self.sample_rate_hz}"
+            )
         if self.chunk_duration_ms <= 0:
             raise ValueError(
                 f"chunk_duration_ms must be > 0, got {self.chunk_duration_ms}"

--- a/sozia/common/models.py
+++ b/sozia/common/models.py
@@ -1,0 +1,418 @@
+"""Shared data structures for the Sozia system.
+
+All types in this module cross the client-server boundary or are used by more
+than one package. They carry no runtime logic — only structure, constraints,
+and serialisation rules.
+
+Dependency rule R3: this module must not import from sozia.server or sozia.client.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Literal
+
+
+# ===========================================================================
+# Enumerations
+# ===========================================================================
+
+
+class SessionState(str, Enum):
+    """Lifecycle state of a transcription session.
+
+    Driven by SessionController (client) and observed by the UI and server.
+    """
+
+    IDLE = "IDLE"
+    INITIALIZING = "INITIALIZING"
+    RUNNING = "RUNNING"
+    PAUSED = "PAUSED"
+    DEGRADED = "DEGRADED"
+    ERROR = "ERROR"
+
+
+class ModalityPath(str, Enum):
+    """Which inference pipeline is active for the session.
+
+    The system is modal-exclusive: only one path is active at a time.
+    """
+
+    SPEECH = "SPEECH"
+    SIGN = "SIGN"
+
+
+class ModalityType(str, Enum):
+    """The specific inference modality that produced a result.
+
+    Used for source labelling in transcript segments and for fusion logic.
+    """
+
+    ASR = "ASR"
+    LIP_READING = "LIP_READING"
+    TSL_RECOGNITION = "TSL_RECOGNITION"
+    GLOSS_TO_TEXT = "GLOSS_TO_TEXT"
+
+
+class SegmentStatus(str, Enum):
+    """Whether a transcript segment is tentative or finalised.
+
+    A PARTIAL segment may be replaced by a FINAL one via replaces_segment_id.
+    A FINAL segment is never revised.
+    """
+
+    PARTIAL = "PARTIAL"
+    FINAL = "FINAL"
+
+
+# ===========================================================================
+# Validation helpers (private)
+# ===========================================================================
+
+
+def _validate_non_empty_str(value: str, field: str) -> None:
+    if not value:
+        raise ValueError(f"{field} must be a non-empty string")
+
+
+def _validate_non_negative_int(value: int, field: str) -> None:
+    if value < 0:
+        raise ValueError(f"{field} must be >= 0, got {value}")
+
+
+def _validate_confidence(value: float, field: str = "confidence") -> None:
+    if not (0.0 <= value <= 1.0):
+        raise ValueError(f"{field} must be in [0.0, 1.0], got {value}")
+
+
+def _validate_landmark_array(
+    arr: list[list[float]],
+    expected_len: int,
+    name: str,
+    check_xy_unit_range: bool = False,
+) -> None:
+    """Validate a landmark array's length and point dimensions.
+
+    Args:
+        arr: 2-D list of landmark points, each [x, y, z].
+        expected_len: Required number of points.
+        name: Field name for error messages.
+        check_xy_unit_range: If True, enforce x and y coords in [0.0, 1.0].
+            z is always unconstrained (MediaPipe relative depth).
+    """
+    if len(arr) != expected_len:
+        raise ValueError(
+            f"{name} must have {expected_len} points, got {len(arr)}"
+        )
+    for i, point in enumerate(arr):
+        if len(point) != 3:
+            raise ValueError(
+                f"{name}[{i}] must have 3 coordinates [x, y, z], got {len(point)}"
+            )
+        if check_xy_unit_range:
+            x, y = point[0], point[1]
+            if not (0.0 <= x <= 1.0):
+                raise ValueError(
+                    f"{name}[{i}].x must be in [0.0, 1.0], got {x}"
+                )
+            if not (0.0 <= y <= 1.0):
+                raise ValueError(
+                    f"{name}[{i}].y must be in [0.0, 1.0], got {y}"
+                )
+
+
+def _validate_rectangular_2d(
+    features: list[list[float]], field: str = "features"
+) -> None:
+    """Validate that a 2-D list is non-empty and rectangular.
+
+    Args:
+        features: 2-D list of shape [T, D].
+        field: Field name for error messages.
+
+    Raises:
+        ValueError: If T < 1, D < 1, or rows have inconsistent length.
+    """
+    if not features:
+        raise ValueError(f"{field} must have at least one row (T >= 1)")
+    d = len(features[0])
+    if d == 0:
+        raise ValueError(f"{field} rows must have at least one column (D >= 1)")
+    for i, row in enumerate(features):
+        if len(row) != d:
+            raise ValueError(
+                f"{field} is not rectangular: row 0 has {d} cols, row {i} has {len(row)}"
+            )
+
+
+# ===========================================================================
+# Data Transfer Objects (DTOs)
+# ===========================================================================
+
+
+@dataclass(frozen=True)
+class ModelConfig:
+    """Configuration passed to InferenceEngine.load_model().
+
+    Args:
+        model_id: Unique identifier for the model (e.g. "whisper-small-tr").
+        weights_path: Absolute path to model weight file(s).
+        device: Compute device — "cpu" or "cuda".
+        params: Engine-specific parameters (e.g. language, quantisation flags).
+            The dict reference is frozen but the contents remain mutable.
+    """
+
+    model_id: str
+    weights_path: str
+    device: str
+    params: dict
+
+    def __post_init__(self) -> None:
+        _validate_non_empty_str(self.model_id, "model_id")
+        _validate_non_empty_str(self.weights_path, "weights_path")
+        if self.device not in {"cpu", "cuda"}:
+            raise ValueError(f"device must be 'cpu' or 'cuda', got '{self.device}'")
+
+
+@dataclass(frozen=True)
+class ModalityResult:
+    """Output of a single inference engine.
+
+    Produced server-side and consumed by FusionOrchestrator.
+    Not sent directly to the client — the fusion layer wraps it into a
+    TranscriptSegment first.
+
+    Args:
+        modality_type: Which engine produced this result.
+        text: Recognised text (UTF-8). May be empty string for silence.
+        confidence: Confidence score in [0.0, 1.0].
+        timestamp_ms: Position in the session timeline (ms since session start).
+        duration_ms: Duration of the audio/video segment this result covers.
+        inference_latency_ms: Wall-clock time the engine took. Used for latency
+            budget monitoring against the 2200 ms cloud inference budget.
+    """
+
+    modality_type: ModalityType
+    text: str
+    confidence: float
+    timestamp_ms: int
+    duration_ms: int
+    inference_latency_ms: int
+
+    def __post_init__(self) -> None:
+        _validate_confidence(self.confidence)
+        _validate_non_negative_int(self.timestamp_ms, "timestamp_ms")
+        _validate_non_negative_int(self.duration_ms, "duration_ms")
+        _validate_non_negative_int(self.inference_latency_ms, "inference_latency_ms")
+
+
+@dataclass(frozen=True)
+class PipelineHealth:
+    """Real-time health report for a client-side pipeline.
+
+    Sent upstream periodically so DegradedModeHandler can adjust fusion
+    strategy. Cross-field invariants enforce that audio-only and video-only
+    fields are not mixed.
+
+    Args:
+        session_id: UUID v4 of the active session.
+        pipeline: "audio" or "video".
+        available: False if the pipeline cannot produce features (device lost,
+            permission denied, etc.).
+        fps: Frame rate — video pipeline only; None for audio.
+        snr: Signal-to-noise ratio in dB — audio pipeline only; None for video.
+        face_detected: Whether a face is currently detected — video only; None
+            for audio.
+        last_updated_ms: Milliseconds since session start.
+    """
+
+    session_id: str
+    pipeline: Literal["audio", "video"]
+    available: bool
+    fps: float | None
+    snr: float | None
+    face_detected: bool | None
+    last_updated_ms: int
+
+    def __post_init__(self) -> None:
+        _validate_non_empty_str(self.session_id, "session_id")
+        if self.pipeline not in {"audio", "video"}:
+            raise ValueError(f"pipeline must be 'audio' or 'video', got '{self.pipeline}'")
+        _validate_non_negative_int(self.last_updated_ms, "last_updated_ms")
+
+        if self.pipeline == "audio":
+            if self.fps is not None:
+                raise ValueError("fps must be None for audio pipeline")
+            if self.face_detected is not None:
+                raise ValueError("face_detected must be None for audio pipeline")
+        else:  # video
+            if self.snr is not None:
+                raise ValueError("snr must be None for video pipeline")
+
+
+# Landmark count constants — sourced from sozia-research extraction pipeline.
+# face: 83-point linguistically-relevant subset (not the full 478-point mesh).
+# See tsl_recognition/config.py FACE_LANDMARK_INDICES for the exact subset.
+FACE_LANDMARK_COUNT = 83
+HAND_LANDMARK_COUNT = 21
+POSE_LANDMARK_COUNT = 33
+
+
+@dataclass(frozen=True)
+class LandmarkFrame:
+    """A single timestamped frame of body landmarks extracted by MediaPipe.
+
+    Transmitted upstream from client to server via WebSocket.
+
+    Invariant: at least one landmark array must be non-null. A frame with all
+    nulls is never transmitted.
+
+    Coordinate conventions:
+        - x, y: normalised to [0.0, 1.0] relative to frame dimensions.
+        - z: MediaPipe relative depth — not normalised, may be any finite float.
+
+    Args:
+        session_id: UUID v4 of the active session.
+        timestamp_ms: Milliseconds since session start. Must be >= 0 and
+            monotonically increasing within a session (enforced by SessionHandler).
+        face_landmarks: 83 × [x, y, z] face mesh points (subset). None if not
+            detected.
+        left_hand_landmarks: 21 × [x, y, z]. None if not detected.
+        right_hand_landmarks: 21 × [x, y, z]. None if not detected.
+        pose_landmarks: 33 × [x, y, z]. None if not detected.
+    """
+
+    session_id: str
+    timestamp_ms: int
+    face_landmarks: list[list[float]] | None
+    left_hand_landmarks: list[list[float]] | None
+    right_hand_landmarks: list[list[float]] | None
+    pose_landmarks: list[list[float]] | None
+
+    def __post_init__(self) -> None:
+        _validate_non_empty_str(self.session_id, "session_id")
+        _validate_non_negative_int(self.timestamp_ms, "timestamp_ms")
+
+        if all(
+            arr is None
+            for arr in (
+                self.face_landmarks,
+                self.left_hand_landmarks,
+                self.right_hand_landmarks,
+                self.pose_landmarks,
+            )
+        ):
+            raise ValueError("at least one landmark array must be non-null")
+
+        if self.face_landmarks is not None:
+            _validate_landmark_array(
+                self.face_landmarks, FACE_LANDMARK_COUNT, "face_landmarks",
+                check_xy_unit_range=True,
+            )
+        if self.left_hand_landmarks is not None:
+            _validate_landmark_array(
+                self.left_hand_landmarks, HAND_LANDMARK_COUNT, "left_hand_landmarks",
+                check_xy_unit_range=True,
+            )
+        if self.right_hand_landmarks is not None:
+            _validate_landmark_array(
+                self.right_hand_landmarks, HAND_LANDMARK_COUNT, "right_hand_landmarks",
+                check_xy_unit_range=True,
+            )
+        if self.pose_landmarks is not None:
+            _validate_landmark_array(
+                self.pose_landmarks, POSE_LANDMARK_COUNT, "pose_landmarks",
+                check_xy_unit_range=True,
+            )
+
+
+_ALLOWED_FEATURE_TYPES = frozenset({"mfcc", "mel_spectrogram"})
+
+
+@dataclass(frozen=True)
+class AudioFeatureChunk:
+    """A timestamped chunk of preprocessed audio features.
+
+    Transmitted upstream from client to server. Never contains raw PCM audio.
+
+    Args:
+        session_id: UUID v4 of the active session.
+        timestamp_ms: Milliseconds since session start.
+        features: 2-D array of shape [T, D] — T temporal frames, D feature
+            dimensions. T >= 1, D >= 1, must be rectangular.
+        feature_type: "mfcc" or "mel_spectrogram".
+        sample_rate_hz: Original audio sample rate in Hz (e.g. 16000).
+        chunk_duration_ms: Duration of audio this chunk covers in ms (> 0).
+    """
+
+    session_id: str
+    timestamp_ms: int
+    features: list[list[float]]
+    feature_type: Literal["mfcc", "mel_spectrogram"]
+    sample_rate_hz: int
+    chunk_duration_ms: int
+
+    def __post_init__(self) -> None:
+        _validate_non_empty_str(self.session_id, "session_id")
+        _validate_non_negative_int(self.timestamp_ms, "timestamp_ms")
+        _validate_rectangular_2d(self.features)
+        if self.feature_type not in _ALLOWED_FEATURE_TYPES:
+            raise ValueError(
+                f"feature_type must be one of {_ALLOWED_FEATURE_TYPES}, "
+                f"got '{self.feature_type}'"
+            )
+        if self.sample_rate_hz <= 0:
+            raise ValueError(f"sample_rate_hz must be positive, got {self.sample_rate_hz}")
+        if self.chunk_duration_ms <= 0:
+            raise ValueError(
+                f"chunk_duration_ms must be > 0, got {self.chunk_duration_ms}"
+            )
+
+
+@dataclass(frozen=True)
+class TranscriptSegment:
+    """The primary output of the Sozia system.
+
+    A time-aligned piece of transcript text with metadata. Produced by
+    FusionOrchestrator, streamed to the client via WebSocket.
+
+    If status is FINAL and replaces_segment_id is non-null, the client must
+    locate the referenced PARTIAL segment and replace it. If the PARTIAL is not
+    found (e.g. already expired), the FINAL segment is appended as a new entry.
+
+    Args:
+        segment_id: Globally unique UUID v4.
+        session_id: UUID v4 of the active session.
+        status: PARTIAL (tentative) or FINAL (will not be revised).
+        text: Display-ready UTF-8 text. For PARTIAL sign segments this is raw
+            gloss (e.g. "MERHABA DUNYA"); for FINAL it is natural Turkish.
+        source: The primary modality that produced this text.
+        confidence: Fused confidence score in [0.0, 1.0].
+        timestamp_ms: Position in the subtitle timeline (ms since session start).
+        duration_ms: How long this segment spans in ms.
+        created_at_ms: Wall-clock Unix epoch milliseconds when the segment was
+            created on the server.
+        replaces_segment_id: If non-null, this segment revises the referenced
+            PARTIAL. The client must replace the old segment with this one.
+    """
+
+    segment_id: str
+    session_id: str
+    status: SegmentStatus
+    text: str
+    source: ModalityType
+    confidence: float
+    timestamp_ms: int
+    duration_ms: int
+    created_at_ms: int
+    replaces_segment_id: str | None
+
+    def __post_init__(self) -> None:
+        _validate_non_empty_str(self.segment_id, "segment_id")
+        _validate_non_empty_str(self.session_id, "session_id")
+        _validate_confidence(self.confidence)
+        _validate_non_negative_int(self.timestamp_ms, "timestamp_ms")
+        _validate_non_negative_int(self.duration_ms, "duration_ms")
+        if self.replaces_segment_id is not None:
+            _validate_non_empty_str(self.replaces_segment_id, "replaces_segment_id")

--- a/tests/common/test_interfaces.py
+++ b/tests/common/test_interfaces.py
@@ -1,0 +1,190 @@
+"""Unit tests for sozia.common.interfaces — ABCs and custom exceptions."""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from sozia.common.interfaces import (
+    FeatureExtractor,
+    FusionStrategy,
+    InferenceEngine,
+    InferenceTimeoutError,
+    ModelNotLoadedError,
+)
+from sozia.common.models import (
+    ModalityResult,
+    ModalityType,
+    ModelConfig,
+    PipelineHealth,
+    TranscriptSegment,
+)
+
+
+# ===========================================================================
+# Custom exceptions
+# ===========================================================================
+
+
+class TestInferenceTimeoutError:
+    def test_is_exception_subclass(self):
+        assert issubclass(InferenceTimeoutError, Exception)
+
+    def test_message_preserved(self):
+        err = InferenceTimeoutError("timed out after 2200ms")
+        assert "2200" in str(err)
+
+    def test_can_be_raised_and_caught(self):
+        with pytest.raises(InferenceTimeoutError):
+            raise InferenceTimeoutError("timeout")
+
+
+class TestModelNotLoadedError:
+    def test_is_exception_subclass(self):
+        assert issubclass(ModelNotLoadedError, Exception)
+
+    def test_message_preserved(self):
+        err = ModelNotLoadedError("no model loaded")
+        assert "no model" in str(err)
+
+    def test_can_be_raised_and_caught(self):
+        with pytest.raises(ModelNotLoadedError):
+            raise ModelNotLoadedError("no model")
+
+
+# ===========================================================================
+# InferenceEngine ABC
+# ===========================================================================
+
+
+class TestInferenceEngineABC:
+    def test_cannot_instantiate_abstract(self):
+        with pytest.raises(TypeError):
+            InferenceEngine()  # type: ignore[abstract]
+
+    def test_minimal_subclass_can_be_instantiated(self):
+        class FakeEngine(InferenceEngine):
+            async def load_model(self, config: ModelConfig) -> None:
+                pass
+
+            async def predict(self, features, timeout_ms: int = 2200) -> ModalityResult:
+                return ModalityResult(
+                    modality_type=ModalityType.ASR,
+                    text="",
+                    confidence=0.0,
+                    timestamp_ms=0,
+                    duration_ms=0,
+                    inference_latency_ms=0,
+                )
+
+            async def unload_model(self) -> None:
+                pass
+
+            def is_loaded(self) -> bool:
+                return False
+
+            def get_model_id(self) -> str:
+                return ""
+
+        engine = FakeEngine()
+        assert isinstance(engine, InferenceEngine)
+
+    def test_subclass_missing_method_cannot_instantiate(self):
+        class IncompleteEngine(InferenceEngine):
+            async def load_model(self, config: ModelConfig) -> None:
+                pass
+
+            # predict, unload_model, is_loaded, get_model_id missing
+
+        with pytest.raises(TypeError):
+            IncompleteEngine()  # type: ignore[abstract]
+
+    def test_async_methods(self):
+        assert inspect.iscoroutinefunction(InferenceEngine.load_model)
+        assert inspect.iscoroutinefunction(InferenceEngine.predict)
+        assert inspect.iscoroutinefunction(InferenceEngine.unload_model)
+
+    def test_sync_methods(self):
+        assert not inspect.iscoroutinefunction(InferenceEngine.is_loaded)
+        assert not inspect.iscoroutinefunction(InferenceEngine.get_model_id)
+
+
+# ===========================================================================
+# FusionStrategy ABC
+# ===========================================================================
+
+
+class TestFusionStrategyABC:
+    def test_cannot_instantiate_abstract(self):
+        with pytest.raises(TypeError):
+            FusionStrategy()  # type: ignore[abstract]
+
+    def test_minimal_subclass_can_be_instantiated(self):
+        class FakePolicy(FusionStrategy):
+            def fuse(
+                self,
+                results: list[ModalityResult],
+                health: list[PipelineHealth],
+            ) -> list[TranscriptSegment]:
+                return []
+
+            def should_suppress(self, result: ModalityResult) -> bool:
+                return result.confidence < 0.30
+
+            def get_confidence_threshold(self) -> float:
+                return 0.30
+
+        policy = FakePolicy()
+        assert isinstance(policy, FusionStrategy)
+
+    def test_subclass_missing_method_cannot_instantiate(self):
+        class IncompletePolicy(FusionStrategy):
+            def fuse(self, results, health):
+                return []
+
+            # should_suppress and get_confidence_threshold missing
+
+        with pytest.raises(TypeError):
+            IncompletePolicy()  # type: ignore[abstract]
+
+    def test_all_methods_are_sync(self):
+        assert not inspect.iscoroutinefunction(FusionStrategy.fuse)
+        assert not inspect.iscoroutinefunction(FusionStrategy.should_suppress)
+        assert not inspect.iscoroutinefunction(FusionStrategy.get_confidence_threshold)
+
+
+# ===========================================================================
+# FeatureExtractor ABC
+# ===========================================================================
+
+
+class TestFeatureExtractorABC:
+    def test_cannot_instantiate_abstract(self):
+        with pytest.raises(TypeError):
+            FeatureExtractor()  # type: ignore[abstract]
+
+    def test_minimal_subclass_can_be_instantiated(self):
+        class FakeExtractor(FeatureExtractor):
+            def extract(self, raw_input) -> object | None:
+                return None
+
+            def is_ready(self) -> bool:
+                return True
+
+        extractor = FakeExtractor()
+        assert isinstance(extractor, FeatureExtractor)
+
+    def test_subclass_missing_method_cannot_instantiate(self):
+        class IncompleteExtractor(FeatureExtractor):
+            def extract(self, raw_input):
+                return None
+
+            # is_ready missing
+
+        with pytest.raises(TypeError):
+            IncompleteExtractor()  # type: ignore[abstract]
+
+    def test_all_methods_are_sync(self):
+        assert not inspect.iscoroutinefunction(FeatureExtractor.extract)
+        assert not inspect.iscoroutinefunction(FeatureExtractor.is_ready)

--- a/tests/common/test_models.py
+++ b/tests/common/test_models.py
@@ -29,7 +29,14 @@ from sozia.common.models import (
 class TestSessionState:
     def test_all_values_present(self):
         names = {s.name for s in SessionState}
-        assert names == {"IDLE", "INITIALIZING", "RUNNING", "PAUSED", "DEGRADED", "ERROR"}
+        assert names == {
+            "IDLE",
+            "INITIALIZING",
+            "RUNNING",
+            "PAUSED",
+            "DEGRADED",
+            "ERROR",
+        }
 
     def test_string_values_match_names(self):
         for state in SessionState:
@@ -51,7 +58,10 @@ class TestModalityPath:
 class TestModalityType:
     def test_all_values_present(self):
         assert {t.name for t in ModalityType} == {
-            "ASR", "LIP_READING", "TSL_RECOGNITION", "GLOSS_TO_TEXT"
+            "ASR",
+            "LIP_READING",
+            "TSL_RECOGNITION",
+            "GLOSS_TO_TEXT",
         }
 
     def test_string_values_match_names(self):
@@ -85,9 +95,7 @@ class TestModelConfig:
         assert cfg.device == "cuda"
 
     def test_frozen(self):
-        cfg = ModelConfig(
-            model_id="m", weights_path="/p", device="cpu", params={}
-        )
+        cfg = ModelConfig(model_id="m", weights_path="/p", device="cpu", params={})
         with pytest.raises(Exception):  # FrozenInstanceError
             cfg.model_id = "other"  # type: ignore[misc]
 
@@ -275,7 +283,9 @@ class TestLandmarkFrame:
         assert len(f.face_landmarks) == 83
 
     def test_happy_path_pose_only(self):
-        f = self._make(face_landmarks=None, left_hand_landmarks=None, right_hand_landmarks=None)
+        f = self._make(
+            face_landmarks=None, left_hand_landmarks=None, right_hand_landmarks=None
+        )
         assert f.pose_landmarks is not None
 
     def test_all_none_raises(self):

--- a/tests/common/test_models.py
+++ b/tests/common/test_models.py
@@ -1,0 +1,473 @@
+"""Unit tests for sozia.common.models — enums and DTOs.
+
+Run with: pytest tests/common/test_models.py -v
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from sozia.common.models import (
+    AudioFeatureChunk,
+    LandmarkFrame,
+    ModalityPath,
+    ModalityResult,
+    ModalityType,
+    ModelConfig,
+    PipelineHealth,
+    SegmentStatus,
+    SessionState,
+    TranscriptSegment,
+)
+
+
+# ===========================================================================
+# Enums
+# ===========================================================================
+
+
+class TestSessionState:
+    def test_all_values_present(self):
+        names = {s.name for s in SessionState}
+        assert names == {"IDLE", "INITIALIZING", "RUNNING", "PAUSED", "DEGRADED", "ERROR"}
+
+    def test_string_values_match_names(self):
+        for state in SessionState:
+            assert state.value == state.name
+
+    def test_iterable_count(self):
+        assert len(list(SessionState)) == 6
+
+
+class TestModalityPath:
+    def test_all_values_present(self):
+        assert {p.name for p in ModalityPath} == {"SPEECH", "SIGN"}
+
+    def test_string_values_match_names(self):
+        for path in ModalityPath:
+            assert path.value == path.name
+
+
+class TestModalityType:
+    def test_all_values_present(self):
+        assert {t.name for t in ModalityType} == {
+            "ASR", "LIP_READING", "TSL_RECOGNITION", "GLOSS_TO_TEXT"
+        }
+
+    def test_string_values_match_names(self):
+        for modality in ModalityType:
+            assert modality.value == modality.name
+
+
+class TestSegmentStatus:
+    def test_all_values_present(self):
+        assert {s.name for s in SegmentStatus} == {"PARTIAL", "FINAL"}
+
+    def test_string_values_match_names(self):
+        for status in SegmentStatus:
+            assert status.value == status.name
+
+
+# ===========================================================================
+# ModelConfig
+# ===========================================================================
+
+
+class TestModelConfig:
+    def test_happy_path(self):
+        cfg = ModelConfig(
+            model_id="whisper-small",
+            weights_path="/models/whisper.pt",
+            device="cuda",
+            params={"language": "tr"},
+        )
+        assert cfg.model_id == "whisper-small"
+        assert cfg.device == "cuda"
+
+    def test_frozen(self):
+        cfg = ModelConfig(
+            model_id="m", weights_path="/p", device="cpu", params={}
+        )
+        with pytest.raises(Exception):  # FrozenInstanceError
+            cfg.model_id = "other"  # type: ignore[misc]
+
+    def test_empty_params_accepted(self):
+        cfg = ModelConfig(model_id="m", weights_path="/p", device="cpu", params={})
+        assert cfg.params == {}
+
+    def test_cpu_device_accepted(self):
+        cfg = ModelConfig(model_id="m", weights_path="/p", device="cpu", params={})
+        assert cfg.device == "cpu"
+
+    def test_empty_model_id_raises(self):
+        with pytest.raises(ValueError):
+            ModelConfig(model_id="", weights_path="/p", device="cpu", params={})
+
+    def test_empty_weights_path_raises(self):
+        with pytest.raises(ValueError):
+            ModelConfig(model_id="m", weights_path="", device="cpu", params={})
+
+    def test_invalid_device_raises(self):
+        with pytest.raises(ValueError):
+            ModelConfig(model_id="m", weights_path="/p", device="gpu", params={})
+
+
+# ===========================================================================
+# ModalityResult
+# ===========================================================================
+
+
+class TestModalityResult:
+    def _make(self, **kwargs):
+        defaults = dict(
+            modality_type=ModalityType.ASR,
+            text="merhaba",
+            confidence=0.9,
+            timestamp_ms=100,
+            duration_ms=500,
+            inference_latency_ms=120,
+        )
+        defaults.update(kwargs)
+        return ModalityResult(**defaults)
+
+    def test_happy_path(self):
+        r = self._make()
+        assert r.text == "merhaba"
+        assert r.confidence == 0.9
+
+    def test_empty_text_allowed(self):
+        r = self._make(text="")
+        assert r.text == ""
+
+    def test_frozen(self):
+        r = self._make()
+        with pytest.raises(Exception):
+            r.text = "other"  # type: ignore[misc]
+
+    def test_confidence_above_one_raises(self):
+        with pytest.raises(ValueError):
+            self._make(confidence=1.01)
+
+    def test_confidence_below_zero_raises(self):
+        with pytest.raises(ValueError):
+            self._make(confidence=-0.01)
+
+    def test_confidence_boundary_zero(self):
+        r = self._make(confidence=0.0)
+        assert r.confidence == 0.0
+
+    def test_confidence_boundary_one(self):
+        r = self._make(confidence=1.0)
+        assert r.confidence == 1.0
+
+    def test_negative_timestamp_raises(self):
+        with pytest.raises(ValueError):
+            self._make(timestamp_ms=-1)
+
+    def test_negative_duration_raises(self):
+        with pytest.raises(ValueError):
+            self._make(duration_ms=-1)
+
+    def test_negative_latency_raises(self):
+        with pytest.raises(ValueError):
+            self._make(inference_latency_ms=-1)
+
+
+# ===========================================================================
+# PipelineHealth
+# ===========================================================================
+
+
+class TestPipelineHealth:
+    def _audio(self, **kwargs):
+        defaults = dict(
+            session_id="550e8400-e29b-41d4-a716-446655440000",
+            pipeline="audio",
+            available=True,
+            fps=None,
+            snr=12.5,
+            face_detected=None,
+            last_updated_ms=100,
+        )
+        defaults.update(kwargs)
+        return PipelineHealth(**defaults)
+
+    def _video(self, **kwargs):
+        defaults = dict(
+            session_id="550e8400-e29b-41d4-a716-446655440000",
+            pipeline="video",
+            available=True,
+            fps=30.0,
+            snr=None,
+            face_detected=True,
+            last_updated_ms=100,
+        )
+        defaults.update(kwargs)
+        return PipelineHealth(**defaults)
+
+    def test_audio_happy_path(self):
+        h = self._audio()
+        assert h.pipeline == "audio"
+        assert h.snr == 12.5
+        assert h.fps is None
+        assert h.face_detected is None
+
+    def test_video_happy_path(self):
+        h = self._video()
+        assert h.pipeline == "video"
+        assert h.fps == 30.0
+        assert h.snr is None
+
+    def test_frozen(self):
+        h = self._audio()
+        with pytest.raises(Exception):
+            h.available = False  # type: ignore[misc]
+
+    def test_invalid_pipeline_raises(self):
+        with pytest.raises(ValueError):
+            self._audio(pipeline="camera")
+
+    def test_negative_last_updated_raises(self):
+        with pytest.raises(ValueError):
+            self._audio(last_updated_ms=-1)
+
+    def test_empty_session_id_raises(self):
+        with pytest.raises(ValueError):
+            self._audio(session_id="")
+
+    # cross-field rules
+    def test_audio_with_fps_raises(self):
+        with pytest.raises(ValueError):
+            self._audio(fps=30.0)
+
+    def test_audio_with_face_detected_raises(self):
+        with pytest.raises(ValueError):
+            self._audio(face_detected=True)
+
+    def test_video_with_snr_raises(self):
+        with pytest.raises(ValueError):
+            self._video(snr=10.0)
+
+
+# ===========================================================================
+# LandmarkFrame
+# ===========================================================================
+
+
+class TestLandmarkFrame:
+    def _make(self, **kwargs):
+        face = [[0.5, 0.5, 0.0]] * 83
+        hand = [[0.5, 0.5, 0.0]] * 21
+        pose = [[0.5, 0.5, 0.0]] * 33
+        defaults = dict(
+            session_id="550e8400-e29b-41d4-a716-446655440000",
+            timestamp_ms=0,
+            face_landmarks=face,
+            left_hand_landmarks=hand,
+            right_hand_landmarks=hand,
+            pose_landmarks=pose,
+        )
+        defaults.update(kwargs)
+        return LandmarkFrame(**defaults)
+
+    def test_happy_path_all_arrays(self):
+        f = self._make()
+        assert len(f.face_landmarks) == 83
+
+    def test_happy_path_pose_only(self):
+        f = self._make(face_landmarks=None, left_hand_landmarks=None, right_hand_landmarks=None)
+        assert f.pose_landmarks is not None
+
+    def test_all_none_raises(self):
+        with pytest.raises(ValueError):
+            self._make(
+                face_landmarks=None,
+                left_hand_landmarks=None,
+                right_hand_landmarks=None,
+                pose_landmarks=None,
+            )
+
+    def test_frozen(self):
+        f = self._make()
+        with pytest.raises(Exception):
+            f.timestamp_ms = 999  # type: ignore[misc]
+
+    def test_empty_session_id_raises(self):
+        with pytest.raises(ValueError):
+            self._make(session_id="")
+
+    def test_negative_timestamp_raises(self):
+        with pytest.raises(ValueError):
+            self._make(timestamp_ms=-1)
+
+    def test_face_wrong_length_raises(self):
+        with pytest.raises(ValueError):
+            self._make(face_landmarks=[[0.5, 0.5, 0.0]] * 10)
+
+    def test_hand_wrong_length_raises(self):
+        with pytest.raises(ValueError):
+            self._make(left_hand_landmarks=[[0.5, 0.5, 0.0]] * 5)
+
+    def test_pose_wrong_length_raises(self):
+        with pytest.raises(ValueError):
+            self._make(pose_landmarks=[[0.5, 0.5, 0.0]] * 10)
+
+    def test_point_wrong_dims_raises(self):
+        bad = [[0.5, 0.5]] * 83  # missing z
+        with pytest.raises(ValueError):
+            self._make(face_landmarks=bad)
+
+    def test_face_xy_out_of_range_raises(self):
+        bad = [[1.5, 0.5, 0.0]] * 83  # x > 1
+        with pytest.raises(ValueError):
+            self._make(face_landmarks=bad)
+
+    def test_face_z_out_of_range_allowed(self):
+        # z is MediaPipe relative depth — not constrained to [0, 1]
+        ok = [[0.5, 0.5, -2.5]] * 83
+        f = self._make(face_landmarks=ok)
+        assert f.face_landmarks[0][2] == -2.5
+
+    def test_hand_xy_out_of_range_raises(self):
+        bad = [[0.5, 1.2, 0.0]] * 21  # y > 1
+        with pytest.raises(ValueError):
+            self._make(left_hand_landmarks=bad)
+
+
+# ===========================================================================
+# AudioFeatureChunk
+# ===========================================================================
+
+
+class TestAudioFeatureChunk:
+    def _make(self, **kwargs):
+        defaults = dict(
+            session_id="550e8400-e29b-41d4-a716-446655440000",
+            timestamp_ms=0,
+            features=[[float(i) for i in range(13)] for _ in range(10)],
+            feature_type="mfcc",
+            sample_rate_hz=16000,
+            chunk_duration_ms=500,
+        )
+        defaults.update(kwargs)
+        return AudioFeatureChunk(**defaults)
+
+    def test_happy_path(self):
+        c = self._make()
+        assert c.sample_rate_hz == 16000
+        assert len(c.features) == 10
+
+    def test_mel_spectrogram_accepted(self):
+        c = self._make(feature_type="mel_spectrogram")
+        assert c.feature_type == "mel_spectrogram"
+
+    def test_frozen(self):
+        c = self._make()
+        with pytest.raises(Exception):
+            c.sample_rate_hz = 8000  # type: ignore[misc]
+
+    def test_empty_session_id_raises(self):
+        with pytest.raises(ValueError):
+            self._make(session_id="")
+
+    def test_empty_features_raises(self):
+        with pytest.raises(ValueError):
+            self._make(features=[])
+
+    def test_empty_feature_row_raises(self):
+        with pytest.raises(ValueError):
+            self._make(features=[[]])
+
+    def test_ragged_features_raises(self):
+        with pytest.raises(ValueError):
+            self._make(features=[[1.0, 2.0], [1.0]])
+
+    def test_invalid_feature_type_raises(self):
+        with pytest.raises(ValueError):
+            self._make(feature_type="raw_pcm")
+
+    def test_zero_sample_rate_raises(self):
+        with pytest.raises(ValueError):
+            self._make(sample_rate_hz=0)
+
+    def test_negative_sample_rate_raises(self):
+        with pytest.raises(ValueError):
+            self._make(sample_rate_hz=-1)
+
+    def test_zero_chunk_duration_raises(self):
+        with pytest.raises(ValueError):
+            self._make(chunk_duration_ms=0)
+
+
+# ===========================================================================
+# TranscriptSegment
+# ===========================================================================
+
+
+class TestTranscriptSegment:
+    def _make(self, **kwargs):
+        defaults = dict(
+            segment_id="6ba7b810-9dad-11d1-80b4-00c04fd430c8",
+            session_id="550e8400-e29b-41d4-a716-446655440000",
+            status=SegmentStatus.PARTIAL,
+            text="merhaba",
+            source=ModalityType.ASR,
+            confidence=0.85,
+            timestamp_ms=0,
+            duration_ms=500,
+            created_at_ms=1_700_000_000_000,
+            replaces_segment_id=None,
+        )
+        defaults.update(kwargs)
+        return TranscriptSegment(**defaults)
+
+    def test_happy_path_partial(self):
+        s = self._make()
+        assert s.status == SegmentStatus.PARTIAL
+        assert s.replaces_segment_id is None
+
+    def test_happy_path_final_with_replaces(self):
+        s = self._make(
+            status=SegmentStatus.FINAL,
+            replaces_segment_id="550e8400-e29b-41d4-a716-446655440000",
+        )
+        assert s.status == SegmentStatus.FINAL
+        assert s.replaces_segment_id is not None
+
+    def test_final_without_replaces_allowed(self):
+        s = self._make(status=SegmentStatus.FINAL, replaces_segment_id=None)
+        assert s.status == SegmentStatus.FINAL
+
+    def test_frozen(self):
+        s = self._make()
+        with pytest.raises(Exception):
+            s.text = "other"  # type: ignore[misc]
+
+    def test_empty_segment_id_raises(self):
+        with pytest.raises(ValueError):
+            self._make(segment_id="")
+
+    def test_empty_session_id_raises(self):
+        with pytest.raises(ValueError):
+            self._make(session_id="")
+
+    def test_confidence_out_of_range_raises(self):
+        with pytest.raises(ValueError):
+            self._make(confidence=1.5)
+
+    def test_negative_timestamp_raises(self):
+        with pytest.raises(ValueError):
+            self._make(timestamp_ms=-1)
+
+    def test_negative_duration_raises(self):
+        with pytest.raises(ValueError):
+            self._make(duration_ms=-1)
+
+    def test_large_created_at_ms_accepted(self):
+        # Unix epoch in ms — should be a large integer
+        s = self._make(created_at_ms=1_700_000_000_000)
+        assert s.created_at_ms == 1_700_000_000_000
+
+    def test_empty_text_allowed(self):
+        s = self._make(text="")
+        assert s.text == ""

--- a/tests/common/test_package.py
+++ b/tests/common/test_package.py
@@ -17,6 +17,7 @@ class TestPublicSurface:
     def test_r3_no_server_imports(self):
         """sozia.common must not import from sozia.server."""
         import sys
+
         importlib.import_module("sozia.common")
         for mod_name in sys.modules:
             if mod_name.startswith("sozia.server"):
@@ -27,6 +28,7 @@ class TestPublicSurface:
     def test_r3_no_client_imports(self):
         """sozia.common must not import from sozia.client."""
         import sys
+
         for mod_name in sys.modules:
             if mod_name.startswith("sozia.client"):
                 raise AssertionError(

--- a/tests/common/test_package.py
+++ b/tests/common/test_package.py
@@ -1,0 +1,34 @@
+"""Smoke tests for the sozia.common package surface.
+
+Verifies __all__ completeness and enforces dependency rule R3.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sozia.common as common
+
+
+class TestPublicSurface:
+    def test_all_symbols_importable(self):
+        for name in common.__all__:
+            assert hasattr(common, name), f"{name} in __all__ but not importable"
+
+    def test_r3_no_server_imports(self):
+        """sozia.common must not import from sozia.server."""
+        import sys
+        importlib.import_module("sozia.common")
+        for mod_name in sys.modules:
+            if mod_name.startswith("sozia.server"):
+                raise AssertionError(
+                    f"sozia.common transitively imports sozia.server ({mod_name}) — R3 violation"
+                )
+
+    def test_r3_no_client_imports(self):
+        """sozia.common must not import from sozia.client."""
+        import sys
+        for mod_name in sys.modules:
+            if mod_name.startswith("sozia.client"):
+                raise AssertionError(
+                    f"sozia.common transitively imports sozia.client ({mod_name}) — R3 violation"
+                )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,7 @@ import pytest
 # Session identifiers
 # ---------------------------------------------------------------------------
 
+
 @pytest.fixture
 def valid_session_id() -> str:
     return "550e8400-e29b-41d4-a716-446655440000"
@@ -22,6 +23,7 @@ def valid_segment_id() -> str:
 # ---------------------------------------------------------------------------
 # Landmark arrays
 # ---------------------------------------------------------------------------
+
 
 @pytest.fixture
 def valid_face_landmarks() -> list[list[float]]:
@@ -47,6 +49,7 @@ def valid_pose_landmarks() -> list[list[float]]:
 # ---------------------------------------------------------------------------
 # Audio features
 # ---------------------------------------------------------------------------
+
 
 @pytest.fixture
 def valid_audio_features() -> list[list[float]]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,54 @@
+"""Shared pytest fixtures for sozia-server tests."""
+
+from __future__ import annotations
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Session identifiers
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def valid_session_id() -> str:
+    return "550e8400-e29b-41d4-a716-446655440000"
+
+
+@pytest.fixture
+def valid_segment_id() -> str:
+    return "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+
+
+# ---------------------------------------------------------------------------
+# Landmark arrays
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def valid_face_landmarks() -> list[list[float]]:
+    """83 face landmark points with x,y in [0,1] and unconstrained z."""
+    return [[0.5, 0.5, 0.0]] * 83
+
+
+@pytest.fixture
+def valid_left_hand_landmarks() -> list[list[float]]:
+    return [[0.5, 0.5, 0.0]] * 21
+
+
+@pytest.fixture
+def valid_right_hand_landmarks() -> list[list[float]]:
+    return [[0.5, 0.5, 0.0]] * 21
+
+
+@pytest.fixture
+def valid_pose_landmarks() -> list[list[float]]:
+    return [[0.5, 0.5, 0.0]] * 33
+
+
+# ---------------------------------------------------------------------------
+# Audio features
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def valid_audio_features() -> list[list[float]]:
+    """10 frames × 13 MFCC dimensions."""
+    return [[float(i) for i in range(13)] for _ in range(10)]


### PR DESCRIPTION
## What does this PR do?

Implements `sozia/common/` — the shared layer everything else imports from. Four enums, six frozen dataclasses with `__post_init__` validation, three ABCs (`InferenceEngine`, `FusionStrategy`, `FeatureExtractor`), and two custom exceptions. No runtime logic.

`face_landmarks` is 83 points, not 478 — matches the subset actually extracted in sozia-research. z-coordinates are unconstrained; MediaPipe depth values aren't normalized to [0, 1].

## Which package(s) does it touch?

`sozia/common` only.

## How to test

```
pytest tests/common/
```

92 tests, 100% coverage.

## Checklist
- [x] Follows commit convention (`<type>(<scope>): <description>`)
- [x] Added/updated tests (if applicable)
- [ ] No sozia.common schema changes (or: both repos updated)
- [x] Tested locally

Closes #1.