### PR TITLE
feat(common): add SessionStatusMessage and ErrorMessage wire types

### DIFF
--- a/sozia/common/__init__.py
+++ b/sozia/common/__init__.py
@@ -17,6 +17,7 @@ from sozia.common.models import (
     HAND_LANDMARK_COUNT,
     POSE_LANDMARK_COUNT,
     AudioFeatureChunk,
+    ErrorMessage,
     LandmarkFrame,
     ModalityPath,
     ModalityResult,
@@ -25,6 +26,7 @@ from sozia.common.models import (
     PipelineHealth,
     SegmentStatus,
     SessionState,
+    SessionStatusMessage,
     TranscriptSegment,
 )
 
@@ -41,6 +43,8 @@ __all__ = [
     "LandmarkFrame",
     "AudioFeatureChunk",
     "TranscriptSegment",
+    "SessionStatusMessage",
+    "ErrorMessage",
     # Constants
     "FACE_LANDMARK_COUNT",
     "HAND_LANDMARK_COUNT",

--- a/sozia/common/models.py
+++ b/sozia/common/models.py
@@ -376,6 +376,73 @@ class AudioFeatureChunk:
             )
 
 
+_VALID_ERROR_CODES = frozenset({4001, 4002, 4003, 4004})
+
+
+@dataclass(frozen=True)
+class SessionStatusMessage:
+    """Outbound server→client session lifecycle notification.
+
+    Sent by the gateway during connection setup and whenever the session
+    state changes (e.g. INITIALIZING while models are loading, DEGRADED
+    when a pipeline becomes unavailable). Always precedes or accompanies
+    a TranscriptSegment stream — never replaces it.
+
+    Wire format: JSON with ``type`` field set to ``"session_status"``.
+
+    Serialisation note: ``state`` must be serialised as its string value
+    (e.g. ``"INITIALIZING"``), not as the enum object.
+
+    Args:
+        session_id: UUID v4 of the active session.
+        state: Current lifecycle state of the session.
+        message: Human-readable detail for the client UI (e.g.
+            "Loading speech models…"). May be empty.
+    """
+
+    session_id: str
+    state: SessionState
+    message: str
+
+    def __post_init__(self) -> None:
+        _validate_non_empty_str(self.session_id, "session_id")
+
+
+@dataclass(frozen=True)
+class ErrorMessage:
+    """Outbound server→client error notification.
+
+    Sent immediately before the server closes the WebSocket connection.
+    The client should surface ``message`` to the user and treat the
+    connection as terminated.
+
+    Wire format: JSON with ``type`` field set to ``"error"``.
+
+    Close code semantics:
+        4001 — authentication failure (bad or missing api_key)
+        4002 — malformed session_init payload
+        4003 — duplicate session_id (session already active)
+        4004 — model warm-up failed (server-side error)
+
+    Args:
+        session_id: UUID v4 of the session, or empty string if the
+            connection failed before a session_id was established.
+        code: WebSocket application close code in {4001, 4002, 4003, 4004}.
+        message: Human-readable error description.
+    """
+
+    session_id: str
+    code: int
+    message: str
+
+    def __post_init__(self) -> None:
+        if self.code not in _VALID_ERROR_CODES:
+            raise ValueError(
+                f"code must be one of {sorted(_VALID_ERROR_CODES)}, got {self.code}"
+            )
+        _validate_non_empty_str(self.message, "message")
+
+
 @dataclass(frozen=True)
 class TranscriptSegment:
     """The primary output of the Sozia system.

--- a/tests/common/test_models.py
+++ b/tests/common/test_models.py
@@ -9,6 +9,7 @@ import pytest
 
 from sozia.common.models import (
     AudioFeatureChunk,
+    ErrorMessage,
     LandmarkFrame,
     ModalityPath,
     ModalityResult,
@@ -17,6 +18,7 @@ from sozia.common.models import (
     PipelineHealth,
     SegmentStatus,
     SessionState,
+    SessionStatusMessage,
     TranscriptSegment,
 )
 
@@ -481,3 +483,123 @@ class TestTranscriptSegment:
     def test_empty_text_allowed(self):
         s = self._make(text="")
         assert s.text == ""
+
+
+# ===========================================================================
+# SessionStatusMessage
+# ===========================================================================
+
+
+class TestSessionStatusMessage:
+    def _make(self, **kwargs):
+        defaults = dict(
+            session_id="550e8400-e29b-41d4-a716-446655440000",
+            state=SessionState.INITIALIZING,
+            message="Loading speech models...",
+        )
+        defaults.update(kwargs)
+        return SessionStatusMessage(**defaults)
+
+    def test_happy_path(self):
+        msg = self._make()
+        assert msg.session_id == "550e8400-e29b-41d4-a716-446655440000"
+        assert msg.state == SessionState.INITIALIZING
+        assert msg.message == "Loading speech models..."
+
+    def test_all_session_states_accepted(self):
+        for state in SessionState:
+            msg = self._make(state=state)
+            assert msg.state == state
+
+    def test_empty_message_allowed(self):
+        msg = self._make(message="")
+        assert msg.message == ""
+
+    def test_frozen(self):
+        msg = self._make()
+        with pytest.raises(Exception):
+            msg.state = SessionState.RUNNING  # type: ignore[misc]
+
+    def test_empty_session_id_raises(self):
+        with pytest.raises(ValueError):
+            self._make(session_id="")
+
+    def test_running_state(self):
+        msg = self._make(state=SessionState.RUNNING, message="Session active.")
+        assert msg.state == SessionState.RUNNING
+
+    def test_degraded_state(self):
+        msg = self._make(
+            state=SessionState.DEGRADED,
+            message="Camera obstructed — visual recognition paused.",
+        )
+        assert msg.state == SessionState.DEGRADED
+
+    def test_error_state(self):
+        msg = self._make(state=SessionState.ERROR, message="Inference engine failed.")
+        assert msg.state == SessionState.ERROR
+
+
+# ===========================================================================
+# ErrorMessage
+# ===========================================================================
+
+
+class TestErrorMessage:
+    def _make(self, **kwargs):
+        defaults = dict(
+            session_id="550e8400-e29b-41d4-a716-446655440000",
+            code=4001,
+            message="Authentication failed.",
+        )
+        defaults.update(kwargs)
+        return ErrorMessage(**defaults)
+
+    def test_happy_path(self):
+        err = self._make()
+        assert err.code == 4001
+        assert err.message == "Authentication failed."
+
+    def test_all_valid_codes_accepted(self):
+        for code in (4001, 4002, 4003, 4004):
+            err = self._make(code=code)
+            assert err.code == code
+
+    def test_frozen(self):
+        err = self._make()
+        with pytest.raises(Exception):
+            err.code = 4002  # type: ignore[misc]
+
+    def test_invalid_code_raises(self):
+        with pytest.raises(ValueError):
+            self._make(code=4000)
+
+    def test_code_above_range_raises(self):
+        with pytest.raises(ValueError):
+            self._make(code=4005)
+
+    def test_standard_ws_code_raises(self):
+        with pytest.raises(ValueError):
+            self._make(code=1000)
+
+    def test_empty_message_raises(self):
+        with pytest.raises(ValueError):
+            self._make(message="")
+
+    def test_empty_session_id_allowed(self):
+        # session_id may be empty when the connection failed before
+        # a session_id was established (e.g. auth failure on first connect)
+        err = self._make(session_id="", code=4001)
+        assert err.session_id == ""
+
+    def test_code_4002_bad_init(self):
+        err = self._make(code=4002, message="Missing modality_path in session_init.")
+        assert err.code == 4002
+
+    def test_code_4003_duplicate_session(self):
+        err = self._make(code=4003, message="Session ID already active.")
+        assert err.code == 4003
+
+    def test_code_4004_warmup_failed(self):
+        err = self._make(code=4004, message="Model warm-up failed.")
+        assert err.code == 4004


### PR DESCRIPTION
## What does this PR do?

Adds two frozen dataclasses to `sozia/common/models.py` so the gateway has typed wire payloads for session lifecycle and error messages. Without these, the gateway would have to send ad-hoc JSON dicts — a direct R8 violation.

- `SessionStatusMessage(session_id, state: SessionState, message)` — sent during warm-up, state transitions, degraded mode
- `ErrorMessage(session_id, code, message)` — sent before closing the connection; code must be in `{4001, 4002, 4003, 4004}`

## Which package(s) does it touch?

`sozia/common/` only.

## How to test

```
pytest tests/common/ -v
```

All 111 pass, 100% coverage on `models.py`.

## Checklist
- [x] Follows commit convention (`<type>(<scope>): <description>`)
- [x] Added/updated tests (if applicable)
- [x] No sozia.common schema changes (or: both repos updated)
- [x] Tested locally

Closes #15