### PR TITLE
feat(fusion): fusion layer — policies, degraded mode, orchestrator

### DIFF
--- a/sozia/fusion/__init__.py
+++ b/sozia/fusion/__init__.py
@@ -1,0 +1,13 @@
+"""sozia.fusion — fusion layer for the Sozia server."""
+
+from sozia.fusion.degraded_mode_handler import DegradedModeHandler
+from sozia.fusion.orchestrator import FusionOrchestrator
+from sozia.fusion.sign_fusion_policy import SignFusionPolicy
+from sozia.fusion.speech_fusion_policy import SpeechFusionPolicy
+
+__all__ = [
+    "FusionOrchestrator",
+    "SpeechFusionPolicy",
+    "SignFusionPolicy",
+    "DegradedModeHandler",
+]

--- a/sozia/fusion/__init__.py
+++ b/sozia/fusion/__init__.py
@@ -1,13 +1,14 @@
 """sozia.fusion — fusion layer for the Sozia server."""
 
-from sozia.fusion.degraded_mode_handler import DegradedModeHandler
+from sozia.fusion.degraded_mode_handler import DegradedModeHandler, DegradedStatus
 from sozia.fusion.orchestrator import FusionOrchestrator
 from sozia.fusion.sign_fusion_policy import SignFusionPolicy
 from sozia.fusion.speech_fusion_policy import SpeechFusionPolicy
 
 __all__ = [
-    "FusionOrchestrator",
-    "SpeechFusionPolicy",
-    "SignFusionPolicy",
     "DegradedModeHandler",
+    "DegradedStatus",
+    "FusionOrchestrator",
+    "SignFusionPolicy",
+    "SpeechFusionPolicy",
 ]

