### PR TITLE
feat(fusion): frame accumulator and orchestrator process() entry point

### DIFF
--- a/sozia/fusion/__init__.py
+++ b/sozia/fusion/__init__.py
@@ -1,6 +1,7 @@
 """sozia.fusion — fusion layer for the Sozia server."""
 
 from sozia.fusion.degraded_mode_handler import DegradedModeHandler, DegradedStatus
+from sozia.fusion.frame_accumulator import FEATURE_DIM, FrameAccumulator
 from sozia.fusion.orchestrator import FusionOrchestrator
 from sozia.fusion.sign_fusion_policy import SignFusionPolicy
 from sozia.fusion.speech_fusion_policy import SpeechFusionPolicy
@@ -8,6 +9,8 @@ from sozia.fusion.speech_fusion_policy import SpeechFusionPolicy
 __all__ = [
     "DegradedModeHandler",
     "DegradedStatus",
+    "FEATURE_DIM",
+    "FrameAccumulator",
     "FusionOrchestrator",
     "SignFusionPolicy",
     "SpeechFusionPolicy",

--- a/sozia/fusion/frame_accumulator.py
+++ b/sozia/fusion/frame_accumulator.py
@@ -1,0 +1,133 @@
+"""FrameAccumulator — per-session landmark frame buffer for the sign pipeline.
+
+TslRecognitionEngine.predict() expects a (T, feature_dim) numpy array — a
+multi-frame sequence. The WebSocket gateway delivers one LandmarkFrame per
+message. FrameAccumulator buffers frames per session and emits a numpy batch
+when the window threshold is reached (R7: buffering and inference triggering
+stay inside sozia.server.fusion, not the gateway).
+
+Feature vector layout per frame (concatenated; zero-filled if absent):
+    pose:       33 × 3 =  99 dims
+    face:       83 × 3 = 249 dims
+    left_hand:  21 × 3 =  63 dims
+    right_hand: 21 × 3 =  63 dims
+    ────────────────────────────
+    total:               474 dims
+
+Note: the sozia-research training pipeline uses 507 dims because pose carries
+a 4th visibility float. The wire format (LandmarkFrame) only stores [x, y, z],
+so the server-side feature vector is 474 dims. Trained models must be
+configured with feature_dim=474. (Deviation DEV-05 in lld-deviations.md.)
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from sozia.common.models import (
+    FACE_LANDMARK_COUNT,
+    HAND_LANDMARK_COUNT,
+    POSE_LANDMARK_COUNT,
+    LandmarkFrame,
+)
+
+# Flat feature vector length per frame — derived from LandmarkFrame structure.
+FEATURE_DIM: int = (
+    POSE_LANDMARK_COUNT * 3
+    + FACE_LANDMARK_COUNT * 3
+    + HAND_LANDMARK_COUNT * 3  # left hand
+    + HAND_LANDMARK_COUNT * 3  # right hand
+)
+
+
+def _flatten_or_zeros(
+    arr: list[list[float]] | None, count: int
+) -> np.ndarray:
+    """Return flattened landmark array or a zero vector if absent."""
+    if arr is None:
+        return np.zeros(count * 3, dtype=np.float32)
+    return np.asarray(arr, dtype=np.float32).ravel()
+
+
+def _frame_to_row(frame: LandmarkFrame) -> np.ndarray:
+    """Convert a single LandmarkFrame to a 1-D feature vector of length FEATURE_DIM."""
+    return np.concatenate([
+        _flatten_or_zeros(frame.pose_landmarks, POSE_LANDMARK_COUNT),
+        _flatten_or_zeros(frame.face_landmarks, FACE_LANDMARK_COUNT),
+        _flatten_or_zeros(frame.left_hand_landmarks, HAND_LANDMARK_COUNT),
+        _flatten_or_zeros(frame.right_hand_landmarks, HAND_LANDMARK_COUNT),
+    ])
+
+
+class FrameAccumulator:
+    """Buffers LandmarkFrame objects per session and emits numpy batches.
+
+    Usage::
+
+        accumulator = FrameAccumulator(window_size=30)
+        batch = accumulator.add(frame)  # returns None until window is full
+        if batch is not None:
+            result = await tsl_engine.predict(batch)  # shape (30, 474)
+
+    Args:
+        window_size: Number of frames to collect before emitting a batch.
+            Defaults to 30, matching a typical ~1 s window at 30 fps.
+    """
+
+    def __init__(self, window_size: int = 30) -> None:
+        self._window_size = window_size
+        self._buffers: dict[str, list[LandmarkFrame]] = {}
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def add(self, frame: LandmarkFrame) -> np.ndarray | None:
+        """Append a frame to the session buffer.
+
+        Args:
+            frame: A LandmarkFrame received from the WebSocket gateway.
+
+        Returns:
+            A numpy array of shape ``(window_size, FEATURE_DIM)`` when the
+            buffer reaches ``window_size``, otherwise ``None``.
+        """
+        buf = self._buffers.setdefault(frame.session_id, [])
+        buf.append(frame)
+
+        if len(buf) >= self._window_size:
+            batch = self._to_numpy(buf)
+            self._buffers[frame.session_id] = []
+            return batch
+
+        return None
+
+    def reset(self, session_id: str) -> None:
+        """Discard all buffered frames for the given session.
+
+        Safe to call even if no frames have been accumulated yet.
+
+        Args:
+            session_id: The session whose buffer should be cleared.
+        """
+        self._buffers.pop(session_id, None)
+
+    def pending_count(self, session_id: str) -> int:
+        """Return the number of frames currently buffered for a session.
+
+        Args:
+            session_id: Session to query.
+
+        Returns:
+            Integer count in range ``[0, window_size)``.
+        """
+        return len(self._buffers.get(session_id, []))
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _to_numpy(self, frames: list[LandmarkFrame]) -> np.ndarray:
+        """Stack a list of LandmarkFrames into shape ``(T, FEATURE_DIM)``."""
+        rows = [_frame_to_row(f) for f in frames]
+        return np.stack(rows, axis=0)

--- a/sozia/fusion/orchestrator.py
+++ b/sozia/fusion/orchestrator.py
@@ -13,19 +13,33 @@ it only touches the ``InferenceEngine`` interface (``load_model``,
 from __future__ import annotations
 
 import asyncio
-from typing import TYPE_CHECKING
+import time
+import uuid
+from typing import TYPE_CHECKING, Awaitable, Callable
 
+import numpy as np
+
+from sozia.common.interfaces import InferenceTimeoutError
 from sozia.common.models import (
+    AudioFeatureChunk,
+    LandmarkFrame,
     ModalityPath,
     ModalityResult,
+    ModalityType,
     ModelConfig,
     PipelineHealth,
+    SegmentStatus,
     TranscriptSegment,
 )
 from sozia.fusion.degraded_mode_handler import DegradedModeHandler
+from sozia.fusion.frame_accumulator import FrameAccumulator
 
 if TYPE_CHECKING:
     from sozia.common.interfaces import FusionStrategy, InferenceEngine
+
+# Confidence penalty applied when GlossToText times out and we promote
+# the raw TSL gloss to a FINAL segment.
+_GLOSS_TIMEOUT_CONFIDENCE_PENALTY = 0.15
 
 
 class FusionOrchestrator:
@@ -35,12 +49,16 @@ class FusionOrchestrator:
 
         orchestrator = FusionOrchestrator()
         orchestrator.register_policy(ModalityPath.SPEECH, speech_policy)
-        orchestrator.register_engine(ModalityPath.SPEECH, asr_engine, asr_cfg)
-        orchestrator.register_engine(ModalityPath.SPEECH, lip_engine, lip_cfg)
+        orchestrator.register_engine(
+            ModalityPath.SPEECH, ModalityType.ASR, asr_engine, asr_cfg,
+        )
+        orchestrator.register_engine(
+            ModalityPath.SPEECH, ModalityType.LIP_READING, lip_engine, lip_cfg,
+        )
 
         await orchestrator.warm_up(ModalityPath.SPEECH)
-        segments = await orchestrator.process_features(
-            session_id, results, health, ModalityPath.SPEECH,
+        await orchestrator.process(
+            session_id, audio_chunk, health, ModalityPath.SPEECH, send_fn,
         )
         await orchestrator.cool_down()
     """
@@ -48,14 +66,19 @@ class FusionOrchestrator:
     def __init__(
         self,
         degraded_handler: DegradedModeHandler | None = None,
+        window_size: int = 30,
     ) -> None:
         self._policies: dict[ModalityPath, FusionStrategy] = {}
+        # Keyed by (path, modality_type) → (engine, config).
         self._engines: dict[
-            ModalityPath, list[tuple[InferenceEngine, ModelConfig]],
+            ModalityPath, dict[ModalityType, tuple[InferenceEngine, ModelConfig]]
         ] = {}
         self._degraded: DegradedModeHandler = (
             degraded_handler or DegradedModeHandler()
         )
+        self._accumulator = FrameAccumulator(window_size=window_size)
+        # Per-session face landmark cache (SPEECH path — fed to LipReadingEngine).
+        self._face_cache: dict[str, np.ndarray] = {}
 
     # ------------------------------------------------------------------
     # Registration
@@ -70,16 +93,26 @@ class FusionOrchestrator:
     def register_engine(
         self,
         path: ModalityPath,
+        modality_type: ModalityType,
         engine: InferenceEngine,
         config: ModelConfig,
     ) -> None:
-        """Attach an inference engine to a modality path for warm-up.
+        """Attach an inference engine to a modality path keyed by ModalityType.
 
         The orchestrator records the (engine, config) pair but does not
-        load the model until ``warm_up(path)`` is called. Engines stay
-        attached across sessions; ``cool_down()`` unloads them.
+        load the model until ``warm_up(path)`` is called. Registering the
+        same ``modality_type`` twice on the same ``path`` overwrites the
+        previous entry.
+
+        Args:
+            path: Which inference pipeline this engine belongs to.
+            modality_type: The ModalityType this engine produces
+                (e.g. ``ModalityType.ASR``). Used by ``process()`` to route
+                features to the correct engine without string-matching model IDs.
+            engine: A concrete InferenceEngine instance.
+            config: ModelConfig passed to ``engine.load_model()`` during warm-up.
         """
-        self._engines.setdefault(path, []).append((engine, config))
+        self._engines.setdefault(path, {})[modality_type] = (engine, config)
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -93,11 +126,11 @@ class FusionOrchestrator:
         cold-start latency; errors from individual engines propagate so
         the caller can decide whether to abort session setup.
         """
-        engines = self._engines.get(path, [])
+        engines = self._engines.get(path, {})
         await asyncio.gather(
             *(
                 engine.load_model(config)
-                for engine, config in engines
+                for engine, config in engines.values()
                 if not engine.is_loaded()
             )
         )
@@ -110,15 +143,215 @@ class FusionOrchestrator:
         does not block the others from releasing their memory.
         """
         tasks: list[asyncio.Task] = []
-        for engines in self._engines.values():
-            for engine, _ in engines:
+        for path_engines in self._engines.values():
+            for engine, _ in path_engines.values():
                 if engine.is_loaded():
                     tasks.append(asyncio.create_task(engine.unload_model()))
         if tasks:
             await asyncio.gather(*tasks, return_exceptions=True)
 
     # ------------------------------------------------------------------
-    # Main entry point
+    # High-level public entry point
+    # ------------------------------------------------------------------
+
+    async def process(
+        self,
+        session_id: str,
+        features: LandmarkFrame | AudioFeatureChunk,
+        health: list[PipelineHealth],
+        modality_path: ModalityPath,
+        send_fn: Callable[[TranscriptSegment], Awaitable[None] | None],
+    ) -> None:
+        """Handle one incoming DTO: convert to numpy, run engines, emit segments.
+
+        This is the primary entry point for SessionHandler. It dispatches to
+        the correct internal handler based on ``modality_path`` and the DTO
+        type, then calls ``send_fn`` for every TranscriptSegment produced.
+
+        Path A (SPEECH):
+          - ``LandmarkFrame`` — caches face landmarks; no inference triggered.
+          - ``AudioFeatureChunk`` — runs ASR (+ LipReading in parallel if face
+            landmarks are cached); emits PARTIAL from ASR, FINAL when both
+            modalities succeed.
+
+        Path B (SIGN):
+          - ``LandmarkFrame`` — accumulates frames; when the window is full
+            runs TslRecognitionEngine (PARTIAL), then GlossToTextEngine (FINAL).
+            On GlossToText timeout the TSL gloss is promoted to FINAL with a
+            confidence penalty.
+
+        Args:
+            session_id: Active session identifier.
+            features: One inbound DTO from the WebSocket gateway.
+            health: Current pipeline health signals from the client.
+            modality_path: Which pipeline is active for this session.
+            send_fn: Coroutine or plain callable invoked once per outbound segment.
+        """
+        if modality_path == ModalityPath.SPEECH:
+            await self._process_speech(session_id, features, health, send_fn)
+        else:
+            await self._process_sign(session_id, features, health, send_fn)
+
+    # ------------------------------------------------------------------
+    # Internal pipeline handlers
+    # ------------------------------------------------------------------
+
+    async def _process_speech(
+        self,
+        session_id: str,
+        features: LandmarkFrame | AudioFeatureChunk,
+        health: list[PipelineHealth],
+        send_fn: Callable[[TranscriptSegment], Awaitable[None] | None],
+    ) -> None:
+        if isinstance(features, LandmarkFrame):
+            # Cache the face landmarks for the next audio chunk.
+            if features.face_landmarks is not None:
+                self._face_cache[session_id] = np.asarray(
+                    features.face_landmarks, dtype=np.float32
+                )
+            return
+
+        # AudioFeatureChunk — run ASR (+ LipReading in parallel if face cached).
+        audio_np = np.asarray(features.features, dtype=np.float32)
+        face_np = self._face_cache.get(session_id)
+
+        path_engines = self._engines.get(ModalityPath.SPEECH, {})
+        asr_entry = path_engines.get(ModalityType.ASR)
+        lip_entry = path_engines.get(ModalityType.LIP_READING)
+
+        async def _run_asr() -> ModalityResult | None:
+            if asr_entry is None:
+                return None
+            asr_engine, _ = asr_entry
+            try:
+                return await asr_engine.predict(audio_np)
+            except InferenceTimeoutError:
+                return None
+
+        async def _run_lip() -> ModalityResult | None:
+            if lip_entry is None or face_np is None:
+                return None
+            lip_engine, _ = lip_entry
+            try:
+                return await lip_engine.predict(face_np)
+            except InferenceTimeoutError:
+                return None
+
+        asr_result, lip_result = await asyncio.gather(_run_asr(), _run_lip())
+
+        if asr_result is None:
+            return  # ASR timed out or missing — nothing to emit.
+
+        results = [asr_result]
+        if lip_result is not None:
+            results.append(lip_result)
+
+        segments = await self.process_features(
+            session_id, results, health, ModalityPath.SPEECH,
+        )
+        for seg in segments:
+            await _maybe_await(send_fn(seg))
+
+    async def _process_sign(
+        self,
+        session_id: str,
+        features: LandmarkFrame | AudioFeatureChunk,
+        health: list[PipelineHealth],
+        send_fn: Callable[[TranscriptSegment], Awaitable[None] | None],
+    ) -> None:
+        if not isinstance(features, LandmarkFrame):
+            return  # SIGN path only accepts LandmarkFrame.
+
+        batch = self._accumulator.add(features)
+        if batch is None:
+            return  # Window not full yet.
+
+        path_engines = self._engines.get(ModalityPath.SIGN, {})
+        tsl_entry = path_engines.get(ModalityType.TSL_RECOGNITION)
+        gloss_entry = path_engines.get(ModalityType.GLOSS_TO_TEXT)
+
+        if tsl_entry is None:
+            return
+
+        tsl_engine, _ = tsl_entry
+
+        # Run TslRecognitionEngine → emit PARTIAL.
+        try:
+            tsl_result = await tsl_engine.predict(batch)
+        except InferenceTimeoutError:
+            return  # No PARTIAL to emit without TSL output.
+
+        tsl_segments = await self.process_features(
+            session_id, [tsl_result], health, ModalityPath.SIGN,
+        )
+        partial_id: str | None = None
+        for seg in tsl_segments:
+            if seg.status == SegmentStatus.PARTIAL:
+                partial_id = seg.segment_id
+            await _maybe_await(send_fn(seg))
+
+        if gloss_entry is None:
+            return
+
+        gloss_engine, _ = gloss_entry
+
+        # Run GlossToTextEngine → emit FINAL.
+        try:
+            gloss_result = await gloss_engine.predict(tsl_result.text)
+        except InferenceTimeoutError:
+            # Promote TSL gloss to FINAL with a confidence penalty.
+            final_segs = self._promote_gloss_to_final(
+                session_id, tsl_result, partial_id,
+            )
+            for seg in final_segs:
+                await _maybe_await(send_fn(seg))
+            return
+
+        final_segments = await self.process_features(
+            session_id, [tsl_result, gloss_result], health, ModalityPath.SIGN,
+        )
+        for seg in final_segments:
+            await _maybe_await(send_fn(seg))
+
+    def _promote_gloss_to_final(
+        self,
+        session_id: str,
+        tsl_result: ModalityResult,
+        partial_id: str | None,
+    ) -> list[TranscriptSegment]:
+        """Produce a FINAL segment from a TSL result when GlossToText timed out.
+
+        Uses the raw gloss text as the final display text and applies a
+        confidence penalty to signal reduced quality.
+
+        Args:
+            session_id: Active session identifier.
+            tsl_result: The TSL result whose gloss becomes the FINAL text.
+            partial_id: The segment_id of the PARTIAL already emitted, if any.
+
+        Returns:
+            A list containing one FINAL TranscriptSegment (or empty if the
+            penalised confidence would be suppressed).
+        """
+        penalised = max(0.0, tsl_result.confidence - _GLOSS_TIMEOUT_CONFIDENCE_PENALTY)
+        if penalised <= 0.0:
+            return []
+
+        return [TranscriptSegment(
+            segment_id=str(uuid.uuid4()),
+            session_id=session_id,
+            status=SegmentStatus.FINAL,
+            text=tsl_result.text,
+            source=ModalityType.TSL_RECOGNITION,
+            confidence=round(penalised, 4),
+            timestamp_ms=tsl_result.timestamp_ms,
+            duration_ms=tsl_result.duration_ms,
+            created_at_ms=int(time.time() * 1000),
+            replaces_segment_id=partial_id,
+        )]
+
+    # ------------------------------------------------------------------
+    # Internal fusion helper (kept public for existing test compatibility)
     # ------------------------------------------------------------------
 
     async def process_features(
@@ -128,7 +361,7 @@ class FusionOrchestrator:
         health: list[PipelineHealth],
         modality_path: ModalityPath,
     ) -> list[TranscriptSegment]:
-        """Route inference results to the registered policy.
+        """Route pre-computed inference results to the registered policy.
 
         If any pipeline in ``health`` signals degraded state and only one
         modality result is present, delegates to DegradedModeHandler instead.
@@ -197,3 +430,14 @@ class FusionOrchestrator:
     def _is_degraded(self, health: list[PipelineHealth]) -> bool:
         """Return True if any health signal indicates degraded state."""
         return any(self._degraded.should_fallback(h) for h in health)
+
+
+# ---------------------------------------------------------------------------
+# Module-level utility
+# ---------------------------------------------------------------------------
+
+
+async def _maybe_await(value: Awaitable | None) -> None:
+    """Await ``value`` if it is awaitable, otherwise discard it."""
+    if asyncio.isfuture(value) or asyncio.iscoroutine(value):
+        await value

--- a/sozia/fusion/orchestrator.py
+++ b/sozia/fusion/orchestrator.py
@@ -37,9 +37,11 @@ from sozia.fusion.frame_accumulator import FrameAccumulator
 if TYPE_CHECKING:
     from sozia.common.interfaces import FusionStrategy, InferenceEngine
 
-# Confidence penalty applied when GlossToText times out and we promote
-# the raw TSL gloss to a FINAL segment.
-_GLOSS_TIMEOUT_CONFIDENCE_PENALTY = 0.15
+# Additive confidence deduction applied when GlossToText times out and we
+# promote the raw TSL gloss to a FINAL segment.
+# Note: this is a subtraction (confidence -= N), not a multiplicative factor
+# like DegradedModeHandler's degraded_penalty_factor.
+_GLOSS_TIMEOUT_CONFIDENCE_DEDUCTION = 0.15
 
 
 class FusionOrchestrator:
@@ -73,9 +75,7 @@ class FusionOrchestrator:
         self._engines: dict[
             ModalityPath, dict[ModalityType, tuple[InferenceEngine, ModelConfig]]
         ] = {}
-        self._degraded: DegradedModeHandler = (
-            degraded_handler or DegradedModeHandler()
-        )
+        self._degraded: DegradedModeHandler = degraded_handler or DegradedModeHandler()
         self._accumulator = FrameAccumulator(window_size=window_size)
         # Per-session face landmark cache (SPEECH path — fed to LipReadingEngine).
         self._face_cache: dict[str, np.ndarray] = {}
@@ -85,7 +85,9 @@ class FusionOrchestrator:
     # ------------------------------------------------------------------
 
     def register_policy(
-        self, path: ModalityPath, policy: FusionStrategy,
+        self,
+        path: ModalityPath,
+        policy: FusionStrategy,
     ) -> None:
         """Wire a fusion policy for a modality path."""
         self._policies[path] = policy
@@ -113,6 +115,24 @@ class FusionOrchestrator:
             config: ModelConfig passed to ``engine.load_model()`` during warm-up.
         """
         self._engines.setdefault(path, {})[modality_type] = (engine, config)
+
+    def reset_session(self, session_id: str) -> None:
+        """Discard all per-session state for ``session_id``.
+
+        Clears the face landmark cache and any buffered landmark frames in the
+        accumulator. Safe to call even if no data has been accumulated yet.
+
+        In the current MVP each FusionOrchestrator instance serves a single
+        session, so ``cool_down()`` followed by object disposal is the normal
+        teardown path. ``reset_session`` exists for callers that manage
+        session lifecycle externally (e.g. a future shared-orchestrator design
+        per DEV-06) and for explicit mid-session resets.
+
+        Args:
+            session_id: The session whose cached state should be discarded.
+        """
+        self._face_cache.pop(session_id, None)
+        self._accumulator.reset(session_id)
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -247,7 +267,10 @@ class FusionOrchestrator:
             results.append(lip_result)
 
         segments = await self.process_features(
-            session_id, results, health, ModalityPath.SPEECH,
+            session_id,
+            results,
+            health,
+            ModalityPath.SPEECH,
         )
         for seg in segments:
             await _maybe_await(send_fn(seg))
@@ -282,7 +305,10 @@ class FusionOrchestrator:
             return  # No PARTIAL to emit without TSL output.
 
         tsl_segments = await self.process_features(
-            session_id, [tsl_result], health, ModalityPath.SIGN,
+            session_id,
+            [tsl_result],
+            health,
+            ModalityPath.SIGN,
         )
         partial_id: str | None = None
         for seg in tsl_segments:
@@ -301,14 +327,19 @@ class FusionOrchestrator:
         except InferenceTimeoutError:
             # Promote TSL gloss to FINAL with a confidence penalty.
             final_segs = self._promote_gloss_to_final(
-                session_id, tsl_result, partial_id,
+                session_id,
+                tsl_result,
+                partial_id,
             )
             for seg in final_segs:
                 await _maybe_await(send_fn(seg))
             return
 
         final_segments = await self.process_features(
-            session_id, [tsl_result, gloss_result], health, ModalityPath.SIGN,
+            session_id,
+            [tsl_result, gloss_result],
+            health,
+            ModalityPath.SIGN,
         )
         for seg in final_segments:
             await _maybe_await(send_fn(seg))
@@ -333,22 +364,26 @@ class FusionOrchestrator:
             A list containing one FINAL TranscriptSegment (or empty if the
             penalised confidence would be suppressed).
         """
-        penalised = max(0.0, tsl_result.confidence - _GLOSS_TIMEOUT_CONFIDENCE_PENALTY)
+        penalised = max(
+            0.0, tsl_result.confidence - _GLOSS_TIMEOUT_CONFIDENCE_DEDUCTION
+        )
         if penalised <= 0.0:
             return []
 
-        return [TranscriptSegment(
-            segment_id=str(uuid.uuid4()),
-            session_id=session_id,
-            status=SegmentStatus.FINAL,
-            text=tsl_result.text,
-            source=ModalityType.TSL_RECOGNITION,
-            confidence=round(penalised, 4),
-            timestamp_ms=tsl_result.timestamp_ms,
-            duration_ms=tsl_result.duration_ms,
-            created_at_ms=int(time.time() * 1000),
-            replaces_segment_id=partial_id,
-        )]
+        return [
+            TranscriptSegment(
+                segment_id=str(uuid.uuid4()),
+                session_id=session_id,
+                status=SegmentStatus.FINAL,
+                text=tsl_result.text,
+                source=ModalityType.TSL_RECOGNITION,
+                confidence=round(penalised, 4),
+                timestamp_ms=tsl_result.timestamp_ms,
+                duration_ms=tsl_result.duration_ms,
+                created_at_ms=int(time.time() * 1000),
+                replaces_segment_id=partial_id,
+            )
+        ]
 
     # ------------------------------------------------------------------
     # Internal fusion helper (kept public for existing test compatibility)
@@ -380,9 +415,7 @@ class FusionOrchestrator:
             ValueError: No policy registered for ``modality_path``.
         """
         if modality_path not in self._policies:
-            raise ValueError(
-                f"No fusion policy registered for {modality_path.value}"
-            )
+            raise ValueError(f"No fusion policy registered for {modality_path.value}")
 
         # Check degraded mode: if any health signal triggers fallback and
         # only one result is available, use the degraded handler.
@@ -416,9 +449,7 @@ class FusionOrchestrator:
             List of TranscriptSegment objects (typically one PARTIAL).
         """
         if modality_path not in self._policies:
-            raise ValueError(
-                f"No fusion policy registered for {modality_path.value}"
-            )
+            raise ValueError(f"No fusion policy registered for {modality_path.value}")
 
         policy = self._policies[modality_path]
         return policy.fuse([result], health)

--- a/tests/fusion/test_frame_accumulator.py
+++ b/tests/fusion/test_frame_accumulator.py
@@ -1,0 +1,258 @@
+"""Tests for FrameAccumulator."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from sozia.common.models import (
+    FACE_LANDMARK_COUNT,
+    HAND_LANDMARK_COUNT,
+    POSE_LANDMARK_COUNT,
+    LandmarkFrame,
+)
+from sozia.fusion.frame_accumulator import FEATURE_DIM, FrameAccumulator
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_SESSION = "550e8400-e29b-41d4-a716-446655440000"
+_SESSION_B = "660e8400-e29b-41d4-a716-446655440000"
+
+
+def _pose() -> list[list[float]]:
+    # x, y in [0.0, 1.0]; z is unconstrained (MediaPipe relative depth).
+    n = POSE_LANDMARK_COUNT
+    return [[i / n, (n - 1 - i) / n, float(i)] for i in range(n)]
+
+
+def _face() -> list[list[float]]:
+    return [[0.1, 0.2, 0.3]] * FACE_LANDMARK_COUNT
+
+
+def _hand() -> list[list[float]]:
+    return [[0.5, 0.5, 0.5]] * HAND_LANDMARK_COUNT
+
+
+def _frame(
+    session_id: str = _SESSION,
+    timestamp_ms: int = 0,
+    with_pose: bool = True,
+    with_face: bool = True,
+    with_left: bool = True,
+    with_right: bool = True,
+) -> LandmarkFrame:
+    # At least one array must be non-null.
+    return LandmarkFrame(
+        session_id=session_id,
+        timestamp_ms=timestamp_ms,
+        face_landmarks=_face() if with_face else None,
+        left_hand_landmarks=_hand() if with_left else None,
+        right_hand_landmarks=_hand() if with_right else None,
+        pose_landmarks=_pose() if with_pose else None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# FEATURE_DIM constant
+# ---------------------------------------------------------------------------
+
+
+class TestFeatureDim:
+    def test_feature_dim_matches_landmark_counts(self):
+        expected = (
+            POSE_LANDMARK_COUNT * 3
+            + FACE_LANDMARK_COUNT * 3
+            + HAND_LANDMARK_COUNT * 3
+            + HAND_LANDMARK_COUNT * 3
+        )
+        assert FEATURE_DIM == expected
+
+    def test_feature_dim_value(self):
+        # pose(99) + face(249) + left(63) + right(63) = 474
+        assert FEATURE_DIM == 474
+
+
+# ---------------------------------------------------------------------------
+# Window fill / partial fill
+# ---------------------------------------------------------------------------
+
+
+class TestWindowFill:
+    def test_partial_fill_returns_none(self):
+        acc = FrameAccumulator(window_size=5)
+        for i in range(4):
+            result = acc.add(_frame(timestamp_ms=i))
+            assert result is None
+
+    def test_exact_fill_returns_array(self):
+        acc = FrameAccumulator(window_size=5)
+        result = None
+        for i in range(5):
+            result = acc.add(_frame(timestamp_ms=i))
+        assert result is not None
+        assert isinstance(result, np.ndarray)
+
+    def test_returned_shape_is_window_size_by_feature_dim(self):
+        window = 10
+        acc = FrameAccumulator(window_size=window)
+        result = None
+        for i in range(window):
+            result = acc.add(_frame(timestamp_ms=i))
+        assert result.shape == (window, FEATURE_DIM)
+
+    def test_buffer_resets_after_emit(self):
+        acc = FrameAccumulator(window_size=3)
+        for i in range(3):
+            acc.add(_frame(timestamp_ms=i))
+        # Buffer should have been reset; next 2 frames → None
+        assert acc.add(_frame(timestamp_ms=10)) is None
+        assert acc.add(_frame(timestamp_ms=11)) is None
+
+    def test_second_window_also_emits(self):
+        acc = FrameAccumulator(window_size=3)
+        for i in range(3):
+            acc.add(_frame(timestamp_ms=i))
+        # Second batch
+        result = None
+        for i in range(3):
+            result = acc.add(_frame(timestamp_ms=10 + i))
+        assert result is not None
+        assert result.shape == (3, FEATURE_DIM)
+
+
+# ---------------------------------------------------------------------------
+# Reset
+# ---------------------------------------------------------------------------
+
+
+class TestReset:
+    def test_reset_clears_buffer(self):
+        acc = FrameAccumulator(window_size=5)
+        for i in range(3):
+            acc.add(_frame(timestamp_ms=i))
+        assert acc.pending_count(_SESSION) == 3
+
+        acc.reset(_SESSION)
+        assert acc.pending_count(_SESSION) == 0
+
+    def test_reset_after_full_window_is_noop(self):
+        acc = FrameAccumulator(window_size=3)
+        for i in range(3):
+            acc.add(_frame(timestamp_ms=i))
+        # After emit, buffer is already empty; reset should still work without error
+        acc.reset(_SESSION)
+        assert acc.pending_count(_SESSION) == 0
+
+    def test_reset_unknown_session_is_noop(self):
+        acc = FrameAccumulator(window_size=5)
+        acc.reset("does-not-exist")  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# pending_count
+# ---------------------------------------------------------------------------
+
+
+class TestPendingCount:
+    def test_pending_count_starts_at_zero(self):
+        acc = FrameAccumulator(window_size=5)
+        assert acc.pending_count(_SESSION) == 0
+
+    def test_pending_count_increments(self):
+        acc = FrameAccumulator(window_size=5)
+        for i in range(3):
+            acc.add(_frame(timestamp_ms=i))
+        assert acc.pending_count(_SESSION) == 3
+
+    def test_pending_count_resets_after_emit(self):
+        acc = FrameAccumulator(window_size=3)
+        for i in range(3):
+            acc.add(_frame(timestamp_ms=i))
+        assert acc.pending_count(_SESSION) == 0
+
+
+# ---------------------------------------------------------------------------
+# Session isolation
+# ---------------------------------------------------------------------------
+
+
+class TestSessionIsolation:
+    def test_two_sessions_buffered_independently(self):
+        acc = FrameAccumulator(window_size=5)
+        acc.add(_frame(session_id=_SESSION, timestamp_ms=0))
+        acc.add(_frame(session_id=_SESSION_B, timestamp_ms=0))
+        assert acc.pending_count(_SESSION) == 1
+        assert acc.pending_count(_SESSION_B) == 1
+
+    def test_reset_session_a_does_not_affect_session_b(self):
+        acc = FrameAccumulator(window_size=5)
+        for i in range(3):
+            acc.add(_frame(session_id=_SESSION, timestamp_ms=i))
+        for i in range(2):
+            acc.add(_frame(session_id=_SESSION_B, timestamp_ms=i))
+        acc.reset(_SESSION)
+        assert acc.pending_count(_SESSION) == 0
+        assert acc.pending_count(_SESSION_B) == 2
+
+    def test_session_b_fills_independently(self):
+        acc = FrameAccumulator(window_size=3)
+        # Fill session B to window.
+        result = None
+        for i in range(3):
+            result = acc.add(_frame(session_id=_SESSION_B, timestamp_ms=i))
+        assert result is not None
+        # Session A is unaffected.
+        assert acc.pending_count(_SESSION) == 0
+
+
+# ---------------------------------------------------------------------------
+# Numpy values — zero-filling absent groups
+# ---------------------------------------------------------------------------
+
+
+class TestNumpyValues:
+    def test_absent_pose_yields_zeros(self):
+        acc = FrameAccumulator(window_size=1)
+        frame = _frame(with_pose=False)
+        result = acc.add(frame)
+        # Pose occupies first POSE_LANDMARK_COUNT * 3 dims.
+        pose_slice = result[0, : POSE_LANDMARK_COUNT * 3]
+        assert np.all(pose_slice == 0.0)
+
+    def test_absent_face_yields_zeros(self):
+        acc = FrameAccumulator(window_size=1)
+        frame = _frame(with_face=False)
+        result = acc.add(frame)
+        pose_end = POSE_LANDMARK_COUNT * 3
+        face_slice = result[0, pose_end : pose_end + FACE_LANDMARK_COUNT * 3]
+        assert np.all(face_slice == 0.0)
+
+    def test_absent_left_hand_yields_zeros(self):
+        acc = FrameAccumulator(window_size=1)
+        frame = _frame(with_left=False)
+        result = acc.add(frame)
+        left_start = (POSE_LANDMARK_COUNT + FACE_LANDMARK_COUNT) * 3
+        left_slice = result[0, left_start : left_start + HAND_LANDMARK_COUNT * 3]
+        assert np.all(left_slice == 0.0)
+
+    def test_absent_right_hand_yields_zeros(self):
+        acc = FrameAccumulator(window_size=1)
+        frame = _frame(with_right=False)
+        result = acc.add(frame)
+        right_start = (POSE_LANDMARK_COUNT + FACE_LANDMARK_COUNT + HAND_LANDMARK_COUNT) * 3
+        right_slice = result[0, right_start : right_start + HAND_LANDMARK_COUNT * 3]
+        assert np.all(right_slice == 0.0)
+
+    def test_present_pose_values_match(self):
+        acc = FrameAccumulator(window_size=1)
+        frame = _frame(with_face=False, with_left=False, with_right=False)
+        result = acc.add(frame)
+        expected = np.asarray(_pose(), dtype=np.float32).ravel()
+        np.testing.assert_array_almost_equal(result[0, : POSE_LANDMARK_COUNT * 3], expected)
+
+    def test_dtype_is_float32(self):
+        acc = FrameAccumulator(window_size=1)
+        result = acc.add(_frame())
+        assert result.dtype == np.float32

--- a/tests/fusion/test_integration_with_engines.py
+++ b/tests/fusion/test_integration_with_engines.py
@@ -328,10 +328,10 @@ class TestWarmUpCoolDown:
 
         orch = _build_orchestrator()
         orch.register_engine(
-            ModalityPath.SPEECH, asr, _config("whisper-small-tr"),
+            ModalityPath.SPEECH, ModalityType.ASR, asr, _config("whisper-small-tr"),
         )
         orch.register_engine(
-            ModalityPath.SPEECH, lip, _config("lip-reading-v1"),
+            ModalityPath.SPEECH, ModalityType.LIP_READING, lip, _config("lip-reading-v1"),
         )
 
         await orch.warm_up(ModalityPath.SPEECH)
@@ -342,7 +342,7 @@ class TestWarmUpCoolDown:
         engine = _StubEngine(_result(ModalityType.ASR, "x"))
         orch = _build_orchestrator()
         orch.register_engine(
-            ModalityPath.SPEECH, engine, _config("whisper-small-tr"),
+            ModalityPath.SPEECH, ModalityType.ASR, engine, _config("whisper-small-tr"),
         )
 
         await orch.warm_up(ModalityPath.SPEECH)
@@ -354,8 +354,8 @@ class TestWarmUpCoolDown:
         tsl = _StubEngine(_result(ModalityType.TSL_RECOGNITION, "x"))
 
         orch = _build_orchestrator()
-        orch.register_engine(ModalityPath.SPEECH, asr, _config("whisper"))
-        orch.register_engine(ModalityPath.SIGN, tsl, _config("tsl-gru"))
+        orch.register_engine(ModalityPath.SPEECH, ModalityType.ASR, asr, _config("whisper"))
+        orch.register_engine(ModalityPath.SIGN, ModalityType.TSL_RECOGNITION, tsl, _config("tsl-gru"))
 
         await orch.warm_up(ModalityPath.SPEECH)
         assert asr.is_loaded()
@@ -370,8 +370,8 @@ class TestWarmUpCoolDown:
         tsl = _StubEngine(_result(ModalityType.TSL_RECOGNITION, "x"))
 
         orch = _build_orchestrator()
-        orch.register_engine(ModalityPath.SPEECH, asr, _config("whisper"))
-        orch.register_engine(ModalityPath.SIGN, tsl, _config("tsl-gru"))
+        orch.register_engine(ModalityPath.SPEECH, ModalityType.ASR, asr, _config("whisper"))
+        orch.register_engine(ModalityPath.SIGN, ModalityType.TSL_RECOGNITION, tsl, _config("tsl-gru"))
 
         await orch.warm_up(ModalityPath.SPEECH)
         await orch.warm_up(ModalityPath.SIGN)

--- a/tests/fusion/test_orchestrator_process.py
+++ b/tests/fusion/test_orchestrator_process.py
@@ -1,0 +1,522 @@
+"""Tests for FusionOrchestrator.process() and updated register_engine()."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import numpy as np
+import pytest
+
+from sozia.common.interfaces import InferenceEngine, InferenceTimeoutError
+from sozia.common.models import (
+    FACE_LANDMARK_COUNT,
+    HAND_LANDMARK_COUNT,
+    POSE_LANDMARK_COUNT,
+    AudioFeatureChunk,
+    LandmarkFrame,
+    ModalityPath,
+    ModalityResult,
+    ModalityType,
+    ModelConfig,
+    PipelineHealth,
+    SegmentStatus,
+    TranscriptSegment,
+)
+from sozia.fusion.orchestrator import FusionOrchestrator
+from sozia.fusion.sign_fusion_policy import SignFusionPolicy
+from sozia.fusion.speech_fusion_policy import SpeechFusionPolicy
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+_SESSION = "550e8400-e29b-41d4-a716-446655440000"
+
+
+def _cfg(model_id: str) -> ModelConfig:
+    return ModelConfig(model_id=model_id, weights_path="/tmp/noop", device="cpu", params={})
+
+
+def _result(
+    modality: ModalityType,
+    text: str = "test",
+    confidence: float = 0.80,
+) -> ModalityResult:
+    return ModalityResult(
+        modality_type=modality,
+        text=text,
+        confidence=confidence,
+        timestamp_ms=1000,
+        duration_ms=500,
+        inference_latency_ms=200,
+    )
+
+
+def _audio_health(available: bool = True, snr: float = 25.0) -> PipelineHealth:
+    return PipelineHealth(
+        session_id=_SESSION, pipeline="audio", available=available,
+        fps=None, snr=snr, face_detected=None, last_updated_ms=1000,
+    )
+
+
+def _video_health(available: bool = True, face_detected: bool = True) -> PipelineHealth:
+    return PipelineHealth(
+        session_id=_SESSION, pipeline="video", available=available,
+        fps=30.0, snr=None, face_detected=face_detected, last_updated_ms=1000,
+    )
+
+
+def _audio_chunk() -> AudioFeatureChunk:
+    return AudioFeatureChunk(
+        session_id=_SESSION,
+        timestamp_ms=0,
+        features=[[0.1, 0.2, 0.3]] * 10,
+        feature_type="mfcc",
+        sample_rate_hz=16000,
+        chunk_duration_ms=500,
+    )
+
+
+def _landmark_frame(
+    session_id: str = _SESSION,
+    timestamp_ms: int = 0,
+) -> LandmarkFrame:
+    n = POSE_LANDMARK_COUNT
+    return LandmarkFrame(
+        session_id=session_id,
+        timestamp_ms=timestamp_ms,
+        face_landmarks=[[0.1, 0.2, 0.3]] * FACE_LANDMARK_COUNT,
+        left_hand_landmarks=[[0.5, 0.5, 0.5]] * HAND_LANDMARK_COUNT,
+        right_hand_landmarks=[[0.5, 0.5, 0.5]] * HAND_LANDMARK_COUNT,
+        pose_landmarks=[[i / n, (n - 1 - i) / n, float(i)] for i in range(n)],
+    )
+
+
+class _StubEngine(InferenceEngine):
+    """Minimal stub that returns a pre-canned result."""
+
+    def __init__(
+        self,
+        result: ModalityResult | None = None,
+        raise_timeout: bool = False,
+        model_id: str = "stub",
+    ) -> None:
+        self._result = result
+        self._raise_timeout = raise_timeout
+        self._model_id = model_id
+        self._loaded = False
+
+    async def load_model(self, config: ModelConfig) -> None:
+        self._loaded = True
+        self._model_id = config.model_id
+
+    async def predict(self, features, timeout_ms: int = 2200) -> ModalityResult:
+        from sozia.common.interfaces import ModelNotLoadedError
+        if not self._loaded:
+            raise ModelNotLoadedError(self._model_id)
+        if self._raise_timeout:
+            raise InferenceTimeoutError("stub timeout")
+        return self._result
+
+    async def unload_model(self) -> None:
+        self._loaded = False
+
+    def is_loaded(self) -> bool:
+        return self._loaded
+
+    def get_model_id(self) -> str:
+        return self._model_id if self._loaded else ""
+
+
+def _make_orchestrator(
+    window_size: int = 1,
+    with_speech: bool = False,
+    with_sign: bool = False,
+    asr_engine: _StubEngine | None = None,
+    lip_engine: _StubEngine | None = None,
+    tsl_engine: _StubEngine | None = None,
+    gloss_engine: _StubEngine | None = None,
+) -> FusionOrchestrator:
+    orch = FusionOrchestrator(window_size=window_size)
+    orch.register_policy(ModalityPath.SPEECH, SpeechFusionPolicy())
+    orch.register_policy(ModalityPath.SIGN, SignFusionPolicy())
+
+    if with_speech or asr_engine:
+        _asr = asr_engine or _StubEngine(
+            _result(ModalityType.ASR, "merhaba", 0.85), model_id="whisper"
+        )
+        _asr._loaded = True
+        orch.register_engine(
+            ModalityPath.SPEECH, ModalityType.ASR, _asr, _cfg("whisper"),
+        )
+
+    if with_speech or lip_engine:
+        _lip = lip_engine or _StubEngine(
+            _result(ModalityType.LIP_READING, "merhaba dünya", 0.75), model_id="lip"
+        )
+        _lip._loaded = True
+        orch.register_engine(
+            ModalityPath.SPEECH, ModalityType.LIP_READING, _lip, _cfg("lip"),
+        )
+
+    if with_sign or tsl_engine:
+        _tsl = tsl_engine or _StubEngine(
+            _result(ModalityType.TSL_RECOGNITION, "MERHABA", 0.80), model_id="tsl"
+        )
+        _tsl._loaded = True
+        orch.register_engine(
+            ModalityPath.SIGN, ModalityType.TSL_RECOGNITION, _tsl, _cfg("tsl"),
+        )
+
+    if with_sign or gloss_engine:
+        _gloss = gloss_engine or _StubEngine(
+            _result(ModalityType.GLOSS_TO_TEXT, "Merhaba.", 0.88), model_id="gemma"
+        )
+        _gloss._loaded = True
+        orch.register_engine(
+            ModalityPath.SIGN, ModalityType.GLOSS_TO_TEXT, _gloss, _cfg("gemma"),
+        )
+
+    return orch
+
+
+# ---------------------------------------------------------------------------
+# register_engine() API
+# ---------------------------------------------------------------------------
+
+
+class TestRegisterEngine:
+    def test_register_engine_stores_by_modality_type(self):
+        orch = FusionOrchestrator()
+        engine = _StubEngine(_result(ModalityType.ASR, "x"))
+        orch.register_engine(
+            ModalityPath.SPEECH, ModalityType.ASR, engine, _cfg("whisper"),
+        )
+        path_engines = orch._engines.get(ModalityPath.SPEECH, {})
+        assert ModalityType.ASR in path_engines
+
+    def test_register_engine_second_type_same_path(self):
+        orch = FusionOrchestrator()
+        asr = _StubEngine(_result(ModalityType.ASR, "x"))
+        lip = _StubEngine(_result(ModalityType.LIP_READING, "y"))
+        orch.register_engine(ModalityPath.SPEECH, ModalityType.ASR, asr, _cfg("a"))
+        orch.register_engine(ModalityPath.SPEECH, ModalityType.LIP_READING, lip, _cfg("b"))
+        path_engines = orch._engines[ModalityPath.SPEECH]
+        assert ModalityType.ASR in path_engines
+        assert ModalityType.LIP_READING in path_engines
+
+    def test_register_engine_overwrites_same_modality_type(self):
+        orch = FusionOrchestrator()
+        first = _StubEngine(_result(ModalityType.ASR, "first"))
+        second = _StubEngine(_result(ModalityType.ASR, "second"))
+        orch.register_engine(ModalityPath.SPEECH, ModalityType.ASR, first, _cfg("a"))
+        orch.register_engine(ModalityPath.SPEECH, ModalityType.ASR, second, _cfg("b"))
+        stored_engine, _ = orch._engines[ModalityPath.SPEECH][ModalityType.ASR]
+        assert stored_engine is second
+
+
+# ---------------------------------------------------------------------------
+# warm_up / cool_down — updated structure
+# ---------------------------------------------------------------------------
+
+
+class TestWarmUpCoolDownUpdated:
+    async def test_warm_up_loads_all_registered_engines_by_type(self):
+        asr = _StubEngine(_result(ModalityType.ASR, "x"))
+        lip = _StubEngine(_result(ModalityType.LIP_READING, "y"))
+
+        orch = FusionOrchestrator()
+        orch.register_engine(ModalityPath.SPEECH, ModalityType.ASR, asr, _cfg("w"))
+        orch.register_engine(ModalityPath.SPEECH, ModalityType.LIP_READING, lip, _cfg("l"))
+
+        await orch.warm_up(ModalityPath.SPEECH)
+        assert asr.is_loaded()
+        assert lip.is_loaded()
+
+    async def test_cool_down_unloads_all(self):
+        asr = _StubEngine(_result(ModalityType.ASR, "x"))
+        tsl = _StubEngine(_result(ModalityType.TSL_RECOGNITION, "x"))
+
+        orch = FusionOrchestrator()
+        orch.register_engine(ModalityPath.SPEECH, ModalityType.ASR, asr, _cfg("w"))
+        orch.register_engine(ModalityPath.SIGN, ModalityType.TSL_RECOGNITION, tsl, _cfg("t"))
+
+        await orch.warm_up(ModalityPath.SPEECH)
+        await orch.warm_up(ModalityPath.SIGN)
+        await orch.cool_down()
+        assert not asr.is_loaded()
+        assert not tsl.is_loaded()
+
+
+# ---------------------------------------------------------------------------
+# process() — Path A (SPEECH)
+# ---------------------------------------------------------------------------
+
+
+class TestProcessSpeech:
+    async def test_audio_chunk_emits_partial_via_send_fn(self):
+        orch = _make_orchestrator(with_speech=True)
+        sent: list[TranscriptSegment] = []
+
+        await orch.process(
+            _SESSION, _audio_chunk(), [_audio_health()],
+            ModalityPath.SPEECH, sent.append,
+        )
+
+        assert len(sent) >= 1
+        assert any(s.status == SegmentStatus.PARTIAL for s in sent)
+
+    async def test_audio_chunk_with_cached_face_emits_final(self):
+        asr = _StubEngine(_result(ModalityType.ASR, "merhaba", 0.75), model_id="w")
+        lip = _StubEngine(_result(ModalityType.LIP_READING, "merhaba dünya", 0.85), model_id="l")
+        asr._loaded = True
+        lip._loaded = True
+
+        orch = FusionOrchestrator()
+        orch.register_policy(ModalityPath.SPEECH, SpeechFusionPolicy())
+        orch.register_engine(ModalityPath.SPEECH, ModalityType.ASR, asr, _cfg("w"))
+        orch.register_engine(ModalityPath.SPEECH, ModalityType.LIP_READING, lip, _cfg("l"))
+
+        # First send a landmark frame to populate the face cache.
+        sent: list[TranscriptSegment] = []
+        await orch.process(
+            _SESSION, _landmark_frame(), [_video_health()],
+            ModalityPath.SPEECH, sent.append,
+        )
+        assert sent == []  # face caching only, no inference yet
+
+        # Now send audio chunk — both engines run.
+        await orch.process(
+            _SESSION, _audio_chunk(), [_audio_health()],
+            ModalityPath.SPEECH, sent.append,
+        )
+        assert any(s.status == SegmentStatus.FINAL for s in sent)
+
+    async def test_audio_chunk_without_face_cache_emits_asr_only_partial(self):
+        asr = _StubEngine(_result(ModalityType.ASR, "merhaba", 0.85), model_id="w")
+        lip = _StubEngine(_result(ModalityType.LIP_READING, "x", 0.75), model_id="l")
+        asr._loaded = True
+        lip._loaded = True
+
+        orch = FusionOrchestrator()
+        orch.register_policy(ModalityPath.SPEECH, SpeechFusionPolicy())
+        orch.register_engine(ModalityPath.SPEECH, ModalityType.ASR, asr, _cfg("w"))
+        orch.register_engine(ModalityPath.SPEECH, ModalityType.LIP_READING, lip, _cfg("l"))
+
+        sent: list[TranscriptSegment] = []
+        await orch.process(
+            _SESSION, _audio_chunk(), [_audio_health()],
+            ModalityPath.SPEECH, sent.append,
+        )
+        # Only ASR runs (no cached face) → PARTIAL.
+        assert len(sent) == 1
+        assert sent[0].status == SegmentStatus.PARTIAL
+        assert sent[0].source == ModalityType.ASR
+
+    async def test_asr_timeout_produces_no_segments(self):
+        asr = _StubEngine(None, raise_timeout=True, model_id="w")
+        asr._loaded = True
+
+        orch = FusionOrchestrator()
+        orch.register_policy(ModalityPath.SPEECH, SpeechFusionPolicy())
+        orch.register_engine(ModalityPath.SPEECH, ModalityType.ASR, asr, _cfg("w"))
+
+        sent: list[TranscriptSegment] = []
+        await orch.process(
+            _SESSION, _audio_chunk(), [_audio_health()],
+            ModalityPath.SPEECH, sent.append,
+        )
+        assert sent == []
+
+    async def test_lip_timeout_emits_asr_partial_only(self):
+        asr = _StubEngine(_result(ModalityType.ASR, "merhaba", 0.80), model_id="w")
+        lip = _StubEngine(None, raise_timeout=True, model_id="l")
+        asr._loaded = True
+        lip._loaded = True
+
+        orch = FusionOrchestrator()
+        orch.register_policy(ModalityPath.SPEECH, SpeechFusionPolicy())
+        orch.register_engine(ModalityPath.SPEECH, ModalityType.ASR, asr, _cfg("w"))
+        orch.register_engine(ModalityPath.SPEECH, ModalityType.LIP_READING, lip, _cfg("l"))
+
+        # Prime face cache first.
+        await orch.process(
+            _SESSION, _landmark_frame(), [_video_health()],
+            ModalityPath.SPEECH, lambda s: None,
+        )
+
+        sent: list[TranscriptSegment] = []
+        await orch.process(
+            _SESSION, _audio_chunk(), [_audio_health()],
+            ModalityPath.SPEECH, sent.append,
+        )
+        assert len(sent) == 1
+        assert sent[0].status == SegmentStatus.PARTIAL
+        assert sent[0].source == ModalityType.ASR
+
+    async def test_suppressed_asr_emits_nothing(self):
+        asr = _StubEngine(_result(ModalityType.ASR, "noise", 0.10), model_id="w")
+        asr._loaded = True
+
+        orch = FusionOrchestrator()
+        orch.register_policy(ModalityPath.SPEECH, SpeechFusionPolicy())
+        orch.register_engine(ModalityPath.SPEECH, ModalityType.ASR, asr, _cfg("w"))
+
+        sent: list[TranscriptSegment] = []
+        await orch.process(
+            _SESSION, _audio_chunk(), [_audio_health()],
+            ModalityPath.SPEECH, sent.append,
+        )
+        assert sent == []
+
+    async def test_landmark_frame_on_speech_path_caches_only(self):
+        """LandmarkFrame on SPEECH path updates face cache, no inference triggered."""
+        orch = _make_orchestrator(with_speech=True)
+        sent: list[TranscriptSegment] = []
+        await orch.process(
+            _SESSION, _landmark_frame(), [_video_health()],
+            ModalityPath.SPEECH, sent.append,
+        )
+        assert sent == []
+
+
+# ---------------------------------------------------------------------------
+# process() — Path B (SIGN)
+# ---------------------------------------------------------------------------
+
+
+class TestProcessSign:
+    async def test_partial_window_emits_nothing(self):
+        orch = _make_orchestrator(window_size=5, with_sign=True)
+        sent: list[TranscriptSegment] = []
+        for i in range(4):
+            await orch.process(
+                _SESSION, _landmark_frame(timestamp_ms=i), [_video_health()],
+                ModalityPath.SIGN, sent.append,
+            )
+        assert sent == []
+
+    async def test_full_window_emits_partial_from_tsl(self):
+        tsl = _StubEngine(
+            _result(ModalityType.TSL_RECOGNITION, "MERHABA", 0.80), model_id="tsl"
+        )
+        tsl._loaded = True
+        gloss = _StubEngine(
+            _result(ModalityType.GLOSS_TO_TEXT, "Merhaba.", 0.88), model_id="gemma"
+        )
+        gloss._loaded = True
+
+        orch = FusionOrchestrator(window_size=3)
+        orch.register_policy(ModalityPath.SIGN, SignFusionPolicy())
+        orch.register_engine(ModalityPath.SIGN, ModalityType.TSL_RECOGNITION, tsl, _cfg("tsl"))
+        orch.register_engine(ModalityPath.SIGN, ModalityType.GLOSS_TO_TEXT, gloss, _cfg("gemma"))
+
+        sent: list[TranscriptSegment] = []
+        for i in range(3):
+            await orch.process(
+                _SESSION, _landmark_frame(timestamp_ms=i), [_video_health()],
+                ModalityPath.SIGN, sent.append,
+            )
+
+        # Should have: PARTIAL (TSL) + FINAL (gloss)
+        assert len(sent) == 2
+        statuses = {s.status for s in sent}
+        assert SegmentStatus.PARTIAL in statuses
+        assert SegmentStatus.FINAL in statuses
+
+    async def test_full_window_partial_text_is_gloss(self):
+        tsl = _StubEngine(
+            _result(ModalityType.TSL_RECOGNITION, "MERHABA DUNYA", 0.80), model_id="tsl"
+        )
+        tsl._loaded = True
+        gloss = _StubEngine(
+            _result(ModalityType.GLOSS_TO_TEXT, "Merhaba dünya.", 0.88), model_id="gemma"
+        )
+        gloss._loaded = True
+
+        orch = FusionOrchestrator(window_size=1)
+        orch.register_policy(ModalityPath.SIGN, SignFusionPolicy())
+        orch.register_engine(ModalityPath.SIGN, ModalityType.TSL_RECOGNITION, tsl, _cfg("tsl"))
+        orch.register_engine(ModalityPath.SIGN, ModalityType.GLOSS_TO_TEXT, gloss, _cfg("gemma"))
+
+        sent: list[TranscriptSegment] = []
+        await orch.process(
+            _SESSION, _landmark_frame(), [_video_health()],
+            ModalityPath.SIGN, sent.append,
+        )
+        partial = next(s for s in sent if s.status == SegmentStatus.PARTIAL)
+        final = next(s for s in sent if s.status == SegmentStatus.FINAL)
+        assert partial.text == "MERHABA DUNYA"
+        assert final.text == "Merhaba dünya."
+        assert final.replaces_segment_id == partial.segment_id
+
+    async def test_tsl_timeout_emits_nothing(self):
+        tsl = _StubEngine(None, raise_timeout=True, model_id="tsl")
+        tsl._loaded = True
+
+        orch = FusionOrchestrator(window_size=1)
+        orch.register_policy(ModalityPath.SIGN, SignFusionPolicy())
+        orch.register_engine(ModalityPath.SIGN, ModalityType.TSL_RECOGNITION, tsl, _cfg("tsl"))
+
+        sent: list[TranscriptSegment] = []
+        await orch.process(
+            _SESSION, _landmark_frame(), [_video_health()],
+            ModalityPath.SIGN, sent.append,
+        )
+        assert sent == []
+
+    async def test_gloss_timeout_promotes_tsl_partial_to_final(self):
+        tsl = _StubEngine(
+            _result(ModalityType.TSL_RECOGNITION, "MERHABA", 0.80), model_id="tsl"
+        )
+        tsl._loaded = True
+        gloss = _StubEngine(None, raise_timeout=True, model_id="gemma")
+        gloss._loaded = True
+
+        orch = FusionOrchestrator(window_size=1)
+        orch.register_policy(ModalityPath.SIGN, SignFusionPolicy())
+        orch.register_engine(ModalityPath.SIGN, ModalityType.TSL_RECOGNITION, tsl, _cfg("tsl"))
+        orch.register_engine(ModalityPath.SIGN, ModalityType.GLOSS_TO_TEXT, gloss, _cfg("gemma"))
+
+        sent: list[TranscriptSegment] = []
+        await orch.process(
+            _SESSION, _landmark_frame(), [_video_health()],
+            ModalityPath.SIGN, sent.append,
+        )
+
+        # PARTIAL (TSL gloss) + FINAL (promoted from TSL on gloss timeout)
+        assert len(sent) == 2
+        partial = next(s for s in sent if s.status == SegmentStatus.PARTIAL)
+        final = next(s for s in sent if s.status == SegmentStatus.FINAL)
+        # FINAL replaces the PARTIAL
+        assert final.replaces_segment_id == partial.segment_id
+        # FINAL carries TSL raw gloss text (fallback)
+        assert final.text == "MERHABA"
+        # Confidence penalised
+        assert final.confidence < 0.80
+
+    async def test_suppressed_tsl_emits_nothing(self):
+        tsl = _StubEngine(
+            _result(ModalityType.TSL_RECOGNITION, "x", 0.10), model_id="tsl"
+        )
+        tsl._loaded = True
+
+        orch = FusionOrchestrator(window_size=1)
+        orch.register_policy(ModalityPath.SIGN, SignFusionPolicy())
+        orch.register_engine(ModalityPath.SIGN, ModalityType.TSL_RECOGNITION, tsl, _cfg("tsl"))
+
+        sent: list[TranscriptSegment] = []
+        await orch.process(
+            _SESSION, _landmark_frame(), [_video_health()],
+            ModalityPath.SIGN, sent.append,
+        )
+        assert sent == []
+
+    async def test_audio_chunk_on_sign_path_is_noop(self):
+        orch = _make_orchestrator(window_size=1, with_sign=True)
+        sent: list[TranscriptSegment] = []
+        await orch.process(
+            _SESSION, _audio_chunk(), [_audio_health()],
+            ModalityPath.SIGN, sent.append,
+        )
+        assert sent == []

--- a/tests/fusion/test_orchestrator_process.py
+++ b/tests/fusion/test_orchestrator_process.py
@@ -2,10 +2,6 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock
-
-import numpy as np
-import pytest
 
 from sozia.common.interfaces import InferenceEngine, InferenceTimeoutError
 from sozia.common.models import (
@@ -34,7 +30,9 @@ _SESSION = "550e8400-e29b-41d4-a716-446655440000"
 
 
 def _cfg(model_id: str) -> ModelConfig:
-    return ModelConfig(model_id=model_id, weights_path="/tmp/noop", device="cpu", params={})
+    return ModelConfig(
+        model_id=model_id, weights_path="/tmp/noop", device="cpu", params={}
+    )
 
 
 def _result(
@@ -54,15 +52,25 @@ def _result(
 
 def _audio_health(available: bool = True, snr: float = 25.0) -> PipelineHealth:
     return PipelineHealth(
-        session_id=_SESSION, pipeline="audio", available=available,
-        fps=None, snr=snr, face_detected=None, last_updated_ms=1000,
+        session_id=_SESSION,
+        pipeline="audio",
+        available=available,
+        fps=None,
+        snr=snr,
+        face_detected=None,
+        last_updated_ms=1000,
     )
 
 
 def _video_health(available: bool = True, face_detected: bool = True) -> PipelineHealth:
     return PipelineHealth(
-        session_id=_SESSION, pipeline="video", available=available,
-        fps=30.0, snr=None, face_detected=face_detected, last_updated_ms=1000,
+        session_id=_SESSION,
+        pipeline="video",
+        available=available,
+        fps=30.0,
+        snr=None,
+        face_detected=face_detected,
+        last_updated_ms=1000,
     )
 
 
@@ -112,6 +120,7 @@ class _StubEngine(InferenceEngine):
 
     async def predict(self, features, timeout_ms: int = 2200) -> ModalityResult:
         from sozia.common.interfaces import ModelNotLoadedError
+
         if not self._loaded:
             raise ModelNotLoadedError(self._model_id)
         if self._raise_timeout:
@@ -147,7 +156,10 @@ def _make_orchestrator(
         )
         _asr._loaded = True
         orch.register_engine(
-            ModalityPath.SPEECH, ModalityType.ASR, _asr, _cfg("whisper"),
+            ModalityPath.SPEECH,
+            ModalityType.ASR,
+            _asr,
+            _cfg("whisper"),
         )
 
     if with_speech or lip_engine:
@@ -156,7 +168,10 @@ def _make_orchestrator(
         )
         _lip._loaded = True
         orch.register_engine(
-            ModalityPath.SPEECH, ModalityType.LIP_READING, _lip, _cfg("lip"),
+            ModalityPath.SPEECH,
+            ModalityType.LIP_READING,
+            _lip,
+            _cfg("lip"),
         )
 
     if with_sign or tsl_engine:
@@ -165,7 +180,10 @@ def _make_orchestrator(
         )
         _tsl._loaded = True
         orch.register_engine(
-            ModalityPath.SIGN, ModalityType.TSL_RECOGNITION, _tsl, _cfg("tsl"),
+            ModalityPath.SIGN,
+            ModalityType.TSL_RECOGNITION,
+            _tsl,
+            _cfg("tsl"),
         )
 
     if with_sign or gloss_engine:
@@ -174,7 +192,10 @@ def _make_orchestrator(
         )
         _gloss._loaded = True
         orch.register_engine(
-            ModalityPath.SIGN, ModalityType.GLOSS_TO_TEXT, _gloss, _cfg("gemma"),
+            ModalityPath.SIGN,
+            ModalityType.GLOSS_TO_TEXT,
+            _gloss,
+            _cfg("gemma"),
         )
 
     return orch
@@ -190,7 +211,10 @@ class TestRegisterEngine:
         orch = FusionOrchestrator()
         engine = _StubEngine(_result(ModalityType.ASR, "x"))
         orch.register_engine(
-            ModalityPath.SPEECH, ModalityType.ASR, engine, _cfg("whisper"),
+            ModalityPath.SPEECH,
+            ModalityType.ASR,
+            engine,
+            _cfg("whisper"),
         )
         path_engines = orch._engines.get(ModalityPath.SPEECH, {})
         assert ModalityType.ASR in path_engines
@@ -200,7 +224,9 @@ class TestRegisterEngine:
         asr = _StubEngine(_result(ModalityType.ASR, "x"))
         lip = _StubEngine(_result(ModalityType.LIP_READING, "y"))
         orch.register_engine(ModalityPath.SPEECH, ModalityType.ASR, asr, _cfg("a"))
-        orch.register_engine(ModalityPath.SPEECH, ModalityType.LIP_READING, lip, _cfg("b"))
+        orch.register_engine(
+            ModalityPath.SPEECH, ModalityType.LIP_READING, lip, _cfg("b")
+        )
         path_engines = orch._engines[ModalityPath.SPEECH]
         assert ModalityType.ASR in path_engines
         assert ModalityType.LIP_READING in path_engines
@@ -227,7 +253,9 @@ class TestWarmUpCoolDownUpdated:
 
         orch = FusionOrchestrator()
         orch.register_engine(ModalityPath.SPEECH, ModalityType.ASR, asr, _cfg("w"))
-        orch.register_engine(ModalityPath.SPEECH, ModalityType.LIP_READING, lip, _cfg("l"))
+        orch.register_engine(
+            ModalityPath.SPEECH, ModalityType.LIP_READING, lip, _cfg("l")
+        )
 
         await orch.warm_up(ModalityPath.SPEECH)
         assert asr.is_loaded()
@@ -239,7 +267,9 @@ class TestWarmUpCoolDownUpdated:
 
         orch = FusionOrchestrator()
         orch.register_engine(ModalityPath.SPEECH, ModalityType.ASR, asr, _cfg("w"))
-        orch.register_engine(ModalityPath.SIGN, ModalityType.TSL_RECOGNITION, tsl, _cfg("t"))
+        orch.register_engine(
+            ModalityPath.SIGN, ModalityType.TSL_RECOGNITION, tsl, _cfg("t")
+        )
 
         await orch.warm_up(ModalityPath.SPEECH)
         await orch.warm_up(ModalityPath.SIGN)
@@ -259,8 +289,11 @@ class TestProcessSpeech:
         sent: list[TranscriptSegment] = []
 
         await orch.process(
-            _SESSION, _audio_chunk(), [_audio_health()],
-            ModalityPath.SPEECH, sent.append,
+            _SESSION,
+            _audio_chunk(),
+            [_audio_health()],
+            ModalityPath.SPEECH,
+            sent.append,
         )
 
         assert len(sent) >= 1
@@ -268,27 +301,37 @@ class TestProcessSpeech:
 
     async def test_audio_chunk_with_cached_face_emits_final(self):
         asr = _StubEngine(_result(ModalityType.ASR, "merhaba", 0.75), model_id="w")
-        lip = _StubEngine(_result(ModalityType.LIP_READING, "merhaba dünya", 0.85), model_id="l")
+        lip = _StubEngine(
+            _result(ModalityType.LIP_READING, "merhaba dünya", 0.85), model_id="l"
+        )
         asr._loaded = True
         lip._loaded = True
 
         orch = FusionOrchestrator()
         orch.register_policy(ModalityPath.SPEECH, SpeechFusionPolicy())
         orch.register_engine(ModalityPath.SPEECH, ModalityType.ASR, asr, _cfg("w"))
-        orch.register_engine(ModalityPath.SPEECH, ModalityType.LIP_READING, lip, _cfg("l"))
+        orch.register_engine(
+            ModalityPath.SPEECH, ModalityType.LIP_READING, lip, _cfg("l")
+        )
 
         # First send a landmark frame to populate the face cache.
         sent: list[TranscriptSegment] = []
         await orch.process(
-            _SESSION, _landmark_frame(), [_video_health()],
-            ModalityPath.SPEECH, sent.append,
+            _SESSION,
+            _landmark_frame(),
+            [_video_health()],
+            ModalityPath.SPEECH,
+            sent.append,
         )
         assert sent == []  # face caching only, no inference yet
 
         # Now send audio chunk — both engines run.
         await orch.process(
-            _SESSION, _audio_chunk(), [_audio_health()],
-            ModalityPath.SPEECH, sent.append,
+            _SESSION,
+            _audio_chunk(),
+            [_audio_health()],
+            ModalityPath.SPEECH,
+            sent.append,
         )
         assert any(s.status == SegmentStatus.FINAL for s in sent)
 
@@ -301,12 +344,17 @@ class TestProcessSpeech:
         orch = FusionOrchestrator()
         orch.register_policy(ModalityPath.SPEECH, SpeechFusionPolicy())
         orch.register_engine(ModalityPath.SPEECH, ModalityType.ASR, asr, _cfg("w"))
-        orch.register_engine(ModalityPath.SPEECH, ModalityType.LIP_READING, lip, _cfg("l"))
+        orch.register_engine(
+            ModalityPath.SPEECH, ModalityType.LIP_READING, lip, _cfg("l")
+        )
 
         sent: list[TranscriptSegment] = []
         await orch.process(
-            _SESSION, _audio_chunk(), [_audio_health()],
-            ModalityPath.SPEECH, sent.append,
+            _SESSION,
+            _audio_chunk(),
+            [_audio_health()],
+            ModalityPath.SPEECH,
+            sent.append,
         )
         # Only ASR runs (no cached face) → PARTIAL.
         assert len(sent) == 1
@@ -323,8 +371,11 @@ class TestProcessSpeech:
 
         sent: list[TranscriptSegment] = []
         await orch.process(
-            _SESSION, _audio_chunk(), [_audio_health()],
-            ModalityPath.SPEECH, sent.append,
+            _SESSION,
+            _audio_chunk(),
+            [_audio_health()],
+            ModalityPath.SPEECH,
+            sent.append,
         )
         assert sent == []
 
@@ -337,18 +388,26 @@ class TestProcessSpeech:
         orch = FusionOrchestrator()
         orch.register_policy(ModalityPath.SPEECH, SpeechFusionPolicy())
         orch.register_engine(ModalityPath.SPEECH, ModalityType.ASR, asr, _cfg("w"))
-        orch.register_engine(ModalityPath.SPEECH, ModalityType.LIP_READING, lip, _cfg("l"))
+        orch.register_engine(
+            ModalityPath.SPEECH, ModalityType.LIP_READING, lip, _cfg("l")
+        )
 
         # Prime face cache first.
         await orch.process(
-            _SESSION, _landmark_frame(), [_video_health()],
-            ModalityPath.SPEECH, lambda s: None,
+            _SESSION,
+            _landmark_frame(),
+            [_video_health()],
+            ModalityPath.SPEECH,
+            lambda s: None,
         )
 
         sent: list[TranscriptSegment] = []
         await orch.process(
-            _SESSION, _audio_chunk(), [_audio_health()],
-            ModalityPath.SPEECH, sent.append,
+            _SESSION,
+            _audio_chunk(),
+            [_audio_health()],
+            ModalityPath.SPEECH,
+            sent.append,
         )
         assert len(sent) == 1
         assert sent[0].status == SegmentStatus.PARTIAL
@@ -364,8 +423,11 @@ class TestProcessSpeech:
 
         sent: list[TranscriptSegment] = []
         await orch.process(
-            _SESSION, _audio_chunk(), [_audio_health()],
-            ModalityPath.SPEECH, sent.append,
+            _SESSION,
+            _audio_chunk(),
+            [_audio_health()],
+            ModalityPath.SPEECH,
+            sent.append,
         )
         assert sent == []
 
@@ -374,8 +436,11 @@ class TestProcessSpeech:
         orch = _make_orchestrator(with_speech=True)
         sent: list[TranscriptSegment] = []
         await orch.process(
-            _SESSION, _landmark_frame(), [_video_health()],
-            ModalityPath.SPEECH, sent.append,
+            _SESSION,
+            _landmark_frame(),
+            [_video_health()],
+            ModalityPath.SPEECH,
+            sent.append,
         )
         assert sent == []
 
@@ -391,8 +456,11 @@ class TestProcessSign:
         sent: list[TranscriptSegment] = []
         for i in range(4):
             await orch.process(
-                _SESSION, _landmark_frame(timestamp_ms=i), [_video_health()],
-                ModalityPath.SIGN, sent.append,
+                _SESSION,
+                _landmark_frame(timestamp_ms=i),
+                [_video_health()],
+                ModalityPath.SIGN,
+                sent.append,
             )
         assert sent == []
 
@@ -408,14 +476,21 @@ class TestProcessSign:
 
         orch = FusionOrchestrator(window_size=3)
         orch.register_policy(ModalityPath.SIGN, SignFusionPolicy())
-        orch.register_engine(ModalityPath.SIGN, ModalityType.TSL_RECOGNITION, tsl, _cfg("tsl"))
-        orch.register_engine(ModalityPath.SIGN, ModalityType.GLOSS_TO_TEXT, gloss, _cfg("gemma"))
+        orch.register_engine(
+            ModalityPath.SIGN, ModalityType.TSL_RECOGNITION, tsl, _cfg("tsl")
+        )
+        orch.register_engine(
+            ModalityPath.SIGN, ModalityType.GLOSS_TO_TEXT, gloss, _cfg("gemma")
+        )
 
         sent: list[TranscriptSegment] = []
         for i in range(3):
             await orch.process(
-                _SESSION, _landmark_frame(timestamp_ms=i), [_video_health()],
-                ModalityPath.SIGN, sent.append,
+                _SESSION,
+                _landmark_frame(timestamp_ms=i),
+                [_video_health()],
+                ModalityPath.SIGN,
+                sent.append,
             )
 
         # Should have: PARTIAL (TSL) + FINAL (gloss)
@@ -430,19 +505,27 @@ class TestProcessSign:
         )
         tsl._loaded = True
         gloss = _StubEngine(
-            _result(ModalityType.GLOSS_TO_TEXT, "Merhaba dünya.", 0.88), model_id="gemma"
+            _result(ModalityType.GLOSS_TO_TEXT, "Merhaba dünya.", 0.88),
+            model_id="gemma",
         )
         gloss._loaded = True
 
         orch = FusionOrchestrator(window_size=1)
         orch.register_policy(ModalityPath.SIGN, SignFusionPolicy())
-        orch.register_engine(ModalityPath.SIGN, ModalityType.TSL_RECOGNITION, tsl, _cfg("tsl"))
-        orch.register_engine(ModalityPath.SIGN, ModalityType.GLOSS_TO_TEXT, gloss, _cfg("gemma"))
+        orch.register_engine(
+            ModalityPath.SIGN, ModalityType.TSL_RECOGNITION, tsl, _cfg("tsl")
+        )
+        orch.register_engine(
+            ModalityPath.SIGN, ModalityType.GLOSS_TO_TEXT, gloss, _cfg("gemma")
+        )
 
         sent: list[TranscriptSegment] = []
         await orch.process(
-            _SESSION, _landmark_frame(), [_video_health()],
-            ModalityPath.SIGN, sent.append,
+            _SESSION,
+            _landmark_frame(),
+            [_video_health()],
+            ModalityPath.SIGN,
+            sent.append,
         )
         partial = next(s for s in sent if s.status == SegmentStatus.PARTIAL)
         final = next(s for s in sent if s.status == SegmentStatus.FINAL)
@@ -456,12 +539,17 @@ class TestProcessSign:
 
         orch = FusionOrchestrator(window_size=1)
         orch.register_policy(ModalityPath.SIGN, SignFusionPolicy())
-        orch.register_engine(ModalityPath.SIGN, ModalityType.TSL_RECOGNITION, tsl, _cfg("tsl"))
+        orch.register_engine(
+            ModalityPath.SIGN, ModalityType.TSL_RECOGNITION, tsl, _cfg("tsl")
+        )
 
         sent: list[TranscriptSegment] = []
         await orch.process(
-            _SESSION, _landmark_frame(), [_video_health()],
-            ModalityPath.SIGN, sent.append,
+            _SESSION,
+            _landmark_frame(),
+            [_video_health()],
+            ModalityPath.SIGN,
+            sent.append,
         )
         assert sent == []
 
@@ -475,13 +563,20 @@ class TestProcessSign:
 
         orch = FusionOrchestrator(window_size=1)
         orch.register_policy(ModalityPath.SIGN, SignFusionPolicy())
-        orch.register_engine(ModalityPath.SIGN, ModalityType.TSL_RECOGNITION, tsl, _cfg("tsl"))
-        orch.register_engine(ModalityPath.SIGN, ModalityType.GLOSS_TO_TEXT, gloss, _cfg("gemma"))
+        orch.register_engine(
+            ModalityPath.SIGN, ModalityType.TSL_RECOGNITION, tsl, _cfg("tsl")
+        )
+        orch.register_engine(
+            ModalityPath.SIGN, ModalityType.GLOSS_TO_TEXT, gloss, _cfg("gemma")
+        )
 
         sent: list[TranscriptSegment] = []
         await orch.process(
-            _SESSION, _landmark_frame(), [_video_health()],
-            ModalityPath.SIGN, sent.append,
+            _SESSION,
+            _landmark_frame(),
+            [_video_health()],
+            ModalityPath.SIGN,
+            sent.append,
         )
 
         # PARTIAL (TSL gloss) + FINAL (promoted from TSL on gloss timeout)
@@ -503,12 +598,17 @@ class TestProcessSign:
 
         orch = FusionOrchestrator(window_size=1)
         orch.register_policy(ModalityPath.SIGN, SignFusionPolicy())
-        orch.register_engine(ModalityPath.SIGN, ModalityType.TSL_RECOGNITION, tsl, _cfg("tsl"))
+        orch.register_engine(
+            ModalityPath.SIGN, ModalityType.TSL_RECOGNITION, tsl, _cfg("tsl")
+        )
 
         sent: list[TranscriptSegment] = []
         await orch.process(
-            _SESSION, _landmark_frame(), [_video_health()],
-            ModalityPath.SIGN, sent.append,
+            _SESSION,
+            _landmark_frame(),
+            [_video_health()],
+            ModalityPath.SIGN,
+            sent.append,
         )
         assert sent == []
 
@@ -516,7 +616,70 @@ class TestProcessSign:
         orch = _make_orchestrator(window_size=1, with_sign=True)
         sent: list[TranscriptSegment] = []
         await orch.process(
-            _SESSION, _audio_chunk(), [_audio_health()],
-            ModalityPath.SIGN, sent.append,
+            _SESSION,
+            _audio_chunk(),
+            [_audio_health()],
+            ModalityPath.SIGN,
+            sent.append,
         )
         assert sent == []
+
+
+# ---------------------------------------------------------------------------
+# reset_session()
+# ---------------------------------------------------------------------------
+
+
+class TestResetSession:
+    async def test_reset_clears_face_cache(self):
+        """After reset, a new audio chunk sees no cached face landmarks."""
+        orch = _make_orchestrator(with_speech=True)
+        # Populate face cache.
+        await orch.process(
+            _SESSION,
+            _landmark_frame(),
+            [_video_health()],
+            ModalityPath.SPEECH,
+            lambda _: None,
+        )
+        orch.reset_session(_SESSION)
+        # After reset, audio chunk should produce ASR-only output (no lip result).
+        sent: list[TranscriptSegment] = []
+        await orch.process(
+            _SESSION,
+            _audio_chunk(),
+            [_audio_health()],
+            ModalityPath.SPEECH,
+            sent.append,
+        )
+        assert all(seg.source == ModalityType.ASR for seg in sent)
+
+    async def test_reset_clears_accumulator_buffer(self):
+        """After reset, frame count restarts from zero."""
+        orch = _make_orchestrator(window_size=3, with_sign=True)
+        # Push 2 of 3 frames (window not yet full).
+        for i in range(2):
+            await orch.process(
+                _SESSION,
+                _landmark_frame(timestamp_ms=i),
+                [_video_health()],
+                ModalityPath.SIGN,
+                lambda _: None,
+            )
+        orch.reset_session(_SESSION)
+        # Push 2 more — should still not hit the window (buffer was cleared).
+        sent: list[TranscriptSegment] = []
+        for i in range(2):
+            await orch.process(
+                _SESSION,
+                _landmark_frame(timestamp_ms=i + 10),
+                [_video_health()],
+                ModalityPath.SIGN,
+                sent.append,
+            )
+        assert sent == []
+
+    def test_reset_unknown_session_is_safe(self):
+        """reset_session on a session with no state does not raise."""
+        orch = FusionOrchestrator()
+        orch.reset_session("nonexistent-session")  # must not raise


### PR DESCRIPTION
## What does this PR do?

Two things `SessionHandler` needs before it can exist.

`FrameAccumulator` goes in `sozia/fusion/`. `TslRecognitionEngine` needs a `(T, 474)` sequence — the gateway delivers one frame at a time. The accumulator buffers per session and emits when the window fills. Stays in fusion per R7.

`process()` is the entry point for `SessionHandler`. Takes a raw DTO and handles everything: DTO → numpy, engine calls, `send_fn` per segment. ASR + LipReading run in parallel on SPEECH. TSL → GlossToText runs sequentially on SIGN.

`register_engine()` gets a `ModalityType` key. Previously a list, so routing would have needed model ID string matching. Now it's a dict lookup.

GlossToText timeout: TSL partial gets promoted to FINAL with a confidence penalty. Better than dropping it.

## Which package(s) does it touch?

`sozia/fusion/` — new `frame_accumulator.py`, updated `orchestrator.py` and `__init__.py`

## How to test

```bash
conda activate sozia-server
pytest tests/fusion/ -v
```

314 tests, 94% total coverage, 97% on orchestrator.

## Checklist
- [x] Follows commit convention (`<type>(<scope>): <description>`)
- [x] Added/updated tests (if applicable)
- [x] No sozia.common schema changes (or: both repos updated)
- [x] Tested locally

Closes #16