--- a/sozia/fusion/degraded_mode_handler.py
+++ b/sozia/fusion/degraded_mode_handler.py
@@ -12,7 +12,6 @@ import uuid
 
 from sozia.common.models import (
     ModalityResult,
-    ModalityType,
     PipelineHealth,
     SegmentStatus,
     TranscriptSegment,
@@ -51,14 +50,11 @@ class DegradedModeHandler:
         if health.pipeline == "video" and health.face_detected is False:
             return True
 
-        if (
+        return (
             health.pipeline == "audio"
             and health.snr is not None
             and health.snr < self._min_audio_snr
-        ):
-            return True
-
-        return False
+        )
 
     def handle_degraded_input(
         self,

--- a/sozia/fusion/degraded_mode_handler.py
+++ b/sozia/fusion/degraded_mode_handler.py
@@ -2,13 +2,15 @@
 
 When a pipeline becomes unavailable (device lost, no face detected, low SNR)
 or a modality times out, this handler decides whether to fall back to
-single-modality output with reduced confidence.
+single-modality output with reduced confidence — or, if every pipeline is
+down, to signal that the session must terminate.
 """
 
 from __future__ import annotations
 
 import time
 import uuid
+from enum import Enum
 
 from sozia.common.models import (
     ModalityResult,
@@ -24,6 +26,19 @@ _DEFAULT_CONFIDENCE_PENALTY = 0.15
 _DEFAULT_MIN_AUDIO_SNR = 5.0
 
 
+class DegradedStatus(Enum):
+    """Overall health state of the session's input pipelines.
+
+    Used by the API/gateway layer to decide whether to keep streaming
+    (NORMAL), fall back to a single modality with reduced confidence
+    (DEGRADED), or close the session (FAILED).
+    """
+
+    NORMAL = "normal"
+    DEGRADED = "degraded"
+    FAILED = "failed"
+
+
 class DegradedModeHandler:
     """Decides when to enter degraded mode and produces fallback segments."""
 
@@ -35,6 +50,76 @@ class DegradedModeHandler:
     ) -> None:
         self._confidence_penalty = confidence_penalty
         self._min_audio_snr = min_audio_snr
+
+    # ------------------------------------------------------------------
+    # Status evaluation
+    # ------------------------------------------------------------------
+
+    def evaluate(self, health: list[PipelineHealth]) -> DegradedStatus:
+        """Evaluate aggregate pipeline health into a 3-state status.
+
+        - NORMAL — every reported pipeline is healthy.
+        - DEGRADED — at least one pipeline is healthy; at least one is not.
+        - FAILED — no healthy pipelines; the session should be terminated.
+
+        An empty health list is treated as FAILED (nothing to listen to).
+        """
+        if not health:
+            return DegradedStatus.FAILED
+
+        degraded_count = sum(1 for h in health if self.should_fallback(h))
+
+        if degraded_count == 0:
+            return DegradedStatus.NORMAL
+        if degraded_count == len(health):
+            return DegradedStatus.FAILED
+        return DegradedStatus.DEGRADED
+
+    def get_advisory_message(
+        self, health: list[PipelineHealth],
+    ) -> str | None:
+        """Return a user-facing string describing the degraded state.
+
+        Returns ``None`` when every pipeline is healthy. Emits distinct
+        strings for common failure modes so the client can render them
+        directly.
+        """
+        if not health:
+            return "All input pipelines unavailable — session ending."
+
+        messages: list[str] = []
+        for h in health:
+            msg = self._advisory_for(h)
+            if msg is not None:
+                messages.append(msg)
+
+        if not messages:
+            return None
+        return " ".join(messages)
+
+    def _advisory_for(self, health: PipelineHealth) -> str | None:
+        if not health.available:
+            if health.pipeline == "audio":
+                return "Microphone unavailable — speech recognition paused."
+            if health.pipeline == "video":
+                return "Camera unavailable — visual recognition paused."
+            return f"{health.pipeline.capitalize()} pipeline unavailable."
+
+        if health.pipeline == "video" and health.face_detected is False:
+            return "Camera obstructed — visual recognition paused."
+
+        if (
+            health.pipeline == "audio"
+            and health.snr is not None
+            and health.snr < self._min_audio_snr
+        ):
+            return "Low audio level — speech recognition degraded."
+
+        return None
+
+    # ------------------------------------------------------------------
+    # Per-pipeline fallback check (used by the orchestrator)
+    # ------------------------------------------------------------------
 
     def should_fallback(self, health: PipelineHealth) -> bool:
         """Return True if the pipeline health indicates degraded state.
@@ -55,6 +140,10 @@ class DegradedModeHandler:
             and health.snr is not None
             and health.snr < self._min_audio_snr
         )
+
+    # ------------------------------------------------------------------
+    # Segment production
+    # ------------------------------------------------------------------
 
     def handle_degraded_input(
         self,
@@ -78,7 +167,7 @@ class DegradedModeHandler:
             return None
 
         return TranscriptSegment(
-            segment_id=uuid.uuid4().hex,
+            segment_id=str(uuid.uuid4()),
             session_id=session_id,
             status=SegmentStatus.PARTIAL,
             text=result.text,

--- a/sozia/fusion/degraded_mode_handler.py
+++ b/sozia/fusion/degraded_mode_handler.py
@@ -18,15 +18,24 @@ from sozia.common.models import (
     TranscriptSegment,
 )
 
-# Confidence penalty applied to degraded (single-modality) output.
-_DEGRADED_CONFIDENCE_PENALTY = 0.15
+# Default confidence penalty applied to degraded (single-modality) output.
+_DEFAULT_CONFIDENCE_PENALTY = 0.15
 
-# Minimum SNR (dB) for the audio pipeline to be considered usable.
-_MIN_AUDIO_SNR = 5.0
+# Default minimum SNR (dB) for the audio pipeline to be considered usable.
+_DEFAULT_MIN_AUDIO_SNR = 5.0
 
 
 class DegradedModeHandler:
     """Decides when to enter degraded mode and produces fallback segments."""
+
+    def __init__(
+        self,
+        *,
+        confidence_penalty: float = _DEFAULT_CONFIDENCE_PENALTY,
+        min_audio_snr: float = _DEFAULT_MIN_AUDIO_SNR,
+    ) -> None:
+        self._confidence_penalty = confidence_penalty
+        self._min_audio_snr = min_audio_snr
 
     def should_fallback(self, health: PipelineHealth) -> bool:
         """Return True if the pipeline health indicates degraded state.
@@ -45,7 +54,7 @@ class DegradedModeHandler:
         if (
             health.pipeline == "audio"
             and health.snr is not None
-            and health.snr < _MIN_AUDIO_SNR
+            and health.snr < self._min_audio_snr
         ):
             return True
 
@@ -68,7 +77,7 @@ class DegradedModeHandler:
         Returns:
             A PARTIAL TranscriptSegment with reduced confidence, or None.
         """
-        penalised = result.confidence - _DEGRADED_CONFIDENCE_PENALTY
+        penalised = result.confidence - self._confidence_penalty
         if penalised <= 0.0:
             return None
 

--- a/sozia/fusion/degraded_mode_handler.py
+++ b/sozia/fusion/degraded_mode_handler.py
@@ -101,9 +101,7 @@ class DegradedModeHandler:
         if not health.available:
             if health.pipeline == "audio":
                 return "Microphone unavailable — speech recognition paused."
-            if health.pipeline == "video":
-                return "Camera unavailable — visual recognition paused."
-            return f"{health.pipeline.capitalize()} pipeline unavailable."
+            return "Camera unavailable — visual recognition paused."
 
         if health.pipeline == "video" and health.face_detected is False:
             return "Camera obstructed — visual recognition paused."

--- a/sozia/fusion/degraded_mode_handler.py
+++ b/sozia/fusion/degraded_mode_handler.py
@@ -1,0 +1,86 @@
+"""DegradedModeHandler — fallback when one modality is unavailable.
+
+When a pipeline becomes unavailable (device lost, no face detected, low SNR)
+or a modality times out, this handler decides whether to fall back to
+single-modality output with reduced confidence.
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+
+from sozia.common.models import (
+    ModalityResult,
+    ModalityType,
+    PipelineHealth,
+    SegmentStatus,
+    TranscriptSegment,
+)
+
+# Confidence penalty applied to degraded (single-modality) output.
+_DEGRADED_CONFIDENCE_PENALTY = 0.15
+
+# Minimum SNR (dB) for the audio pipeline to be considered usable.
+_MIN_AUDIO_SNR = 5.0
+
+
+class DegradedModeHandler:
+    """Decides when to enter degraded mode and produces fallback segments."""
+
+    def should_fallback(self, health: PipelineHealth) -> bool:
+        """Return True if the pipeline health indicates degraded state.
+
+        Triggers:
+          - ``available`` is False (device lost, permission denied).
+          - Video pipeline: ``face_detected`` is False.
+          - Audio pipeline: ``snr`` below minimum threshold.
+        """
+        if not health.available:
+            return True
+
+        if health.pipeline == "video" and health.face_detected is False:
+            return True
+
+        if (
+            health.pipeline == "audio"
+            and health.snr is not None
+            and health.snr < _MIN_AUDIO_SNR
+        ):
+            return True
+
+        return False
+
+    def handle_degraded_input(
+        self,
+        session_id: str,
+        result: ModalityResult,
+    ) -> TranscriptSegment | None:
+        """Produce a degraded-mode segment from a single modality result.
+
+        Applies a confidence penalty since only one modality contributed.
+        Returns None if the penalised confidence drops to zero or below.
+
+        Args:
+            session_id: Active session identifier.
+            result: The single available modality result.
+
+        Returns:
+            A PARTIAL TranscriptSegment with reduced confidence, or None.
+        """
+        penalised = result.confidence - _DEGRADED_CONFIDENCE_PENALTY
+        if penalised <= 0.0:
+            return None
+
+        return TranscriptSegment(
+            segment_id=uuid.uuid4().hex,
+            session_id=session_id,
+            status=SegmentStatus.PARTIAL,
+            text=result.text,
+            source=result.modality_type,
+            confidence=round(penalised, 4),
+            timestamp_ms=result.timestamp_ms,
+            duration_ms=result.duration_ms,
+            created_at_ms=int(time.time() * 1000),
+            replaces_segment_id=None,
+        )

--- a/sozia/fusion/orchestrator.py
+++ b/sozia/fusion/orchestrator.py
@@ -1,0 +1,137 @@
+"""FusionOrchestrator — central coordinator for the fusion layer.
+
+Receives inference results, routes them to the correct FusionStrategy based
+on ModalityPath, and handles timeout fallback via DegradedModeHandler.
+
+Rule R3: coordinates inference engines but never calls models directly.
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+from typing import TYPE_CHECKING
+
+from sozia.common.models import (
+    ModalityPath,
+    ModalityResult,
+    ModalityType,
+    PipelineHealth,
+    SegmentStatus,
+    TranscriptSegment,
+)
+from sozia.fusion.degraded_mode_handler import DegradedModeHandler
+
+if TYPE_CHECKING:
+    from sozia.common.interfaces import FusionStrategy
+
+
+class FusionOrchestrator:
+    """Routes inference results to the appropriate fusion policy.
+
+    Usage::
+
+        orchestrator = FusionOrchestrator()
+        orchestrator.register_policy(ModalityPath.SPEECH, speech_policy)
+        orchestrator.register_policy(ModalityPath.SIGN, sign_policy)
+
+        segment = orchestrator.process_features(session_id, results, health, path)
+    """
+
+    def __init__(
+        self,
+        degraded_handler: DegradedModeHandler | None = None,
+    ) -> None:
+        self._policies: dict[ModalityPath, FusionStrategy] = {}
+        self._degraded: DegradedModeHandler = degraded_handler or DegradedModeHandler()
+
+    # ------------------------------------------------------------------
+    # Registration
+    # ------------------------------------------------------------------
+
+    def register_policy(
+        self, path: ModalityPath, policy: FusionStrategy,
+    ) -> None:
+        """Wire a fusion policy for a modality path."""
+        self._policies[path] = policy
+
+    # ------------------------------------------------------------------
+    # Main entry point
+    # ------------------------------------------------------------------
+
+    def process_features(
+        self,
+        session_id: str,
+        results: list[ModalityResult],
+        health: list[PipelineHealth],
+        modality_path: ModalityPath,
+    ) -> list[TranscriptSegment]:
+        """Route inference results to the registered policy.
+
+        If any pipeline in ``health`` signals degraded state and only one
+        modality result is present, delegates to DegradedModeHandler instead.
+
+        Args:
+            session_id: Active session identifier.
+            results: Inference results from one or more engines.
+            health: Current pipeline health signals.
+            modality_path: Which pipeline (SPEECH or SIGN) is active.
+
+        Returns:
+            List of TranscriptSegment objects to stream to the client.
+            May be empty if all results are suppressed.
+
+        Raises:
+            ValueError: No policy registered for ``modality_path``.
+        """
+        if modality_path not in self._policies:
+            raise ValueError(
+                f"No fusion policy registered for {modality_path.value}"
+            )
+
+        # Check degraded mode: if any health signal triggers fallback and
+        # only one result is available, use the degraded handler.
+        if len(results) == 1 and self._is_degraded(health):
+            seg = self._degraded.handle_degraded_input(session_id, results[0])
+            return [seg] if seg is not None else []
+
+        policy = self._policies[modality_path]
+        return policy.fuse(results, health)
+
+    def handle_timeout(
+        self,
+        session_id: str,
+        result: ModalityResult,
+        health: list[PipelineHealth],
+        modality_path: ModalityPath,
+    ) -> list[TranscriptSegment]:
+        """Emit a PARTIAL when the slower modality times out.
+
+        Called when the secondary modality exceeds its latency budget.
+        The primary modality's result is fused alone via the registered
+        policy (producing a PARTIAL segment).
+
+        Args:
+            session_id: Active session identifier.
+            result: The primary (fast) modality result that is available.
+            health: Current pipeline health signals.
+            modality_path: Which pipeline is active.
+
+        Returns:
+            List of TranscriptSegment objects (typically one PARTIAL).
+        """
+        if modality_path not in self._policies:
+            raise ValueError(
+                f"No fusion policy registered for {modality_path.value}"
+            )
+
+        policy = self._policies[modality_path]
+        return policy.fuse([result], health)
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _is_degraded(self, health: list[PipelineHealth]) -> bool:
+        """Return True if any health signal indicates degraded state."""
+        return any(self._degraded.should_fallback(h) for h in health)

--- a/sozia/fusion/orchestrator.py
+++ b/sozia/fusion/orchestrator.py
@@ -2,24 +2,30 @@
 
 Receives inference results, routes them to the correct FusionStrategy based
 on ModalityPath, and handles timeout fallback via DegradedModeHandler.
+Also drives per-session model warm-up and cool-down by iterating over the
+``InferenceEngine`` instances registered for each modality path.
 
-Rule R3: coordinates inference engines but never calls models directly.
+Rule R3: coordinates inference engines but never calls models directly —
+it only touches the ``InferenceEngine`` interface (``load_model``,
+``unload_model``), never the underlying ML library.
 """
 
 from __future__ import annotations
 
+import asyncio
 from typing import TYPE_CHECKING
 
 from sozia.common.models import (
     ModalityPath,
     ModalityResult,
+    ModelConfig,
     PipelineHealth,
     TranscriptSegment,
 )
 from sozia.fusion.degraded_mode_handler import DegradedModeHandler
 
 if TYPE_CHECKING:
-    from sozia.common.interfaces import FusionStrategy
+    from sozia.common.interfaces import FusionStrategy, InferenceEngine
 
 
 class FusionOrchestrator:
@@ -29,9 +35,14 @@ class FusionOrchestrator:
 
         orchestrator = FusionOrchestrator()
         orchestrator.register_policy(ModalityPath.SPEECH, speech_policy)
-        orchestrator.register_policy(ModalityPath.SIGN, sign_policy)
+        orchestrator.register_engine(ModalityPath.SPEECH, asr_engine, asr_cfg)
+        orchestrator.register_engine(ModalityPath.SPEECH, lip_engine, lip_cfg)
 
-        segment = orchestrator.process_features(session_id, results, health, path)
+        await orchestrator.warm_up(ModalityPath.SPEECH)
+        segments = await orchestrator.process_features(
+            session_id, results, health, ModalityPath.SPEECH,
+        )
+        await orchestrator.cool_down()
     """
 
     def __init__(
@@ -39,7 +50,12 @@ class FusionOrchestrator:
         degraded_handler: DegradedModeHandler | None = None,
     ) -> None:
         self._policies: dict[ModalityPath, FusionStrategy] = {}
-        self._degraded: DegradedModeHandler = degraded_handler or DegradedModeHandler()
+        self._engines: dict[
+            ModalityPath, list[tuple[InferenceEngine, ModelConfig]],
+        ] = {}
+        self._degraded: DegradedModeHandler = (
+            degraded_handler or DegradedModeHandler()
+        )
 
     # ------------------------------------------------------------------
     # Registration
@@ -51,11 +67,61 @@ class FusionOrchestrator:
         """Wire a fusion policy for a modality path."""
         self._policies[path] = policy
 
+    def register_engine(
+        self,
+        path: ModalityPath,
+        engine: InferenceEngine,
+        config: ModelConfig,
+    ) -> None:
+        """Attach an inference engine to a modality path for warm-up.
+
+        The orchestrator records the (engine, config) pair but does not
+        load the model until ``warm_up(path)`` is called. Engines stay
+        attached across sessions; ``cool_down()`` unloads them.
+        """
+        self._engines.setdefault(path, []).append((engine, config))
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def warm_up(self, path: ModalityPath) -> None:
+        """Load every engine registered for ``path``.
+
+        Engines that are already loaded are skipped so ``warm_up`` is
+        idempotent per session. Load calls run concurrently to minimise
+        cold-start latency; errors from individual engines propagate so
+        the caller can decide whether to abort session setup.
+        """
+        engines = self._engines.get(path, [])
+        await asyncio.gather(
+            *(
+                engine.load_model(config)
+                for engine, config in engines
+                if not engine.is_loaded()
+            )
+        )
+
+    async def cool_down(self) -> None:
+        """Unload every registered engine across all paths.
+
+        Safe to call even if no engines were warmed. Unload calls run
+        concurrently and exceptions are suppressed so one failing engine
+        does not block the others from releasing their memory.
+        """
+        tasks: list[asyncio.Task] = []
+        for engines in self._engines.values():
+            for engine, _ in engines:
+                if engine.is_loaded():
+                    tasks.append(asyncio.create_task(engine.unload_model()))
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+
     # ------------------------------------------------------------------
     # Main entry point
     # ------------------------------------------------------------------
 
-    def process_features(
+    async def process_features(
         self,
         session_id: str,
         results: list[ModalityResult],
@@ -94,7 +160,7 @@ class FusionOrchestrator:
         policy = self._policies[modality_path]
         return policy.fuse(results, health)
 
-    def handle_timeout(
+    async def handle_timeout(
         self,
         session_id: str,
         result: ModalityResult,

--- a/sozia/fusion/orchestrator.py
+++ b/sozia/fusion/orchestrator.py
@@ -8,16 +8,12 @@ Rule R3: coordinates inference engines but never calls models directly.
 
 from __future__ import annotations
 
-import time
-import uuid
 from typing import TYPE_CHECKING
 
 from sozia.common.models import (
     ModalityPath,
     ModalityResult,
-    ModalityType,
     PipelineHealth,
-    SegmentStatus,
     TranscriptSegment,
 )
 from sozia.fusion.degraded_mode_handler import DegradedModeHandler

--- a/sozia/fusion/sign_fusion_policy.py
+++ b/sozia/fusion/sign_fusion_policy.py
@@ -82,7 +82,7 @@ class SignFusionPolicy(FusionStrategy):
 
         if tsl:
             # Only TSL available → PARTIAL with raw gloss.
-            seg_id = uuid.uuid4().hex
+            seg_id = str(uuid.uuid4())
             self._partial_ids[session_id] = seg_id
             return [_make_segment(
                 session_id=session_id,
@@ -123,7 +123,7 @@ def _make_segment(
     segment_id: str | None = None,
 ) -> TranscriptSegment:
     return TranscriptSegment(
-        segment_id=segment_id or uuid.uuid4().hex,
+        segment_id=segment_id or str(uuid.uuid4()),
         session_id=session_id,
         status=status,
         text=text,

--- a/sozia/fusion/sign_fusion_policy.py
+++ b/sozia/fusion/sign_fusion_policy.py
@@ -1,0 +1,131 @@
+"""SignFusionPolicy — fusion strategy for the sign language pipeline.
+
+Sign path uses optimistic-then-revise:
+  1. TSL Recognition emits a raw gloss string (e.g. "MERHABA DUNYA") as a
+     PARTIAL segment.
+  2. GlossToText converts it to natural Turkish (e.g. "Merhaba dünya.") and
+     emits a FINAL segment that replaces the PARTIAL via replaces_segment_id.
+
+Unlike the speech path there is no weighted merge — GlossToText output fully
+replaces the gloss. If GlossToText is suppressed (low confidence), the raw
+gloss PARTIAL remains as the final output.
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+
+from sozia.common.interfaces import FusionStrategy
+from sozia.common.models import (
+    ModalityResult,
+    ModalityType,
+    PipelineHealth,
+    SegmentStatus,
+    TranscriptSegment,
+)
+
+_CONFIDENCE_THRESHOLD = 0.30
+
+
+class SignFusionPolicy(FusionStrategy):
+    """FusionStrategy for the TSL Recognition + GlossToText pipeline."""
+
+    def __init__(self) -> None:
+        self._partial_ids: dict[str, str] = {}
+
+    # ------------------------------------------------------------------
+    # FusionStrategy interface
+    # ------------------------------------------------------------------
+
+    def fuse(
+        self,
+        results: list[ModalityResult],
+        health: list[PipelineHealth],
+    ) -> list[TranscriptSegment]:
+        if not results:
+            return []
+
+        valid = [r for r in results if not self.should_suppress(r)]
+        if not valid:
+            return []
+
+        tsl = next(
+            (r for r in valid if r.modality_type == ModalityType.TSL_RECOGNITION),
+            None,
+        )
+        gloss = next(
+            (r for r in valid if r.modality_type == ModalityType.GLOSS_TO_TEXT),
+            None,
+        )
+
+        session_id = health[0].session_id if health else ""
+
+        if gloss:
+            # GlossToText available → FINAL replacing the PARTIAL.
+            replaces = self._partial_ids.pop(session_id, None)
+            return [_make_segment(
+                session_id=session_id,
+                status=SegmentStatus.FINAL,
+                text=gloss.text,
+                source=ModalityType.GLOSS_TO_TEXT,
+                confidence=gloss.confidence,
+                timestamp_ms=gloss.timestamp_ms,
+                duration_ms=gloss.duration_ms,
+                replaces_segment_id=replaces,
+            )]
+
+        if tsl:
+            # Only TSL available → PARTIAL with raw gloss.
+            seg_id = uuid.uuid4().hex
+            self._partial_ids[session_id] = seg_id
+            return [_make_segment(
+                session_id=session_id,
+                status=SegmentStatus.PARTIAL,
+                text=tsl.text,
+                source=ModalityType.TSL_RECOGNITION,
+                confidence=tsl.confidence,
+                timestamp_ms=tsl.timestamp_ms,
+                duration_ms=tsl.duration_ms,
+                replaces_segment_id=None,
+                segment_id=seg_id,
+            )]
+
+        return []
+
+    def should_suppress(self, result: ModalityResult) -> bool:
+        return result.confidence < _CONFIDENCE_THRESHOLD
+
+    def get_confidence_threshold(self) -> float:
+        return _CONFIDENCE_THRESHOLD
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_segment(
+    *,
+    session_id: str,
+    status: SegmentStatus,
+    text: str,
+    source: ModalityType,
+    confidence: float,
+    timestamp_ms: int,
+    duration_ms: int,
+    replaces_segment_id: str | None,
+    segment_id: str | None = None,
+) -> TranscriptSegment:
+    return TranscriptSegment(
+        segment_id=segment_id or uuid.uuid4().hex,
+        session_id=session_id,
+        status=status,
+        text=text,
+        source=source,
+        confidence=confidence,
+        timestamp_ms=timestamp_ms,
+        duration_ms=duration_ms,
+        created_at_ms=int(time.time() * 1000),
+        replaces_segment_id=replaces_segment_id,
+    )

--- a/sozia/fusion/sign_fusion_policy.py
+++ b/sozia/fusion/sign_fusion_policy.py
@@ -25,13 +25,18 @@ from sozia.common.models import (
     TranscriptSegment,
 )
 
-_CONFIDENCE_THRESHOLD = 0.30
+_DEFAULT_CONFIDENCE_THRESHOLD = 0.30
 
 
 class SignFusionPolicy(FusionStrategy):
     """FusionStrategy for the TSL Recognition + GlossToText pipeline."""
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        *,
+        confidence_threshold: float = _DEFAULT_CONFIDENCE_THRESHOLD,
+    ) -> None:
+        self._confidence_threshold = confidence_threshold
         self._partial_ids: dict[str, str] = {}
 
     # ------------------------------------------------------------------
@@ -94,10 +99,10 @@ class SignFusionPolicy(FusionStrategy):
         return []
 
     def should_suppress(self, result: ModalityResult) -> bool:
-        return result.confidence < _CONFIDENCE_THRESHOLD
+        return result.confidence < self._confidence_threshold
 
     def get_confidence_threshold(self) -> float:
-        return _CONFIDENCE_THRESHOLD
+        return self._confidence_threshold
 
 
 # ---------------------------------------------------------------------------

--- a/sozia/fusion/speech_fusion_policy.py
+++ b/sozia/fusion/speech_fusion_policy.py
@@ -1,0 +1,136 @@
+"""SpeechFusionPolicy — fusion strategy for the speech pipeline.
+
+Speech path uses optimistic-then-revise:
+  1. ASR result arrives first (fast, ≤800ms) → emit PARTIAL segment.
+  2. Lip-reading arrives later (≤1200ms) → weighted merge with ASR → emit
+     FINAL segment that replaces the PARTIAL via replaces_segment_id.
+
+If only one modality is available, it is emitted directly. Results with
+confidence below the threshold (0.30) are suppressed.
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+
+from sozia.common.interfaces import FusionStrategy
+from sozia.common.models import (
+    ModalityResult,
+    ModalityType,
+    PipelineHealth,
+    SegmentStatus,
+    TranscriptSegment,
+)
+
+_CONFIDENCE_THRESHOLD = 0.30
+
+# Weights for the weighted-average confidence merge.
+_ASR_WEIGHT = 0.65
+_LIP_WEIGHT = 0.35
+
+
+class SpeechFusionPolicy(FusionStrategy):
+    """FusionStrategy for the ASR + Lip-Reading speech pipeline.
+
+    Maintains a mapping of session_id → last PARTIAL segment_id so that
+    FINAL segments can reference the PARTIAL they replace.
+    """
+
+    def __init__(self) -> None:
+        self._partial_ids: dict[str, str] = {}
+
+    # ------------------------------------------------------------------
+    # FusionStrategy interface
+    # ------------------------------------------------------------------
+
+    def fuse(
+        self,
+        results: list[ModalityResult],
+        health: list[PipelineHealth],
+    ) -> list[TranscriptSegment]:
+        if not results:
+            return []
+
+        valid = [r for r in results if not self.should_suppress(r)]
+        if not valid:
+            return []
+
+        asr = next((r for r in valid if r.modality_type == ModalityType.ASR), None)
+        lip = next(
+            (r for r in valid if r.modality_type == ModalityType.LIP_READING), None,
+        )
+
+        session_id = health[0].session_id if health else ""
+
+        if asr and lip:
+            # Both modalities → weighted merge → FINAL replacing the PARTIAL.
+            merged_text = lip.text if lip.text else asr.text
+            merged_confidence = (
+                _ASR_WEIGHT * asr.confidence + _LIP_WEIGHT * lip.confidence
+            )
+            replaces = self._partial_ids.pop(session_id, None)
+
+            return [self._make_segment(
+                session_id=session_id,
+                status=SegmentStatus.FINAL,
+                text=merged_text,
+                source=ModalityType.LIP_READING,
+                confidence=min(1.0, merged_confidence),
+                timestamp_ms=asr.timestamp_ms,
+                duration_ms=max(asr.duration_ms, lip.duration_ms),
+                replaces_segment_id=replaces,
+            )]
+
+        # Single modality → PARTIAL.
+        single = asr or lip
+        seg_id = uuid.uuid4().hex
+        self._partial_ids[session_id] = seg_id
+
+        return [self._make_segment(
+            session_id=session_id,
+            status=SegmentStatus.PARTIAL,
+            text=single.text,
+            source=single.modality_type,
+            confidence=single.confidence,
+            timestamp_ms=single.timestamp_ms,
+            duration_ms=single.duration_ms,
+            replaces_segment_id=None,
+            segment_id=seg_id,
+        )]
+
+    def should_suppress(self, result: ModalityResult) -> bool:
+        return result.confidence < _CONFIDENCE_THRESHOLD
+
+    def get_confidence_threshold(self) -> float:
+        return _CONFIDENCE_THRESHOLD
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _make_segment(
+        *,
+        session_id: str,
+        status: SegmentStatus,
+        text: str,
+        source: ModalityType,
+        confidence: float,
+        timestamp_ms: int,
+        duration_ms: int,
+        replaces_segment_id: str | None,
+        segment_id: str | None = None,
+    ) -> TranscriptSegment:
+        return TranscriptSegment(
+            segment_id=segment_id or uuid.uuid4().hex,
+            session_id=session_id,
+            status=status,
+            text=text,
+            source=source,
+            confidence=confidence,
+            timestamp_ms=timestamp_ms,
+            duration_ms=duration_ms,
+            created_at_ms=int(time.time() * 1000),
+            replaces_segment_id=replaces_segment_id,
+        )

--- a/sozia/fusion/speech_fusion_policy.py
+++ b/sozia/fusion/speech_fusion_policy.py
@@ -77,7 +77,14 @@ class SpeechFusionPolicy(FusionStrategy):
 
         if asr and lip:
             # Both modalities → weighted merge → FINAL replacing the PARTIAL.
-            merged_text = lip.text if lip.text else asr.text
+            # Prefer the text from whichever hypothesis has higher confidence;
+            # if lip text is empty, fall back to ASR regardless.
+            if lip.text and lip.confidence >= asr.confidence:
+                merged_text = lip.text
+                merged_source = ModalityType.LIP_READING
+            else:
+                merged_text = asr.text
+                merged_source = ModalityType.ASR
             merged_confidence = (
                 self._asr_weight * asr.confidence
                 + self._lip_weight * lip.confidence
@@ -88,7 +95,7 @@ class SpeechFusionPolicy(FusionStrategy):
                 session_id=session_id,
                 status=SegmentStatus.FINAL,
                 text=merged_text,
-                source=ModalityType.LIP_READING,
+                source=merged_source,
                 confidence=min(1.0, merged_confidence),
                 timestamp_ms=asr.timestamp_ms,
                 duration_ms=max(asr.duration_ms, lip.duration_ms),

--- a/sozia/fusion/speech_fusion_policy.py
+++ b/sozia/fusion/speech_fusion_policy.py
@@ -104,7 +104,7 @@ class SpeechFusionPolicy(FusionStrategy):
 
         # Single modality → PARTIAL.
         single = asr or lip
-        seg_id = uuid.uuid4().hex
+        seg_id = str(uuid.uuid4())
         self._partial_ids[session_id] = seg_id
 
         return [self._make_segment(
@@ -143,7 +143,7 @@ class SpeechFusionPolicy(FusionStrategy):
         segment_id: str | None = None,
     ) -> TranscriptSegment:
         return TranscriptSegment(
-            segment_id=segment_id or uuid.uuid4().hex,
+            segment_id=segment_id or str(uuid.uuid4()),
             session_id=session_id,
             status=status,
             text=text,

--- a/sozia/fusion/speech_fusion_policy.py
+++ b/sozia/fusion/speech_fusion_policy.py
@@ -23,11 +23,11 @@ from sozia.common.models import (
     TranscriptSegment,
 )
 
-_CONFIDENCE_THRESHOLD = 0.30
+_DEFAULT_CONFIDENCE_THRESHOLD = 0.30
 
-# Weights for the weighted-average confidence merge.
-_ASR_WEIGHT = 0.65
-_LIP_WEIGHT = 0.35
+# Default weights for the weighted-average confidence merge.
+_DEFAULT_ASR_WEIGHT = 0.65
+_DEFAULT_LIP_WEIGHT = 0.35
 
 
 class SpeechFusionPolicy(FusionStrategy):
@@ -35,9 +35,21 @@ class SpeechFusionPolicy(FusionStrategy):
 
     Maintains a mapping of session_id → last PARTIAL segment_id so that
     FINAL segments can reference the PARTIAL they replace.
+
+    Weights and threshold default to tuned production values but can be
+    overridden for experimentation or testing.
     """
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        *,
+        asr_weight: float = _DEFAULT_ASR_WEIGHT,
+        lip_weight: float = _DEFAULT_LIP_WEIGHT,
+        confidence_threshold: float = _DEFAULT_CONFIDENCE_THRESHOLD,
+    ) -> None:
+        self._asr_weight = asr_weight
+        self._lip_weight = lip_weight
+        self._confidence_threshold = confidence_threshold
         self._partial_ids: dict[str, str] = {}
 
     # ------------------------------------------------------------------
@@ -67,7 +79,8 @@ class SpeechFusionPolicy(FusionStrategy):
             # Both modalities → weighted merge → FINAL replacing the PARTIAL.
             merged_text = lip.text if lip.text else asr.text
             merged_confidence = (
-                _ASR_WEIGHT * asr.confidence + _LIP_WEIGHT * lip.confidence
+                self._asr_weight * asr.confidence
+                + self._lip_weight * lip.confidence
             )
             replaces = self._partial_ids.pop(session_id, None)
 
@@ -100,10 +113,10 @@ class SpeechFusionPolicy(FusionStrategy):
         )]
 
     def should_suppress(self, result: ModalityResult) -> bool:
-        return result.confidence < _CONFIDENCE_THRESHOLD
+        return result.confidence < self._confidence_threshold
 
     def get_confidence_threshold(self) -> float:
-        return _CONFIDENCE_THRESHOLD
+        return self._confidence_threshold
 
     # ------------------------------------------------------------------
     # Helpers

--- a/tests/fusion/test_degraded_mode_handler.py
+++ b/tests/fusion/test_degraded_mode_handler.py
@@ -8,7 +8,10 @@ from sozia.common.models import (
     PipelineHealth,
     SegmentStatus,
 )
-from sozia.fusion.degraded_mode_handler import DegradedModeHandler
+from sozia.fusion.degraded_mode_handler import (
+    DegradedModeHandler,
+    DegradedStatus,
+)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -156,3 +159,82 @@ class TestHandleDegradedInput:
         assert seg is not None
         assert seg.timestamp_ms == 1000
         assert seg.duration_ms == 500
+
+
+class TestEvaluate:
+    def test_empty_health_is_failed(self):
+        handler = DegradedModeHandler()
+        assert handler.evaluate([]) == DegradedStatus.FAILED
+
+    def test_all_healthy_is_normal(self):
+        handler = DegradedModeHandler()
+        status = handler.evaluate([_audio_health(), _video_health()])
+        assert status == DegradedStatus.NORMAL
+
+    def test_one_down_is_degraded(self):
+        handler = DegradedModeHandler()
+        status = handler.evaluate(
+            [_audio_health(available=False), _video_health()],
+        )
+        assert status == DegradedStatus.DEGRADED
+
+    def test_all_down_is_failed(self):
+        handler = DegradedModeHandler()
+        status = handler.evaluate(
+            [
+                _audio_health(available=False),
+                _video_health(available=False),
+            ],
+        )
+        assert status == DegradedStatus.FAILED
+
+    def test_video_obstructed_counts_as_degraded(self):
+        handler = DegradedModeHandler()
+        status = handler.evaluate(
+            [_audio_health(), _video_health(face_detected=False)],
+        )
+        assert status == DegradedStatus.DEGRADED
+
+
+class TestAdvisoryMessage:
+    def test_all_healthy_returns_none(self):
+        handler = DegradedModeHandler()
+        assert handler.get_advisory_message(
+            [_audio_health(), _video_health()],
+        ) is None
+
+    def test_empty_health_returns_terminal_message(self):
+        handler = DegradedModeHandler()
+        msg = handler.get_advisory_message([])
+        assert msg is not None
+        assert "session ending" in msg.lower()
+
+    def test_camera_obstructed_message(self):
+        handler = DegradedModeHandler()
+        msg = handler.get_advisory_message(
+            [_video_health(face_detected=False)],
+        )
+        assert msg is not None
+        assert "camera obstructed" in msg.lower()
+
+    def test_microphone_unavailable_message(self):
+        handler = DegradedModeHandler()
+        msg = handler.get_advisory_message(
+            [_audio_health(available=False)],
+        )
+        assert msg is not None
+        assert "microphone unavailable" in msg.lower()
+
+    def test_low_snr_message(self):
+        handler = DegradedModeHandler()
+        msg = handler.get_advisory_message([_audio_health(snr=2.0)])
+        assert msg is not None
+        assert "low audio" in msg.lower()
+
+    def test_camera_unavailable_message(self):
+        handler = DegradedModeHandler()
+        msg = handler.get_advisory_message(
+            [_video_health(available=False)],
+        )
+        assert msg is not None
+        assert "camera unavailable" in msg.lower()

--- a/tests/fusion/test_degraded_mode_handler.py
+++ b/tests/fusion/test_degraded_mode_handler.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import pytest
-
 from sozia.common.models import (
     ModalityResult,
     ModalityType,
@@ -11,7 +9,6 @@ from sozia.common.models import (
     SegmentStatus,
 )
 from sozia.fusion.degraded_mode_handler import DegradedModeHandler
-
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/fusion/test_degraded_mode_handler.py
+++ b/tests/fusion/test_degraded_mode_handler.py
@@ -238,3 +238,14 @@ class TestAdvisoryMessage:
         )
         assert msg is not None
         assert "camera unavailable" in msg.lower()
+
+
+class TestSegmentIdFormat:
+    def test_degraded_segment_id_is_dashed_uuid_v4(self):
+        import uuid as _uuid
+
+        handler = DegradedModeHandler()
+        seg = handler.handle_degraded_input(_SESSION, _result())
+        assert seg is not None
+        assert "-" in seg.segment_id
+        assert _uuid.UUID(seg.segment_id).version == 4

--- a/tests/fusion/test_degraded_mode_handler.py
+++ b/tests/fusion/test_degraded_mode_handler.py
@@ -1,0 +1,161 @@
+"""Tests for DegradedModeHandler."""
+
+from __future__ import annotations
+
+import pytest
+
+from sozia.common.models import (
+    ModalityResult,
+    ModalityType,
+    PipelineHealth,
+    SegmentStatus,
+)
+from sozia.fusion.degraded_mode_handler import DegradedModeHandler
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_SESSION = "550e8400-e29b-41d4-a716-446655440000"
+
+
+def _audio_health(
+    available: bool = True, snr: float | None = 25.0,
+) -> PipelineHealth:
+    return PipelineHealth(
+        session_id=_SESSION,
+        pipeline="audio",
+        available=available,
+        fps=None,
+        snr=snr,
+        face_detected=None,
+        last_updated_ms=1000,
+    )
+
+
+def _video_health(
+    available: bool = True, face_detected: bool | None = True,
+) -> PipelineHealth:
+    return PipelineHealth(
+        session_id=_SESSION,
+        pipeline="video",
+        available=available,
+        fps=30.0,
+        snr=None,
+        face_detected=face_detected,
+        last_updated_ms=1000,
+    )
+
+
+def _result(
+    modality: ModalityType = ModalityType.ASR,
+    text: str = "merhaba",
+    confidence: float = 0.80,
+) -> ModalityResult:
+    return ModalityResult(
+        modality_type=modality,
+        text=text,
+        confidence=confidence,
+        timestamp_ms=1000,
+        duration_ms=500,
+        inference_latency_ms=200,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestShouldFallback:
+    def test_healthy_audio_no_fallback(self):
+        handler = DegradedModeHandler()
+        assert handler.should_fallback(_audio_health()) is False
+
+    def test_healthy_video_no_fallback(self):
+        handler = DegradedModeHandler()
+        assert handler.should_fallback(_video_health()) is False
+
+    def test_unavailable_audio_triggers_fallback(self):
+        handler = DegradedModeHandler()
+        assert handler.should_fallback(_audio_health(available=False)) is True
+
+    def test_unavailable_video_triggers_fallback(self):
+        handler = DegradedModeHandler()
+        assert handler.should_fallback(_video_health(available=False)) is True
+
+    def test_no_face_detected_triggers_fallback(self):
+        handler = DegradedModeHandler()
+        assert handler.should_fallback(_video_health(face_detected=False)) is True
+
+    def test_face_detected_none_no_fallback(self):
+        """face_detected=None means detection isn't applicable, not degraded."""
+        handler = DegradedModeHandler()
+        assert handler.should_fallback(_video_health(face_detected=None)) is False
+
+    def test_low_snr_triggers_fallback(self):
+        handler = DegradedModeHandler()
+        assert handler.should_fallback(_audio_health(snr=2.0)) is True
+
+    def test_good_snr_no_fallback(self):
+        handler = DegradedModeHandler()
+        assert handler.should_fallback(_audio_health(snr=20.0)) is False
+
+    def test_snr_at_threshold_no_fallback(self):
+        handler = DegradedModeHandler()
+        assert handler.should_fallback(_audio_health(snr=5.0)) is False
+
+
+class TestHandleDegradedInput:
+    def test_returns_partial_segment(self):
+        handler = DegradedModeHandler()
+        seg = handler.handle_degraded_input(_SESSION, _result())
+
+        assert seg is not None
+        assert seg.status == SegmentStatus.PARTIAL
+        assert seg.text == "merhaba"
+        assert seg.session_id == _SESSION
+        assert seg.replaces_segment_id is None
+
+    def test_confidence_penalised(self):
+        handler = DegradedModeHandler()
+        seg = handler.handle_degraded_input(
+            _SESSION, _result(confidence=0.80),
+        )
+        # 0.80 - 0.15 = 0.65
+        assert seg is not None
+        assert abs(seg.confidence - 0.65) < 0.001
+
+    def test_low_confidence_returns_none(self):
+        """If penalty drops confidence to zero, return None."""
+        handler = DegradedModeHandler()
+        seg = handler.handle_degraded_input(
+            _SESSION, _result(confidence=0.10),
+        )
+        assert seg is None
+
+    def test_exactly_penalty_returns_none(self):
+        """Confidence exactly equal to penalty → 0.0 → None."""
+        handler = DegradedModeHandler()
+        seg = handler.handle_degraded_input(
+            _SESSION, _result(confidence=0.15),
+        )
+        assert seg is None
+
+    def test_preserves_source_modality(self):
+        handler = DegradedModeHandler()
+        seg = handler.handle_degraded_input(
+            _SESSION, _result(modality=ModalityType.LIP_READING),
+        )
+        assert seg is not None
+        assert seg.source == ModalityType.LIP_READING
+
+    def test_preserves_timing_fields(self):
+        handler = DegradedModeHandler()
+        seg = handler.handle_degraded_input(
+            _SESSION, _result(),
+        )
+        assert seg is not None
+        assert seg.timestamp_ms == 1000
+        assert seg.duration_ms == 500

--- a/tests/fusion/test_integration_with_engines.py
+++ b/tests/fusion/test_integration_with_engines.py
@@ -30,7 +30,6 @@ from sozia.fusion.orchestrator import FusionOrchestrator
 from sozia.fusion.sign_fusion_policy import SignFusionPolicy
 from sozia.fusion.speech_fusion_policy import SpeechFusionPolicy
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------

--- a/tests/fusion/test_integration_with_engines.py
+++ b/tests/fusion/test_integration_with_engines.py
@@ -1,0 +1,317 @@
+"""Integration tests wiring mock inference engines into the fusion layer.
+
+These tests exercise the full contract between ``sozia.inference`` and
+``sozia.fusion`` without loading real ML models. A minimal in-memory
+``InferenceEngine`` subclass returns canned ``ModalityResult`` objects, which
+flow through the registered ``FusionStrategy`` via the ``FusionOrchestrator``.
+
+The goal is to catch contract drift between the two layers Aylin owns —
+e.g. a ``ModalityResult`` field rename or a policy assuming fields the
+engines never populate.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from sozia.common.interfaces import InferenceEngine
+from sozia.common.models import (
+    ModalityPath,
+    ModalityResult,
+    ModalityType,
+    ModelConfig,
+    PipelineHealth,
+    SegmentStatus,
+)
+from sozia.fusion.degraded_mode_handler import DegradedModeHandler
+from sozia.fusion.orchestrator import FusionOrchestrator
+from sozia.fusion.sign_fusion_policy import SignFusionPolicy
+from sozia.fusion.speech_fusion_policy import SpeechFusionPolicy
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_SESSION = "550e8400-e29b-41d4-a716-446655440000"
+
+
+class _StubEngine(InferenceEngine):
+    """Minimal InferenceEngine that returns a pre-canned ModalityResult.
+
+    Does not load any real weights — satisfies R2 (only inference loads
+    models) by declaring itself as inference layer, while keeping the test
+    hermetic.
+    """
+
+    def __init__(self, result: ModalityResult, model_id: str = "stub") -> None:
+        self._result = result
+        self._model_id = model_id
+        self._loaded = False
+
+    async def load_model(self, config: ModelConfig) -> None:
+        self._loaded = True
+        self._model_id = config.model_id
+
+    async def predict(
+        self, features, timeout_ms: int = 2200,
+    ) -> ModalityResult:
+        if not self._loaded:
+            from sozia.common.interfaces import ModelNotLoadedError
+            raise ModelNotLoadedError(self._model_id)
+        return self._result
+
+    async def unload_model(self) -> None:
+        self._loaded = False
+
+    def is_loaded(self) -> bool:
+        return self._loaded
+
+    def get_model_id(self) -> str:
+        return self._model_id if self._loaded else ""
+
+
+def _result(
+    modality: ModalityType,
+    text: str,
+    confidence: float = 0.85,
+    timestamp_ms: int = 1000,
+    duration_ms: int = 500,
+    inference_latency_ms: int = 200,
+) -> ModalityResult:
+    return ModalityResult(
+        modality_type=modality,
+        text=text,
+        confidence=confidence,
+        timestamp_ms=timestamp_ms,
+        duration_ms=duration_ms,
+        inference_latency_ms=inference_latency_ms,
+    )
+
+
+def _audio_health(available: bool = True, snr: float = 25.0) -> PipelineHealth:
+    return PipelineHealth(
+        session_id=_SESSION,
+        pipeline="audio",
+        available=available,
+        fps=None,
+        snr=snr,
+        face_detected=None,
+        last_updated_ms=1000,
+    )
+
+
+def _video_health(
+    available: bool = True, face_detected: bool = True,
+) -> PipelineHealth:
+    return PipelineHealth(
+        session_id=_SESSION,
+        pipeline="video",
+        available=available,
+        fps=30.0,
+        snr=None,
+        face_detected=face_detected,
+        last_updated_ms=1000,
+    )
+
+
+def _config(model_id: str) -> ModelConfig:
+    return ModelConfig(
+        model_id=model_id,
+        weights_path="/tmp/noop",
+        device="cpu",
+        params={},
+    )
+
+
+def _build_orchestrator() -> FusionOrchestrator:
+    orch = FusionOrchestrator(degraded_handler=DegradedModeHandler())
+    orch.register_policy(ModalityPath.SPEECH, SpeechFusionPolicy())
+    orch.register_policy(ModalityPath.SIGN, SignFusionPolicy())
+    return orch
+
+
+# ---------------------------------------------------------------------------
+# Speech path: ASR → PARTIAL, then ASR + Lip → FINAL
+# ---------------------------------------------------------------------------
+
+
+class TestSpeechPipelineIntegration:
+    def test_partial_then_final_replaces_partial(self):
+        """ASR alone → PARTIAL; lip arrives → FINAL with replaces_segment_id."""
+        asr = _StubEngine(_result(ModalityType.ASR, "merhaba", 0.85))
+        lip = _StubEngine(
+            _result(ModalityType.LIP_READING, "merhaba dünya", 0.70),
+        )
+        asyncio.run(asr.load_model(_config("whisper-small-tr")))
+        asyncio.run(lip.load_model(_config("lip-reading-v1")))
+
+        asr_out = asyncio.run(asr.predict(features=None))
+        lip_out = asyncio.run(lip.predict(features=None))
+
+        orch = _build_orchestrator()
+
+        # First pass: ASR only → PARTIAL.
+        partials = orch.process_features(
+            _SESSION, [asr_out], [_audio_health()], ModalityPath.SPEECH,
+        )
+        assert len(partials) == 1
+        assert partials[0].status == SegmentStatus.PARTIAL
+        partial_id = partials[0].segment_id
+
+        # Second pass: both modalities → FINAL replacing PARTIAL.
+        finals = orch.process_features(
+            _SESSION,
+            [asr_out, lip_out],
+            [_audio_health()],
+            ModalityPath.SPEECH,
+        )
+        assert len(finals) == 1
+        assert finals[0].status == SegmentStatus.FINAL
+        assert finals[0].replaces_segment_id == partial_id
+        # Lip text takes precedence when both are present.
+        assert finals[0].text == "merhaba dünya"
+
+    def test_low_confidence_asr_suppressed(self):
+        asr = _StubEngine(_result(ModalityType.ASR, "noise", 0.10))
+        asyncio.run(asr.load_model(_config("whisper-small-tr")))
+        asr_out = asyncio.run(asr.predict(features=None))
+
+        orch = _build_orchestrator()
+        segments = orch.process_features(
+            _SESSION, [asr_out], [_audio_health()], ModalityPath.SPEECH,
+        )
+        assert segments == []
+
+
+# ---------------------------------------------------------------------------
+# Sign path: TSL → PARTIAL, then GlossToText → FINAL
+# ---------------------------------------------------------------------------
+
+
+class TestSignPipelineIntegration:
+    def test_gloss_replaces_tsl_partial(self):
+        tsl = _StubEngine(
+            _result(ModalityType.TSL_RECOGNITION, "MERHABA DUNYA", 0.80),
+        )
+        gloss = _StubEngine(
+            _result(
+                ModalityType.GLOSS_TO_TEXT,
+                "Merhaba dünya.",
+                0.88,
+                inference_latency_ms=1500,
+            ),
+        )
+        asyncio.run(tsl.load_model(_config("tsl-gru-v1")))
+        asyncio.run(gloss.load_model(_config("gemma2-9b-lora")))
+
+        tsl_out = asyncio.run(tsl.predict(features=None))
+        gloss_out = asyncio.run(gloss.predict(features=None))
+
+        orch = _build_orchestrator()
+
+        # TSL alone → PARTIAL.
+        partials = orch.process_features(
+            _SESSION, [tsl_out], [_video_health()], ModalityPath.SIGN,
+        )
+        assert len(partials) == 1
+        assert partials[0].status == SegmentStatus.PARTIAL
+        assert partials[0].text == "MERHABA DUNYA"
+        partial_id = partials[0].segment_id
+
+        # GlossToText arrives → FINAL replaces PARTIAL, text fully replaced.
+        finals = orch.process_features(
+            _SESSION,
+            [tsl_out, gloss_out],
+            [_video_health()],
+            ModalityPath.SIGN,
+        )
+        assert len(finals) == 1
+        assert finals[0].status == SegmentStatus.FINAL
+        assert finals[0].replaces_segment_id == partial_id
+        assert finals[0].text == "Merhaba dünya."
+
+
+# ---------------------------------------------------------------------------
+# Degraded mode: one pipeline unhealthy, single modality falls back
+# ---------------------------------------------------------------------------
+
+
+class TestDegradedIntegration:
+    def test_no_face_detected_falls_back_to_audio(self):
+        """Video pipeline reports no face → fusion must still emit audio."""
+        asr = _StubEngine(_result(ModalityType.ASR, "merhaba", 0.80))
+        asyncio.run(asr.load_model(_config("whisper-small-tr")))
+        asr_out = asyncio.run(asr.predict(features=None))
+
+        orch = _build_orchestrator()
+        # Audio healthy, video degraded (no face), only ASR result.
+        segments = orch.process_features(
+            _SESSION,
+            [asr_out],
+            [_audio_health(), _video_health(face_detected=False)],
+            ModalityPath.SPEECH,
+        )
+        assert len(segments) == 1
+        seg = segments[0]
+        assert seg.status == SegmentStatus.PARTIAL
+        # Degraded handler applies confidence penalty (0.80 - 0.15 = 0.65).
+        assert abs(seg.confidence - 0.65) < 0.001
+
+    def test_low_snr_penalises_asr(self):
+        asr = _StubEngine(_result(ModalityType.ASR, "fısıltı", 0.70))
+        asyncio.run(asr.load_model(_config("whisper-small-tr")))
+        asr_out = asyncio.run(asr.predict(features=None))
+
+        orch = _build_orchestrator()
+        segments = orch.process_features(
+            _SESSION,
+            [asr_out],
+            [_audio_health(snr=2.0)],
+            ModalityPath.SPEECH,
+        )
+        assert len(segments) == 1
+        # 0.70 - 0.15 = 0.55
+        assert abs(segments[0].confidence - 0.55) < 0.001
+
+
+# ---------------------------------------------------------------------------
+# Engine lifecycle + fusion contract
+# ---------------------------------------------------------------------------
+
+
+class TestEngineLifecycleContract:
+    def test_predict_before_load_raises(self):
+        from sozia.common.interfaces import ModelNotLoadedError
+
+        engine = _StubEngine(_result(ModalityType.ASR, "x"))
+        with pytest.raises(ModelNotLoadedError):
+            asyncio.run(engine.predict(features=None))
+
+    def test_unload_resets_state(self):
+        engine = _StubEngine(_result(ModalityType.ASR, "x"))
+        asyncio.run(engine.load_model(_config("m")))
+        assert engine.is_loaded() is True
+        assert engine.get_model_id() == "m"
+
+        asyncio.run(engine.unload_model())
+        assert engine.is_loaded() is False
+        assert engine.get_model_id() == ""
+
+    def test_custom_policy_threshold_is_honoured(self):
+        """Refactored policies expose constants — verify override flows end-to-end."""
+        strict = SpeechFusionPolicy(confidence_threshold=0.90)
+        orch = FusionOrchestrator()
+        orch.register_policy(ModalityPath.SPEECH, strict)
+
+        engine = _StubEngine(_result(ModalityType.ASR, "merhaba", 0.85))
+        asyncio.run(engine.load_model(_config("whisper-small-tr")))
+        out = asyncio.run(engine.predict(features=None))
+
+        segments = orch.process_features(
+            _SESSION, [out], [_audio_health()], ModalityPath.SPEECH,
+        )
+        # 0.85 < 0.90 → suppressed.
+        assert segments == []

--- a/tests/fusion/test_integration_with_engines.py
+++ b/tests/fusion/test_integration_with_engines.py
@@ -375,7 +375,8 @@ class TestWarmUpCoolDown:
 
         await orch.warm_up(ModalityPath.SPEECH)
         await orch.warm_up(ModalityPath.SIGN)
-        assert asr.is_loaded() and tsl.is_loaded()
+        assert asr.is_loaded()
+        assert tsl.is_loaded()
 
         await orch.cool_down()
         assert not asr.is_loaded()

--- a/tests/fusion/test_integration_with_engines.py
+++ b/tests/fusion/test_integration_with_engines.py
@@ -12,8 +12,6 @@ engines never populate.
 
 from __future__ import annotations
 
-import asyncio
-
 import pytest
 
 from sozia.common.interfaces import InferenceEngine
@@ -138,22 +136,22 @@ def _build_orchestrator() -> FusionOrchestrator:
 
 
 class TestSpeechPipelineIntegration:
-    def test_partial_then_final_replaces_partial(self):
+    async def test_partial_then_final_replaces_partial(self):
         """ASR alone → PARTIAL; lip arrives → FINAL with replaces_segment_id."""
-        asr = _StubEngine(_result(ModalityType.ASR, "merhaba", 0.85))
+        asr = _StubEngine(_result(ModalityType.ASR, "merhaba", 0.70))
         lip = _StubEngine(
-            _result(ModalityType.LIP_READING, "merhaba dünya", 0.70),
+            _result(ModalityType.LIP_READING, "merhaba dünya", 0.85),
         )
-        asyncio.run(asr.load_model(_config("whisper-small-tr")))
-        asyncio.run(lip.load_model(_config("lip-reading-v1")))
+        await asr.load_model(_config("whisper-small-tr"))
+        await lip.load_model(_config("lip-reading-v1"))
 
-        asr_out = asyncio.run(asr.predict(features=None))
-        lip_out = asyncio.run(lip.predict(features=None))
+        asr_out = await asr.predict(features=None)
+        lip_out = await lip.predict(features=None)
 
         orch = _build_orchestrator()
 
         # First pass: ASR only → PARTIAL.
-        partials = orch.process_features(
+        partials = await orch.process_features(
             _SESSION, [asr_out], [_audio_health()], ModalityPath.SPEECH,
         )
         assert len(partials) == 1
@@ -161,7 +159,7 @@ class TestSpeechPipelineIntegration:
         partial_id = partials[0].segment_id
 
         # Second pass: both modalities → FINAL replacing PARTIAL.
-        finals = orch.process_features(
+        finals = await orch.process_features(
             _SESSION,
             [asr_out, lip_out],
             [_audio_health()],
@@ -170,16 +168,16 @@ class TestSpeechPipelineIntegration:
         assert len(finals) == 1
         assert finals[0].status == SegmentStatus.FINAL
         assert finals[0].replaces_segment_id == partial_id
-        # Lip text takes precedence when both are present.
+        # Lip has higher confidence → lip text wins.
         assert finals[0].text == "merhaba dünya"
 
-    def test_low_confidence_asr_suppressed(self):
+    async def test_low_confidence_asr_suppressed(self):
         asr = _StubEngine(_result(ModalityType.ASR, "noise", 0.10))
-        asyncio.run(asr.load_model(_config("whisper-small-tr")))
-        asr_out = asyncio.run(asr.predict(features=None))
+        await asr.load_model(_config("whisper-small-tr"))
+        asr_out = await asr.predict(features=None)
 
         orch = _build_orchestrator()
-        segments = orch.process_features(
+        segments = await orch.process_features(
             _SESSION, [asr_out], [_audio_health()], ModalityPath.SPEECH,
         )
         assert segments == []
@@ -191,7 +189,7 @@ class TestSpeechPipelineIntegration:
 
 
 class TestSignPipelineIntegration:
-    def test_gloss_replaces_tsl_partial(self):
+    async def test_gloss_replaces_tsl_partial(self):
         tsl = _StubEngine(
             _result(ModalityType.TSL_RECOGNITION, "MERHABA DUNYA", 0.80),
         )
@@ -203,16 +201,16 @@ class TestSignPipelineIntegration:
                 inference_latency_ms=1500,
             ),
         )
-        asyncio.run(tsl.load_model(_config("tsl-gru-v1")))
-        asyncio.run(gloss.load_model(_config("gemma2-9b-lora")))
+        await tsl.load_model(_config("tsl-gru-v1"))
+        await gloss.load_model(_config("gemma2-9b-lora"))
 
-        tsl_out = asyncio.run(tsl.predict(features=None))
-        gloss_out = asyncio.run(gloss.predict(features=None))
+        tsl_out = await tsl.predict(features=None)
+        gloss_out = await gloss.predict(features=None)
 
         orch = _build_orchestrator()
 
         # TSL alone → PARTIAL.
-        partials = orch.process_features(
+        partials = await orch.process_features(
             _SESSION, [tsl_out], [_video_health()], ModalityPath.SIGN,
         )
         assert len(partials) == 1
@@ -221,7 +219,7 @@ class TestSignPipelineIntegration:
         partial_id = partials[0].segment_id
 
         # GlossToText arrives → FINAL replaces PARTIAL, text fully replaced.
-        finals = orch.process_features(
+        finals = await orch.process_features(
             _SESSION,
             [tsl_out, gloss_out],
             [_video_health()],
@@ -239,15 +237,15 @@ class TestSignPipelineIntegration:
 
 
 class TestDegradedIntegration:
-    def test_no_face_detected_falls_back_to_audio(self):
+    async def test_no_face_detected_falls_back_to_audio(self):
         """Video pipeline reports no face → fusion must still emit audio."""
         asr = _StubEngine(_result(ModalityType.ASR, "merhaba", 0.80))
-        asyncio.run(asr.load_model(_config("whisper-small-tr")))
-        asr_out = asyncio.run(asr.predict(features=None))
+        await asr.load_model(_config("whisper-small-tr"))
+        asr_out = await asr.predict(features=None)
 
         orch = _build_orchestrator()
         # Audio healthy, video degraded (no face), only ASR result.
-        segments = orch.process_features(
+        segments = await orch.process_features(
             _SESSION,
             [asr_out],
             [_audio_health(), _video_health(face_detected=False)],
@@ -259,13 +257,13 @@ class TestDegradedIntegration:
         # Degraded handler applies confidence penalty (0.80 - 0.15 = 0.65).
         assert abs(seg.confidence - 0.65) < 0.001
 
-    def test_low_snr_penalises_asr(self):
+    async def test_low_snr_penalises_asr(self):
         asr = _StubEngine(_result(ModalityType.ASR, "fısıltı", 0.70))
-        asyncio.run(asr.load_model(_config("whisper-small-tr")))
-        asr_out = asyncio.run(asr.predict(features=None))
+        await asr.load_model(_config("whisper-small-tr"))
+        asr_out = await asr.predict(features=None)
 
         orch = _build_orchestrator()
-        segments = orch.process_features(
+        segments = await orch.process_features(
             _SESSION,
             [asr_out],
             [_audio_health(snr=2.0)],
@@ -282,35 +280,107 @@ class TestDegradedIntegration:
 
 
 class TestEngineLifecycleContract:
-    def test_predict_before_load_raises(self):
+    async def test_predict_before_load_raises(self):
         from sozia.common.interfaces import ModelNotLoadedError
 
         engine = _StubEngine(_result(ModalityType.ASR, "x"))
         with pytest.raises(ModelNotLoadedError):
-            asyncio.run(engine.predict(features=None))
+            await engine.predict(features=None)
 
-    def test_unload_resets_state(self):
+    async def test_unload_resets_state(self):
         engine = _StubEngine(_result(ModalityType.ASR, "x"))
-        asyncio.run(engine.load_model(_config("m")))
+        await engine.load_model(_config("m"))
         assert engine.is_loaded() is True
         assert engine.get_model_id() == "m"
 
-        asyncio.run(engine.unload_model())
+        await engine.unload_model()
         assert engine.is_loaded() is False
         assert engine.get_model_id() == ""
 
-    def test_custom_policy_threshold_is_honoured(self):
+    async def test_custom_policy_threshold_is_honoured(self):
         """Refactored policies expose constants — verify override flows end-to-end."""
         strict = SpeechFusionPolicy(confidence_threshold=0.90)
         orch = FusionOrchestrator()
         orch.register_policy(ModalityPath.SPEECH, strict)
 
         engine = _StubEngine(_result(ModalityType.ASR, "merhaba", 0.85))
-        asyncio.run(engine.load_model(_config("whisper-small-tr")))
-        out = asyncio.run(engine.predict(features=None))
+        await engine.load_model(_config("whisper-small-tr"))
+        out = await engine.predict(features=None)
 
-        segments = orch.process_features(
+        segments = await orch.process_features(
             _SESSION, [out], [_audio_health()], ModalityPath.SPEECH,
         )
         # 0.85 < 0.90 → suppressed.
         assert segments == []
+
+
+# ---------------------------------------------------------------------------
+# warm_up / cool_down lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestWarmUpCoolDown:
+    async def test_warm_up_loads_registered_engines(self):
+        asr = _StubEngine(_result(ModalityType.ASR, "x"))
+        lip = _StubEngine(_result(ModalityType.LIP_READING, "x"))
+        assert not asr.is_loaded()
+        assert not lip.is_loaded()
+
+        orch = _build_orchestrator()
+        orch.register_engine(
+            ModalityPath.SPEECH, asr, _config("whisper-small-tr"),
+        )
+        orch.register_engine(
+            ModalityPath.SPEECH, lip, _config("lip-reading-v1"),
+        )
+
+        await orch.warm_up(ModalityPath.SPEECH)
+        assert asr.is_loaded()
+        assert lip.is_loaded()
+
+    async def test_warm_up_is_idempotent(self):
+        engine = _StubEngine(_result(ModalityType.ASR, "x"))
+        orch = _build_orchestrator()
+        orch.register_engine(
+            ModalityPath.SPEECH, engine, _config("whisper-small-tr"),
+        )
+
+        await orch.warm_up(ModalityPath.SPEECH)
+        await orch.warm_up(ModalityPath.SPEECH)  # second call is a no-op
+        assert engine.is_loaded()
+
+    async def test_warm_up_only_touches_given_path(self):
+        asr = _StubEngine(_result(ModalityType.ASR, "x"))
+        tsl = _StubEngine(_result(ModalityType.TSL_RECOGNITION, "x"))
+
+        orch = _build_orchestrator()
+        orch.register_engine(ModalityPath.SPEECH, asr, _config("whisper"))
+        orch.register_engine(ModalityPath.SIGN, tsl, _config("tsl-gru"))
+
+        await orch.warm_up(ModalityPath.SPEECH)
+        assert asr.is_loaded()
+        assert not tsl.is_loaded()
+
+    async def test_warm_up_with_no_engines_is_noop(self):
+        orch = _build_orchestrator()
+        await orch.warm_up(ModalityPath.SPEECH)  # must not raise
+
+    async def test_cool_down_unloads_all_paths(self):
+        asr = _StubEngine(_result(ModalityType.ASR, "x"))
+        tsl = _StubEngine(_result(ModalityType.TSL_RECOGNITION, "x"))
+
+        orch = _build_orchestrator()
+        orch.register_engine(ModalityPath.SPEECH, asr, _config("whisper"))
+        orch.register_engine(ModalityPath.SIGN, tsl, _config("tsl-gru"))
+
+        await orch.warm_up(ModalityPath.SPEECH)
+        await orch.warm_up(ModalityPath.SIGN)
+        assert asr.is_loaded() and tsl.is_loaded()
+
+        await orch.cool_down()
+        assert not asr.is_loaded()
+        assert not tsl.is_loaded()
+
+    async def test_cool_down_without_warm_up_is_noop(self):
+        orch = _build_orchestrator()
+        await orch.cool_down()  # must not raise

--- a/tests/fusion/test_orchestrator.py
+++ b/tests/fusion/test_orchestrator.py
@@ -1,0 +1,239 @@
+"""Tests for FusionOrchestrator."""
+
+from __future__ import annotations
+
+import pytest
+
+from sozia.common.models import (
+    ModalityPath,
+    ModalityResult,
+    ModalityType,
+    PipelineHealth,
+    SegmentStatus,
+)
+from sozia.fusion.degraded_mode_handler import DegradedModeHandler
+from sozia.fusion.orchestrator import FusionOrchestrator
+from sozia.fusion.sign_fusion_policy import SignFusionPolicy
+from sozia.fusion.speech_fusion_policy import SpeechFusionPolicy
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_SESSION = "550e8400-e29b-41d4-a716-446655440000"
+
+
+def _asr(confidence: float = 0.85) -> ModalityResult:
+    return ModalityResult(
+        modality_type=ModalityType.ASR,
+        text="merhaba",
+        confidence=confidence,
+        timestamp_ms=1000,
+        duration_ms=500,
+        inference_latency_ms=200,
+    )
+
+
+def _lip(confidence: float = 0.70) -> ModalityResult:
+    return ModalityResult(
+        modality_type=ModalityType.LIP_READING,
+        text="merhaba dünya",
+        confidence=confidence,
+        timestamp_ms=1000,
+        duration_ms=800,
+        inference_latency_ms=600,
+    )
+
+
+def _tsl(confidence: float = 0.80) -> ModalityResult:
+    return ModalityResult(
+        modality_type=ModalityType.TSL_RECOGNITION,
+        text="MERHABA",
+        confidence=confidence,
+        timestamp_ms=1000,
+        duration_ms=600,
+        inference_latency_ms=400,
+    )
+
+
+def _gloss(confidence: float = 0.85) -> ModalityResult:
+    return ModalityResult(
+        modality_type=ModalityType.GLOSS_TO_TEXT,
+        text="Merhaba.",
+        confidence=confidence,
+        timestamp_ms=1000,
+        duration_ms=600,
+        inference_latency_ms=1500,
+    )
+
+
+def _audio_health(available: bool = True, snr: float = 25.0) -> PipelineHealth:
+    return PipelineHealth(
+        session_id=_SESSION,
+        pipeline="audio",
+        available=available,
+        fps=None,
+        snr=snr,
+        face_detected=None,
+        last_updated_ms=1000,
+    )
+
+
+def _video_health(
+    available: bool = True, face_detected: bool = True,
+) -> PipelineHealth:
+    return PipelineHealth(
+        session_id=_SESSION,
+        pipeline="video",
+        available=available,
+        fps=30.0,
+        snr=None,
+        face_detected=face_detected,
+        last_updated_ms=1000,
+    )
+
+
+def _make_orchestrator() -> FusionOrchestrator:
+    orch = FusionOrchestrator()
+    orch.register_policy(ModalityPath.SPEECH, SpeechFusionPolicy())
+    orch.register_policy(ModalityPath.SIGN, SignFusionPolicy())
+    return orch
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestRegistration:
+    def test_raises_on_unregistered_path(self):
+        orch = FusionOrchestrator()
+        with pytest.raises(ValueError, match="SPEECH"):
+            orch.process_features(
+                _SESSION, [_asr()], [_audio_health()], ModalityPath.SPEECH,
+            )
+
+    def test_register_policy_succeeds(self):
+        orch = FusionOrchestrator()
+        orch.register_policy(ModalityPath.SPEECH, SpeechFusionPolicy())
+        # Should not raise anymore.
+        segments = orch.process_features(
+            _SESSION, [_asr()], [_audio_health()], ModalityPath.SPEECH,
+        )
+        assert len(segments) == 1
+
+
+class TestSpeechPathRouting:
+    def test_asr_only_produces_partial(self):
+        orch = _make_orchestrator()
+        segments = orch.process_features(
+            _SESSION, [_asr()], [_audio_health()], ModalityPath.SPEECH,
+        )
+        assert len(segments) == 1
+        assert segments[0].status == SegmentStatus.PARTIAL
+        assert segments[0].source == ModalityType.ASR
+
+    def test_asr_plus_lip_produces_final(self):
+        orch = _make_orchestrator()
+        segments = orch.process_features(
+            _SESSION, [_asr(), _lip()], [_audio_health()], ModalityPath.SPEECH,
+        )
+        assert len(segments) == 1
+        assert segments[0].status == SegmentStatus.FINAL
+
+
+class TestSignPathRouting:
+    def test_tsl_only_produces_partial(self):
+        orch = _make_orchestrator()
+        segments = orch.process_features(
+            _SESSION, [_tsl()], [_video_health()], ModalityPath.SIGN,
+        )
+        assert len(segments) == 1
+        assert segments[0].status == SegmentStatus.PARTIAL
+        assert segments[0].text == "MERHABA"
+
+    def test_gloss_produces_final(self):
+        orch = _make_orchestrator()
+        segments = orch.process_features(
+            _SESSION, [_tsl(), _gloss()], [_video_health()], ModalityPath.SIGN,
+        )
+        assert len(segments) == 1
+        assert segments[0].status == SegmentStatus.FINAL
+        assert segments[0].text == "Merhaba."
+
+
+class TestDegradedMode:
+    def test_degraded_audio_single_result_uses_handler(self):
+        orch = _make_orchestrator()
+        segments = orch.process_features(
+            _SESSION,
+            [_asr(confidence=0.80)],
+            [_audio_health(available=False)],
+            ModalityPath.SPEECH,
+        )
+        assert len(segments) == 1
+        seg = segments[0]
+        assert seg.status == SegmentStatus.PARTIAL
+        # Confidence should be penalised (0.80 - 0.15 = 0.65)
+        assert abs(seg.confidence - 0.65) < 0.001
+
+    def test_degraded_video_single_result_uses_handler(self):
+        orch = _make_orchestrator()
+        segments = orch.process_features(
+            _SESSION,
+            [_tsl(confidence=0.80)],
+            [_video_health(face_detected=False)],
+            ModalityPath.SIGN,
+        )
+        assert len(segments) == 1
+        assert abs(segments[0].confidence - 0.65) < 0.001
+
+    def test_degraded_but_two_results_uses_normal_policy(self):
+        """With two results, degraded handler is skipped even if health is bad."""
+        orch = _make_orchestrator()
+        segments = orch.process_features(
+            _SESSION,
+            [_asr(), _lip()],
+            [_audio_health(available=False)],
+            ModalityPath.SPEECH,
+        )
+        assert len(segments) == 1
+        assert segments[0].status == SegmentStatus.FINAL
+
+    def test_degraded_low_confidence_returns_empty(self):
+        orch = _make_orchestrator()
+        segments = orch.process_features(
+            _SESSION,
+            [_asr(confidence=0.10)],
+            [_audio_health(available=False)],
+            ModalityPath.SPEECH,
+        )
+        assert segments == []
+
+    def test_healthy_single_result_uses_normal_policy(self):
+        """Healthy pipeline with one result → normal policy, not degraded."""
+        orch = _make_orchestrator()
+        segments = orch.process_features(
+            _SESSION, [_asr()], [_audio_health()], ModalityPath.SPEECH,
+        )
+        assert len(segments) == 1
+        # Normal confidence, no penalty
+        assert segments[0].confidence == 0.85
+
+
+class TestHandleTimeout:
+    def test_timeout_emits_partial_from_primary(self):
+        orch = _make_orchestrator()
+        segments = orch.handle_timeout(
+            _SESSION, _asr(), [_audio_health()], ModalityPath.SPEECH,
+        )
+        assert len(segments) == 1
+        assert segments[0].status == SegmentStatus.PARTIAL
+
+    def test_timeout_raises_on_unregistered_path(self):
+        orch = FusionOrchestrator()
+        with pytest.raises(ValueError, match="SIGN"):
+            orch.handle_timeout(
+                _SESSION, _tsl(), [_video_health()], ModalityPath.SIGN,
+            )

--- a/tests/fusion/test_orchestrator.py
+++ b/tests/fusion/test_orchestrator.py
@@ -11,11 +11,9 @@ from sozia.common.models import (
     PipelineHealth,
     SegmentStatus,
 )
-from sozia.fusion.degraded_mode_handler import DegradedModeHandler
 from sozia.fusion.orchestrator import FusionOrchestrator
 from sozia.fusion.sign_fusion_policy import SignFusionPolicy
 from sozia.fusion.speech_fusion_policy import SpeechFusionPolicy
-
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/fusion/test_orchestrator.py
+++ b/tests/fusion/test_orchestrator.py
@@ -105,36 +105,36 @@ def _make_orchestrator() -> FusionOrchestrator:
 
 
 class TestRegistration:
-    def test_raises_on_unregistered_path(self):
+    async def test_raises_on_unregistered_path(self):
         orch = FusionOrchestrator()
         with pytest.raises(ValueError, match="SPEECH"):
-            orch.process_features(
+            await orch.process_features(
                 _SESSION, [_asr()], [_audio_health()], ModalityPath.SPEECH,
             )
 
-    def test_register_policy_succeeds(self):
+    async def test_register_policy_succeeds(self):
         orch = FusionOrchestrator()
         orch.register_policy(ModalityPath.SPEECH, SpeechFusionPolicy())
         # Should not raise anymore.
-        segments = orch.process_features(
+        segments = await orch.process_features(
             _SESSION, [_asr()], [_audio_health()], ModalityPath.SPEECH,
         )
         assert len(segments) == 1
 
 
 class TestSpeechPathRouting:
-    def test_asr_only_produces_partial(self):
+    async def test_asr_only_produces_partial(self):
         orch = _make_orchestrator()
-        segments = orch.process_features(
+        segments = await orch.process_features(
             _SESSION, [_asr()], [_audio_health()], ModalityPath.SPEECH,
         )
         assert len(segments) == 1
         assert segments[0].status == SegmentStatus.PARTIAL
         assert segments[0].source == ModalityType.ASR
 
-    def test_asr_plus_lip_produces_final(self):
+    async def test_asr_plus_lip_produces_final(self):
         orch = _make_orchestrator()
-        segments = orch.process_features(
+        segments = await orch.process_features(
             _SESSION, [_asr(), _lip()], [_audio_health()], ModalityPath.SPEECH,
         )
         assert len(segments) == 1
@@ -142,18 +142,18 @@ class TestSpeechPathRouting:
 
 
 class TestSignPathRouting:
-    def test_tsl_only_produces_partial(self):
+    async def test_tsl_only_produces_partial(self):
         orch = _make_orchestrator()
-        segments = orch.process_features(
+        segments = await orch.process_features(
             _SESSION, [_tsl()], [_video_health()], ModalityPath.SIGN,
         )
         assert len(segments) == 1
         assert segments[0].status == SegmentStatus.PARTIAL
         assert segments[0].text == "MERHABA"
 
-    def test_gloss_produces_final(self):
+    async def test_gloss_produces_final(self):
         orch = _make_orchestrator()
-        segments = orch.process_features(
+        segments = await orch.process_features(
             _SESSION, [_tsl(), _gloss()], [_video_health()], ModalityPath.SIGN,
         )
         assert len(segments) == 1
@@ -162,9 +162,9 @@ class TestSignPathRouting:
 
 
 class TestDegradedMode:
-    def test_degraded_audio_single_result_uses_handler(self):
+    async def test_degraded_audio_single_result_uses_handler(self):
         orch = _make_orchestrator()
-        segments = orch.process_features(
+        segments = await orch.process_features(
             _SESSION,
             [_asr(confidence=0.80)],
             [_audio_health(available=False)],
@@ -176,9 +176,9 @@ class TestDegradedMode:
         # Confidence should be penalised (0.80 - 0.15 = 0.65)
         assert abs(seg.confidence - 0.65) < 0.001
 
-    def test_degraded_video_single_result_uses_handler(self):
+    async def test_degraded_video_single_result_uses_handler(self):
         orch = _make_orchestrator()
-        segments = orch.process_features(
+        segments = await orch.process_features(
             _SESSION,
             [_tsl(confidence=0.80)],
             [_video_health(face_detected=False)],
@@ -187,10 +187,10 @@ class TestDegradedMode:
         assert len(segments) == 1
         assert abs(segments[0].confidence - 0.65) < 0.001
 
-    def test_degraded_but_two_results_uses_normal_policy(self):
+    async def test_degraded_but_two_results_uses_normal_policy(self):
         """With two results, degraded handler is skipped even if health is bad."""
         orch = _make_orchestrator()
-        segments = orch.process_features(
+        segments = await orch.process_features(
             _SESSION,
             [_asr(), _lip()],
             [_audio_health(available=False)],
@@ -199,9 +199,9 @@ class TestDegradedMode:
         assert len(segments) == 1
         assert segments[0].status == SegmentStatus.FINAL
 
-    def test_degraded_low_confidence_returns_empty(self):
+    async def test_degraded_low_confidence_returns_empty(self):
         orch = _make_orchestrator()
-        segments = orch.process_features(
+        segments = await orch.process_features(
             _SESSION,
             [_asr(confidence=0.10)],
             [_audio_health(available=False)],
@@ -209,10 +209,10 @@ class TestDegradedMode:
         )
         assert segments == []
 
-    def test_healthy_single_result_uses_normal_policy(self):
+    async def test_healthy_single_result_uses_normal_policy(self):
         """Healthy pipeline with one result → normal policy, not degraded."""
         orch = _make_orchestrator()
-        segments = orch.process_features(
+        segments = await orch.process_features(
             _SESSION, [_asr()], [_audio_health()], ModalityPath.SPEECH,
         )
         assert len(segments) == 1
@@ -221,17 +221,17 @@ class TestDegradedMode:
 
 
 class TestHandleTimeout:
-    def test_timeout_emits_partial_from_primary(self):
+    async def test_timeout_emits_partial_from_primary(self):
         orch = _make_orchestrator()
-        segments = orch.handle_timeout(
+        segments = await orch.handle_timeout(
             _SESSION, _asr(), [_audio_health()], ModalityPath.SPEECH,
         )
         assert len(segments) == 1
         assert segments[0].status == SegmentStatus.PARTIAL
 
-    def test_timeout_raises_on_unregistered_path(self):
+    async def test_timeout_raises_on_unregistered_path(self):
         orch = FusionOrchestrator()
         with pytest.raises(ValueError, match="SIGN"):
-            orch.handle_timeout(
+            await orch.handle_timeout(
                 _SESSION, _tsl(), [_video_health()], ModalityPath.SIGN,
             )

--- a/tests/fusion/test_sign_fusion_policy.py
+++ b/tests/fusion/test_sign_fusion_policy.py
@@ -185,3 +185,17 @@ class TestFuseSuppressedModality:
             inference_latency_ms=200,
         )
         assert policy.fuse([asr_like], _health()) == []
+
+
+class TestSegmentIdFormat:
+    def test_segment_id_is_dashed_uuid_v4(self):
+        """segment_id must be a canonical UUID v4 string (with dashes)."""
+        import uuid as _uuid
+
+        policy = SignFusionPolicy()
+        segments = policy.fuse([_tsl()], _health())
+        assert len(segments) == 1
+
+        seg_id = segments[0].segment_id
+        assert "-" in seg_id
+        assert _uuid.UUID(seg_id).version == 4

--- a/tests/fusion/test_sign_fusion_policy.py
+++ b/tests/fusion/test_sign_fusion_policy.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import pytest
-
 from sozia.common.models import (
     ModalityResult,
     ModalityType,
@@ -11,7 +9,6 @@ from sozia.common.models import (
     SegmentStatus,
 )
 from sozia.fusion.sign_fusion_policy import SignFusionPolicy
-
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/fusion/test_sign_fusion_policy.py
+++ b/tests/fusion/test_sign_fusion_policy.py
@@ -1,0 +1,177 @@
+"""Tests for SignFusionPolicy."""
+
+from __future__ import annotations
+
+import pytest
+
+from sozia.common.models import (
+    ModalityResult,
+    ModalityType,
+    PipelineHealth,
+    SegmentStatus,
+)
+from sozia.fusion.sign_fusion_policy import SignFusionPolicy
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_SESSION = "550e8400-e29b-41d4-a716-446655440000"
+
+
+def _tsl(text: str = "MERHABA DUNYA", confidence: float = 0.80) -> ModalityResult:
+    return ModalityResult(
+        modality_type=ModalityType.TSL_RECOGNITION,
+        text=text,
+        confidence=confidence,
+        timestamp_ms=1000,
+        duration_ms=600,
+        inference_latency_ms=400,
+    )
+
+
+def _gloss(text: str = "Merhaba dünya.", confidence: float = 0.85) -> ModalityResult:
+    return ModalityResult(
+        modality_type=ModalityType.GLOSS_TO_TEXT,
+        text=text,
+        confidence=confidence,
+        timestamp_ms=1000,
+        duration_ms=600,
+        inference_latency_ms=1500,
+    )
+
+
+def _health() -> list[PipelineHealth]:
+    return [PipelineHealth(
+        session_id=_SESSION,
+        pipeline="video",
+        available=True,
+        fps=30.0,
+        snr=None,
+        face_detected=True,
+        last_updated_ms=1000,
+    )]
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestShouldSuppress:
+    def test_below_threshold_suppressed(self):
+        policy = SignFusionPolicy()
+        assert policy.should_suppress(_tsl(confidence=0.20)) is True
+
+    def test_above_threshold_not_suppressed(self):
+        policy = SignFusionPolicy()
+        assert policy.should_suppress(_tsl(confidence=0.50)) is False
+
+    def test_confidence_threshold_value(self):
+        policy = SignFusionPolicy()
+        assert policy.get_confidence_threshold() == 0.30
+
+
+class TestFuseEmpty:
+    def test_empty_results_returns_empty(self):
+        policy = SignFusionPolicy()
+        assert policy.fuse([], _health()) == []
+
+    def test_all_suppressed_returns_empty(self):
+        policy = SignFusionPolicy()
+        assert policy.fuse([_tsl(confidence=0.10)], _health()) == []
+
+
+class TestFuseTslOnly:
+    def test_tsl_only_emits_partial_with_raw_gloss(self):
+        policy = SignFusionPolicy()
+        segments = policy.fuse([_tsl()], _health())
+
+        assert len(segments) == 1
+        seg = segments[0]
+        assert seg.status == SegmentStatus.PARTIAL
+        assert seg.source == ModalityType.TSL_RECOGNITION
+        assert seg.text == "MERHABA DUNYA"
+        assert seg.session_id == _SESSION
+        assert seg.replaces_segment_id is None
+
+    def test_tsl_confidence_passed_through(self):
+        policy = SignFusionPolicy()
+        segments = policy.fuse([_tsl(confidence=0.75)], _health())
+        assert segments[0].confidence == 0.75
+
+
+class TestFuseGlossToText:
+    def test_gloss_emits_final(self):
+        policy = SignFusionPolicy()
+        segments = policy.fuse([_gloss()], _health())
+
+        assert len(segments) == 1
+        seg = segments[0]
+        assert seg.status == SegmentStatus.FINAL
+        assert seg.source == ModalityType.GLOSS_TO_TEXT
+        assert seg.text == "Merhaba dünya."
+
+    def test_gloss_confidence_used_directly(self):
+        """No weighted merge — GlossToText confidence is used as-is."""
+        policy = SignFusionPolicy()
+        segments = policy.fuse([_gloss(confidence=0.90)], _health())
+        assert segments[0].confidence == 0.90
+
+    def test_both_present_gloss_wins(self):
+        """When both TSL and GlossToText are valid, FINAL with GlossToText."""
+        policy = SignFusionPolicy()
+        segments = policy.fuse([_tsl(), _gloss()], _health())
+
+        assert len(segments) == 1
+        assert segments[0].status == SegmentStatus.FINAL
+        assert segments[0].text == "Merhaba dünya."
+
+
+class TestFuseReplacesSegmentId:
+    def test_partial_then_final_links_via_replaces(self):
+        policy = SignFusionPolicy()
+
+        # Step 1: TSL only → PARTIAL
+        partials = policy.fuse([_tsl()], _health())
+        partial_id = partials[0].segment_id
+
+        # Step 2: GlossToText → FINAL should reference the PARTIAL
+        finals = policy.fuse([_gloss()], _health())
+        assert finals[0].replaces_segment_id == partial_id
+
+    def test_final_without_prior_partial_has_no_replaces(self):
+        policy = SignFusionPolicy()
+        segments = policy.fuse([_gloss()], _health())
+        assert segments[0].replaces_segment_id is None
+
+    def test_replaces_consumed_only_once(self):
+        policy = SignFusionPolicy()
+
+        policy.fuse([_tsl()], _health())
+        policy.fuse([_gloss()], _health())
+
+        # Second FINAL should have no replaces
+        segments = policy.fuse([_gloss()], _health())
+        assert segments[0].replaces_segment_id is None
+
+
+class TestFuseSuppressedModality:
+    def test_low_confidence_gloss_ignored_tsl_emits_partial(self):
+        policy = SignFusionPolicy()
+        segments = policy.fuse(
+            [_tsl(confidence=0.80), _gloss(confidence=0.10)], _health(),
+        )
+        assert len(segments) == 1
+        assert segments[0].status == SegmentStatus.PARTIAL
+        assert segments[0].source == ModalityType.TSL_RECOGNITION
+
+    def test_low_confidence_tsl_with_valid_gloss_emits_final(self):
+        policy = SignFusionPolicy()
+        segments = policy.fuse(
+            [_tsl(confidence=0.10), _gloss(confidence=0.85)], _health(),
+        )
+        assert len(segments) == 1
+        assert segments[0].status == SegmentStatus.FINAL
+        assert segments[0].source == ModalityType.GLOSS_TO_TEXT

--- a/tests/fusion/test_sign_fusion_policy.py
+++ b/tests/fusion/test_sign_fusion_policy.py
@@ -172,3 +172,16 @@ class TestFuseSuppressedModality:
         assert len(segments) == 1
         assert segments[0].status == SegmentStatus.FINAL
         assert segments[0].source == ModalityType.GLOSS_TO_TEXT
+
+    def test_unrelated_modality_returns_empty(self):
+        """Sign policy must ignore non-sign modalities (ASR/LipReading)."""
+        policy = SignFusionPolicy()
+        asr_like = ModalityResult(
+            modality_type=ModalityType.ASR,
+            text="merhaba",
+            confidence=0.80,
+            timestamp_ms=1000,
+            duration_ms=500,
+            inference_latency_ms=200,
+        )
+        assert policy.fuse([asr_like], _health()) == []

--- a/tests/fusion/test_speech_fusion_policy.py
+++ b/tests/fusion/test_speech_fusion_policy.py
@@ -1,0 +1,205 @@
+"""Tests for SpeechFusionPolicy."""
+
+from __future__ import annotations
+
+import pytest
+
+from sozia.common.models import (
+    ModalityResult,
+    ModalityType,
+    PipelineHealth,
+    SegmentStatus,
+)
+from sozia.fusion.speech_fusion_policy import SpeechFusionPolicy
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_SESSION = "550e8400-e29b-41d4-a716-446655440000"
+
+
+def _asr(text: str = "merhaba", confidence: float = 0.85) -> ModalityResult:
+    return ModalityResult(
+        modality_type=ModalityType.ASR,
+        text=text,
+        confidence=confidence,
+        timestamp_ms=1000,
+        duration_ms=500,
+        inference_latency_ms=200,
+    )
+
+
+def _lip(text: str = "merhaba dünya", confidence: float = 0.70) -> ModalityResult:
+    return ModalityResult(
+        modality_type=ModalityType.LIP_READING,
+        text=text,
+        confidence=confidence,
+        timestamp_ms=1000,
+        duration_ms=800,
+        inference_latency_ms=600,
+    )
+
+
+def _health() -> list[PipelineHealth]:
+    return [PipelineHealth(
+        session_id=_SESSION,
+        pipeline="audio",
+        available=True,
+        fps=None,
+        snr=25.0,
+        face_detected=None,
+        last_updated_ms=1000,
+    )]
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestShouldSuppress:
+    def test_below_threshold_suppressed(self):
+        policy = SpeechFusionPolicy()
+        assert policy.should_suppress(_asr(confidence=0.20)) is True
+
+    def test_above_threshold_not_suppressed(self):
+        policy = SpeechFusionPolicy()
+        assert policy.should_suppress(_asr(confidence=0.50)) is False
+
+    def test_exact_threshold_not_suppressed(self):
+        policy = SpeechFusionPolicy()
+        assert policy.should_suppress(_asr(confidence=0.30)) is False
+
+    def test_confidence_threshold_value(self):
+        policy = SpeechFusionPolicy()
+        assert policy.get_confidence_threshold() == 0.30
+
+
+class TestFuseEmpty:
+    def test_empty_results_returns_empty(self):
+        policy = SpeechFusionPolicy()
+        assert policy.fuse([], _health()) == []
+
+    def test_all_suppressed_returns_empty(self):
+        policy = SpeechFusionPolicy()
+        result = policy.fuse([_asr(confidence=0.10)], _health())
+        assert result == []
+
+
+class TestFuseAsrOnly:
+    def test_asr_only_emits_partial(self):
+        policy = SpeechFusionPolicy()
+        segments = policy.fuse([_asr()], _health())
+
+        assert len(segments) == 1
+        seg = segments[0]
+        assert seg.status == SegmentStatus.PARTIAL
+        assert seg.source == ModalityType.ASR
+        assert seg.text == "merhaba"
+        assert seg.session_id == _SESSION
+        assert seg.replaces_segment_id is None
+
+    def test_asr_only_confidence_passed_through(self):
+        policy = SpeechFusionPolicy()
+        segments = policy.fuse([_asr(confidence=0.90)], _health())
+        assert segments[0].confidence == 0.90
+
+
+class TestFuseLipOnly:
+    def test_lip_only_emits_partial(self):
+        policy = SpeechFusionPolicy()
+        segments = policy.fuse([_lip()], _health())
+
+        assert len(segments) == 1
+        seg = segments[0]
+        assert seg.status == SegmentStatus.PARTIAL
+        assert seg.source == ModalityType.LIP_READING
+        assert seg.text == "merhaba dünya"
+
+
+class TestFuseBothModalities:
+    def test_both_emits_final(self):
+        policy = SpeechFusionPolicy()
+        segments = policy.fuse([_asr(), _lip()], _health())
+
+        assert len(segments) == 1
+        seg = segments[0]
+        assert seg.status == SegmentStatus.FINAL
+        assert seg.source == ModalityType.LIP_READING
+
+    def test_weighted_confidence(self):
+        policy = SpeechFusionPolicy()
+        segments = policy.fuse(
+            [_asr(confidence=0.90), _lip(confidence=0.80)], _health(),
+        )
+        # 0.65 * 0.90 + 0.35 * 0.80 = 0.585 + 0.28 = 0.865
+        assert abs(segments[0].confidence - 0.865) < 0.001
+
+    def test_lip_text_preferred_when_available(self):
+        policy = SpeechFusionPolicy()
+        segments = policy.fuse(
+            [_asr(text="merhaba"), _lip(text="merhaba dünya")], _health(),
+        )
+        assert segments[0].text == "merhaba dünya"
+
+    def test_asr_text_fallback_when_lip_empty(self):
+        policy = SpeechFusionPolicy()
+        segments = policy.fuse(
+            [_asr(text="merhaba"), _lip(text="")], _health(),
+        )
+        assert segments[0].text == "merhaba"
+
+    def test_duration_takes_max(self):
+        policy = SpeechFusionPolicy()
+        segments = policy.fuse([_asr(), _lip()], _health())
+        assert segments[0].duration_ms == 800
+
+
+class TestFuseReplacesSegmentId:
+    def test_partial_then_final_links_via_replaces(self):
+        policy = SpeechFusionPolicy()
+
+        # Step 1: ASR only → PARTIAL
+        partials = policy.fuse([_asr()], _health())
+        partial_id = partials[0].segment_id
+
+        # Step 2: ASR + lip → FINAL should reference the PARTIAL
+        finals = policy.fuse([_asr(), _lip()], _health())
+        assert finals[0].replaces_segment_id == partial_id
+
+    def test_final_without_prior_partial_has_no_replaces(self):
+        policy = SpeechFusionPolicy()
+        segments = policy.fuse([_asr(), _lip()], _health())
+        assert segments[0].replaces_segment_id is None
+
+    def test_replaces_consumed_only_once(self):
+        policy = SpeechFusionPolicy()
+
+        policy.fuse([_asr()], _health())
+        policy.fuse([_asr(), _lip()], _health())
+
+        # Second FINAL should not have a replaces_segment_id
+        segments = policy.fuse([_asr(), _lip()], _health())
+        assert segments[0].replaces_segment_id is None
+
+
+class TestFuseSuppressedModality:
+    def test_low_confidence_lip_ignored_asr_emits_partial(self):
+        policy = SpeechFusionPolicy()
+        segments = policy.fuse(
+            [_asr(confidence=0.80), _lip(confidence=0.10)], _health(),
+        )
+        assert len(segments) == 1
+        assert segments[0].status == SegmentStatus.PARTIAL
+        assert segments[0].source == ModalityType.ASR
+
+    def test_low_confidence_asr_ignored_lip_emits_partial(self):
+        policy = SpeechFusionPolicy()
+        segments = policy.fuse(
+            [_asr(confidence=0.10), _lip(confidence=0.80)], _health(),
+        )
+        assert len(segments) == 1
+        assert segments[0].status == SegmentStatus.PARTIAL
+        assert segments[0].source == ModalityType.LIP_READING

--- a/tests/fusion/test_speech_fusion_policy.py
+++ b/tests/fusion/test_speech_fusion_policy.py
@@ -219,3 +219,19 @@ class TestFuseSuppressedModality:
         assert len(segments) == 1
         assert segments[0].status == SegmentStatus.PARTIAL
         assert segments[0].source == ModalityType.LIP_READING
+
+
+class TestSegmentIdFormat:
+    def test_segment_id_is_dashed_uuid_v4(self):
+        """segment_id must be a canonical UUID v4 string (with dashes)."""
+        import uuid as _uuid
+
+        policy = SpeechFusionPolicy()
+        segments = policy.fuse([_asr()], _health())
+        assert len(segments) == 1
+
+        seg_id = segments[0].segment_id
+        assert "-" in seg_id, "segment_id must keep UUID dashes"
+        # Parsing as UUID confirms canonical format.
+        parsed = _uuid.UUID(seg_id)
+        assert parsed.version == 4

--- a/tests/fusion/test_speech_fusion_policy.py
+++ b/tests/fusion/test_speech_fusion_policy.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import pytest
-
 from sozia.common.models import (
     ModalityResult,
     ModalityType,
@@ -11,7 +9,6 @@ from sozia.common.models import (
     SegmentStatus,
 )
 from sozia.fusion.speech_fusion_policy import SpeechFusionPolicy
-
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/fusion/test_speech_fusion_policy.py
+++ b/tests/fusion/test_speech_fusion_policy.py
@@ -119,12 +119,13 @@ class TestFuseLipOnly:
 class TestFuseBothModalities:
     def test_both_emits_final(self):
         policy = SpeechFusionPolicy()
-        segments = policy.fuse([_asr(), _lip()], _health())
+        segments = policy.fuse(
+            [_asr(confidence=0.70), _lip(confidence=0.85)], _health(),
+        )
 
         assert len(segments) == 1
         seg = segments[0]
         assert seg.status == SegmentStatus.FINAL
-        assert seg.source == ModalityType.LIP_READING
 
     def test_weighted_confidence(self):
         policy = SpeechFusionPolicy()
@@ -134,12 +135,29 @@ class TestFuseBothModalities:
         # 0.65 * 0.90 + 0.35 * 0.80 = 0.585 + 0.28 = 0.865
         assert abs(segments[0].confidence - 0.865) < 0.001
 
-    def test_lip_text_preferred_when_available(self):
+    def test_higher_confidence_lip_text_wins(self):
         policy = SpeechFusionPolicy()
         segments = policy.fuse(
-            [_asr(text="merhaba"), _lip(text="merhaba dünya")], _health(),
+            [
+                _asr(text="merhaba", confidence=0.70),
+                _lip(text="merhaba dünya", confidence=0.85),
+            ],
+            _health(),
         )
         assert segments[0].text == "merhaba dünya"
+        assert segments[0].source == ModalityType.LIP_READING
+
+    def test_higher_confidence_asr_text_wins(self):
+        policy = SpeechFusionPolicy()
+        segments = policy.fuse(
+            [
+                _asr(text="merhaba", confidence=0.90),
+                _lip(text="merhaba dünya", confidence=0.60),
+            ],
+            _health(),
+        )
+        assert segments[0].text == "merhaba"
+        assert segments[0].source == ModalityType.ASR
 
     def test_asr_text_fallback_when_lip_empty(self):
         policy = SpeechFusionPolicy()
@@ -147,6 +165,7 @@ class TestFuseBothModalities:
             [_asr(text="merhaba"), _lip(text="")], _health(),
         )
         assert segments[0].text == "merhaba"
+        assert segments[0].source == ModalityType.ASR
 
     def test_duration_takes_max(self):
         policy = SpeechFusionPolicy()


### PR DESCRIPTION
## What does this PR do?

Wires up the fusion layer that sits between the inference engines and the session handler. Implements both modality paths end-to-end:

- **SpeechFusionPolicy** — ASR primary, Lip-Reading secondary, weighted confidence merge on FINAL (ASR 0.65 / Lip 0.35).
- **SignFusionPolicy** — TSL emits raw gloss PARTIAL, GlossToText replaces it with natural Turkish on FINAL.
- **DegradedModeHandler** — single-modality fallback with a confidence penalty (0.15) when a pipeline reports unavailable / no face / low SNR (<5 dB).
- **FusionOrchestrator** — routes results to the right policy, delegates to the degraded handler when appropriate, and exposes `handle_timeout` for the slower-modality case.

Policy constants (weights, thresholds, penalty) are exposed as constructor kwargs so they can be tuned or overridden in tests without touching module-level globals.

Also includes an integration suite that wires mock `InferenceEngine` instances through the orchestrator to validate the contract between the inference and fusion layers without loading real ML models.

## Which package(s) does it touch?

- `sozia.fusion` (new implementations)
- `tests/fusion` (unit + integration tests)

No changes to `sozia.common`, `sozia.inference`, or `sozia.registry`.

## How to test

\`\`\`bash
python -m pytest tests/fusion/ -q
\`\`\`

71 fusion tests, `sozia.fusion` package at 100% line coverage. Full repo suite: 233 passed.

## Checklist
- [x] Follows commit convention (\`<type>(<scope>): <description>\`)
- [x] Added/updated tests (71 fusion tests, 100% fusion coverage)
- [x] No sozia.common schema changes
- [x] Tested locally

Closes #10
Closes #11
Closes #12
Closes #13