### PR TITLE
feat(gateway): WebSocket gateway, session handler, and auth middleware

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,4 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+CLAUDE.md

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # sozia-server
 
-Cloud backend for the Sozia real-time multimodal transcription system.
-Receives anonymized features from the client, runs AI inference, fuses results,
-and streams `TranscriptSegment` objects back over WebSocket.
+Backend for the Sozia transcription system. Takes anonymized features from the client, runs inference, and streams transcript segments back over WebSocket.
 
 ---
 
@@ -25,39 +23,39 @@ pip install -e ".[dev]"
 
 ## Configuration
 
-All runtime configuration is read from environment variables at server startup.
+All config comes from environment variables.
 
 | Variable | Required | Default | Description |
 |---|---|---|---|
-| `SOZIA_API_KEY` | **Yes** | — | Shared secret clients include in every `session_init` payload. Use a strong random string in production. |
-| `SOZIA_DEVICE` | No | `cpu` | Compute device for inference: `"cpu"` or `"cuda"`. |
-| `SOZIA_WHISPER_WEIGHTS` | No | — | Absolute path to Whisper ASR weight file. Speech path disabled if unset. |
-| `SOZIA_LIP_WEIGHTS` | No | — | Absolute path to LipReading weight file. Supplementary — speech path continues without it. |
-| `SOZIA_TSL_WEIGHTS` | No | — | Absolute path to TSL recognition GRU weight file. Sign path disabled if unset. |
-| `SOZIA_GLOSS_WEIGHTS` | No | — | Absolute path to Gemma-9B LoRA weight directory. Sign path continues (with raw gloss fallback) without it. |
+| `SOZIA_API_KEY` | yes | — | Secret included in every `session_init` payload. Use something random in production. |
+| `SOZIA_DEVICE` | no | `cpu` | `"cpu"` or `"cuda"`. |
+| `SOZIA_WHISPER_WEIGHTS` | no | — | Path to Whisper ASR weights. Speech path is disabled if unset. |
+| `SOZIA_LIP_WEIGHTS` | no | — | Path to lip-reading weights. Optional — speech path works without it. |
+| `SOZIA_TSL_WEIGHTS` | no | — | Path to TSL recognition weights. Sign path is disabled if unset. |
+| `SOZIA_GLOSS_WEIGHTS` | no | — | Path to Gemma-9B LoRA weights. Sign path falls back to raw gloss if unset. |
 
-### Local development — `.env` file
+### Local development
 
-Create a `.env` file in the project root (already in `.gitignore`):
+Create a `.env` in the project root (already in `.gitignore`):
 
 ```dotenv
 SOZIA_API_KEY=dev-only-key-change-in-production
 SOZIA_DEVICE=cpu
 
-# Optional — omit if you don't have model weights locally
+# Omit these if you don't have weights locally
 # SOZIA_WHISPER_WEIGHTS=/path/to/whisper-small-tr.pt
 # SOZIA_LIP_WEIGHTS=/path/to/lip-reading-v1.pt
 # SOZIA_TSL_WEIGHTS=/path/to/tsl-gru-v1.pt
 # SOZIA_GLOSS_WEIGHTS=/path/to/gemma-9b-gloss-tr/
 ```
 
-Load it before starting the server:
+Load it before starting:
 
 ```bash
 export $(grep -v '^#' .env | xargs)
 ```
 
-Or use `python-dotenv` if you add it as a dev dependency.
+Or add `python-dotenv` as a dev dependency.
 
 ---
 
@@ -67,14 +65,11 @@ Or use `python-dotenv` if you add it as a dev dependency.
 uvicorn sozia.server:app --host 0.0.0.0 --port 8000 --reload
 ```
 
-For production (multi-worker with GPU):
+On a single GPU, keep workers at 1 — multiple workers each try to load the full model set and will run out of memory:
 
 ```bash
 uvicorn sozia.server:app --host 0.0.0.0 --port 8000 --workers 1
 ```
-
-> **Note:** Use `--workers 1` when running on a single GPU. Multiple workers each
-> try to load the full model set, which will exhaust GPU memory.
 
 ---
 
@@ -82,7 +77,9 @@ uvicorn sozia.server:app --host 0.0.0.0 --port 8000 --workers 1
 
 Connect to `ws://<host>:8000/ws`.
 
-### 1. session_init (first message from client)
+### session_init
+
+First message from the client:
 
 ```json
 {
@@ -93,20 +90,20 @@ Connect to `ws://<host>:8000/ws`.
 }
 ```
 
-`modality_path` is either `"SPEECH"` or `"SIGN"`.
+`modality_path` is `"SPEECH"` or `"SIGN"`.
 
-### 2. Status messages from server
+### Status frames
 
-After `session_init`, the server sends `session_status` frames:
+The server sends two status frames after init:
 
 ```json
 { "type": "session_status", "session_id": "...", "state": "INITIALIZING", "message": "" }
 { "type": "session_status", "session_id": "...", "state": "RUNNING",       "message": "" }
 ```
 
-### 3. Feature messages from client
+### Feature messages from client
 
-**LandmarkFrame** (for SIGN path, or face cache for SPEECH):
+LandmarkFrame (SIGN path, or face cache for SPEECH):
 ```json
 {
   "type": "landmark_frame",
@@ -119,7 +116,7 @@ After `session_init`, the server sends `session_status` frames:
 }
 ```
 
-**AudioFeatureChunk** (for SPEECH path):
+AudioFeatureChunk (SPEECH path):
 ```json
 {
   "type": "audio_feature_chunk",
@@ -132,7 +129,7 @@ After `session_init`, the server sends `session_status` frames:
 }
 ```
 
-**PipelineHealth** (periodic, either path):
+PipelineHealth (periodic, either path):
 ```json
 {
   "type": "pipeline_health",
@@ -146,7 +143,7 @@ After `session_init`, the server sends `session_status` frames:
 }
 ```
 
-### 4. TranscriptSegment from server
+### TranscriptSegment from server
 
 ```json
 {
@@ -164,7 +161,7 @@ After `session_init`, the server sends `session_status` frames:
 }
 ```
 
-### 5. Ending a session
+### Ending a session
 
 ```json
 { "type": "session_end" }
@@ -175,31 +172,24 @@ After `session_init`, the server sends `session_status` frames:
 | Code | Meaning |
 |------|---------|
 | 4001 | Auth failed — bad or missing `api_key` |
-| 4002 | Malformed `session_init` payload |
-| 4003 | Duplicate `session_id` — already active |
-| 4004 | Model warm-up failed (server error) |
+| 4002 | Malformed `session_init` |
+| 4003 | Duplicate `session_id` |
+| 4004 | Model warm-up failed |
 
 ---
 
 ## Development
 
 ```bash
-# Run tests with coverage
-pytest
-
-# Run only the API layer tests
-pytest tests/api/
-
-# Type check
-mypy sozia/
+pytest              # run tests with coverage
+pytest tests/api/   # API layer only
+mypy sozia/         # type check
 ```
 
 ---
 
 ## Model weights
 
-Weights are **not committed to this repository**. Download them from the shared
-Google Drive or GitHub Release assets in `sozia-research`, then point the env
-vars at the local paths.
+Weights aren't in this repo. Get them from the shared Google Drive or the GitHub release assets in `sozia-research`, then set the env vars to the local paths.
 
-A `download_models.sh` helper script will be added in a future release.
+A `download_models.sh` script is coming.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,212 @@
 # sozia-server
-Sozia cloud backend
+
+Cloud backend for the Sozia real-time multimodal transcription system.
+Receives anonymized features from the client, runs AI inference, fuses results,
+and streams `TranscriptSegment` objects back over WebSocket.
+
+---
+
+## Requirements
+
+- Python 3.11+
+- conda (recommended) or a standard venv
+
+---
+
+## Installation
+
+```bash
+conda create -n sozia-server python=3.11
+conda activate sozia-server
+pip install -e ".[dev]"
+```
+
+---
+
+## Configuration
+
+All runtime configuration is read from environment variables at server startup.
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `SOZIA_API_KEY` | **Yes** | — | Shared secret clients include in every `session_init` payload. Use a strong random string in production. |
+| `SOZIA_DEVICE` | No | `cpu` | Compute device for inference: `"cpu"` or `"cuda"`. |
+| `SOZIA_WHISPER_WEIGHTS` | No | — | Absolute path to Whisper ASR weight file. Speech path disabled if unset. |
+| `SOZIA_LIP_WEIGHTS` | No | — | Absolute path to LipReading weight file. Supplementary — speech path continues without it. |
+| `SOZIA_TSL_WEIGHTS` | No | — | Absolute path to TSL recognition GRU weight file. Sign path disabled if unset. |
+| `SOZIA_GLOSS_WEIGHTS` | No | — | Absolute path to Gemma-9B LoRA weight directory. Sign path continues (with raw gloss fallback) without it. |
+
+### Local development — `.env` file
+
+Create a `.env` file in the project root (already in `.gitignore`):
+
+```dotenv
+SOZIA_API_KEY=dev-only-key-change-in-production
+SOZIA_DEVICE=cpu
+
+# Optional — omit if you don't have model weights locally
+# SOZIA_WHISPER_WEIGHTS=/path/to/whisper-small-tr.pt
+# SOZIA_LIP_WEIGHTS=/path/to/lip-reading-v1.pt
+# SOZIA_TSL_WEIGHTS=/path/to/tsl-gru-v1.pt
+# SOZIA_GLOSS_WEIGHTS=/path/to/gemma-9b-gloss-tr/
+```
+
+Load it before starting the server:
+
+```bash
+export $(grep -v '^#' .env | xargs)
+```
+
+Or use `python-dotenv` if you add it as a dev dependency.
+
+---
+
+## Running the server
+
+```bash
+uvicorn sozia.server:app --host 0.0.0.0 --port 8000 --reload
+```
+
+For production (multi-worker with GPU):
+
+```bash
+uvicorn sozia.server:app --host 0.0.0.0 --port 8000 --workers 1
+```
+
+> **Note:** Use `--workers 1` when running on a single GPU. Multiple workers each
+> try to load the full model set, which will exhaust GPU memory.
+
+---
+
+## WebSocket protocol
+
+Connect to `ws://<host>:8000/ws`.
+
+### 1. session_init (first message from client)
+
+```json
+{
+  "type": "session_init",
+  "session_id": "<uuid-v4>",
+  "modality_path": "SPEECH",
+  "api_key": "<SOZIA_API_KEY>"
+}
+```
+
+`modality_path` is either `"SPEECH"` or `"SIGN"`.
+
+### 2. Status messages from server
+
+After `session_init`, the server sends `session_status` frames:
+
+```json
+{ "type": "session_status", "session_id": "...", "state": "INITIALIZING", "message": "" }
+{ "type": "session_status", "session_id": "...", "state": "RUNNING",       "message": "" }
+```
+
+### 3. Feature messages from client
+
+**LandmarkFrame** (for SIGN path, or face cache for SPEECH):
+```json
+{
+  "type": "landmark_frame",
+  "session_id": "...",
+  "timestamp_ms": 1000,
+  "face_landmarks": [[x,y,z], ...],
+  "left_hand_landmarks": null,
+  "right_hand_landmarks": null,
+  "pose_landmarks": null
+}
+```
+
+**AudioFeatureChunk** (for SPEECH path):
+```json
+{
+  "type": "audio_feature_chunk",
+  "session_id": "...",
+  "timestamp_ms": 2000,
+  "features": [[...], ...],
+  "feature_type": "mfcc",
+  "sample_rate_hz": 16000,
+  "chunk_duration_ms": 500
+}
+```
+
+**PipelineHealth** (periodic, either path):
+```json
+{
+  "type": "pipeline_health",
+  "session_id": "...",
+  "pipeline": "audio",
+  "available": true,
+  "fps": null,
+  "snr": 18.5,
+  "face_detected": null,
+  "last_updated_ms": 1500
+}
+```
+
+### 4. TranscriptSegment from server
+
+```json
+{
+  "type": "transcript_segment",
+  "segment_id": "<uuid>",
+  "session_id": "...",
+  "status": "PARTIAL",
+  "text": "merhaba dünya",
+  "source": "ASR",
+  "confidence": 0.87,
+  "timestamp_ms": 1000,
+  "duration_ms": 500,
+  "created_at_ms": 1700000000000,
+  "replaces_segment_id": null
+}
+```
+
+### 5. Ending a session
+
+```json
+{ "type": "session_end" }
+```
+
+### Close codes
+
+| Code | Meaning |
+|------|---------|
+| 4001 | Auth failed — bad or missing `api_key` |
+| 4002 | Malformed `session_init` payload |
+| 4003 | Duplicate `session_id` — already active |
+| 4004 | Model warm-up failed (server error) |
+
+---
+
+## Development
+
+```bash
+# Run tests with coverage
+pytest
+
+# Run only the API layer tests
+pytest tests/api/
+
+# Type check
+mypy sozia/
+```
+
+---
+
+## Model weights
+
+Weights are **not committed to this repository**. Download them from the shared
+Google Drive or GitHub Release assets in `sozia-research`, then point the env
+vars at the local paths.
+
+A `download_models.sh` helper script will be added in a future release.
+
+---
+
+## Architecture
+
+See [`CLAUDE.md`](CLAUDE.md) for the full module guide, dependency rules,
+latency budget, and design decisions.

--- a/README.md
+++ b/README.md
@@ -203,10 +203,3 @@ Google Drive or GitHub Release assets in `sozia-research`, then point the env
 vars at the local paths.
 
 A `download_models.sh` helper script will be added in a future release.
-
----
-
-## Architecture
-
-See [`CLAUDE.md`](CLAUDE.md) for the full module guide, dependency rules,
-latency budget, and design decisions.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,18 @@ build-backend = "setuptools.backends.legacy:build"
 name = "sozia-server"
 version = "0.1.0"
 requires-python = ">=3.11"
+dependencies = [
+    "fastapi>=0.115",
+    "uvicorn[standard]>=0.34",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8",
+    "pytest-asyncio>=1.3",
+    "pytest-cov>=7",
+    "httpx>=0.27",
+]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/sozia/api/__init__.py
+++ b/sozia/api/__init__.py
@@ -1,0 +1,13 @@
+"""sozia.api — WebSocket gateway layer.
+
+Public surface:
+    AuthMiddleware    — API key authentication for WebSocket connections.
+    SessionHandler    — Per-session WebSocket receive/send loop.
+    WebSocketGateway  — Manages all active sessions.
+"""
+
+from sozia.api.auth_middleware import AuthMiddleware
+from sozia.api.gateway import WebSocketGateway
+from sozia.api.session_handler import SessionHandler
+
+__all__ = ["AuthMiddleware", "SessionHandler", "WebSocketGateway"]

--- a/sozia/api/auth_middleware.py
+++ b/sozia/api/auth_middleware.py
@@ -1,0 +1,72 @@
+"""AuthMiddleware — API key authentication for WebSocket connections.
+
+The client sends the API key inside the ``session_init`` JSON payload because
+browsers cannot set custom HTTP headers on WebSocket upgrade requests.
+
+Timing-safe comparison is done via ``hmac.compare_digest`` to prevent
+timing-based side-channel attacks.
+"""
+
+from __future__ import annotations
+
+import hmac
+import os
+
+
+class AuthMiddleware:
+    """Validates per-connection API keys.
+
+    Args:
+        api_key: The expected API key.  Must be non-empty.
+
+    Raises:
+        ValueError: If ``api_key`` is empty.
+    """
+
+    def __init__(self, api_key: str) -> None:
+        if not api_key:
+            raise ValueError("api_key must be a non-empty string")
+        self._api_key = api_key
+
+    # ------------------------------------------------------------------
+    # Factory
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def from_env(cls, env_var: str = "SOZIA_API_KEY") -> AuthMiddleware:
+        """Construct from an environment variable.
+
+        Args:
+            env_var: Name of the environment variable holding the key.
+                Defaults to ``"SOZIA_API_KEY"``.
+
+        Raises:
+            EnvironmentError: The environment variable is not set.
+        """
+        key = os.environ.get(env_var)
+        if not key:
+            raise EnvironmentError(
+                f"{env_var} environment variable is not set. "
+                "Set it to a strong random string before starting the server."
+            )
+        return cls(api_key=key)
+
+    # ------------------------------------------------------------------
+    # Authentication
+    # ------------------------------------------------------------------
+
+    def authenticate(self, provided_key: str) -> bool:
+        """Return True if ``provided_key`` matches the configured API key.
+
+        Uses ``hmac.compare_digest`` to prevent timing-based attacks.
+        Returns False for any empty or mismatched input without raising.
+
+        Args:
+            provided_key: The key extracted from the ``session_init`` payload.
+        """
+        if not provided_key:
+            return False
+        return hmac.compare_digest(
+            self._api_key.encode(),
+            provided_key.encode(),
+        )

--- a/sozia/api/gateway.py
+++ b/sozia/api/gateway.py
@@ -1,0 +1,243 @@
+"""WebSocketGateway — entry point for all WebSocket connections.
+
+One gateway instance runs for the life of the FastAPI application. It
+accepts connections, authenticates them, negotiates ``session_init``, and
+delegates message handling to per-session ``SessionHandler`` instances.
+
+Close code semantics (per LLD):
+    4001 — authentication failure (bad or missing api_key)
+    4002 — malformed session_init payload
+    4003 — duplicate session_id (session already active)
+    4004 — model warm-up failed (server-side error)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+import json
+import logging
+from typing import TYPE_CHECKING, Any, Callable
+
+from starlette.websockets import WebSocketDisconnect
+
+from sozia.api.auth_middleware import AuthMiddleware
+from sozia.api.session_handler import SessionHandler
+from sozia.common.models import (
+    ModalityPath,
+    SessionState,
+    SessionStatusMessage,
+)
+
+if TYPE_CHECKING:
+    from fastapi import WebSocket
+
+    from sozia.fusion.orchestrator import FusionOrchestrator
+
+logger = logging.getLogger(__name__)
+
+
+class WebSocketGateway:
+    """Manages all active WebSocket sessions.
+
+    Args:
+        auth: The AuthMiddleware used to validate API keys.
+        orchestrator_factory: Callable that returns a new FusionOrchestrator
+            for each accepted session.  Receives ``(session_id, modality_path)``
+            as arguments.
+    """
+
+    def __init__(
+        self,
+        auth: AuthMiddleware,
+        orchestrator_factory: Callable[..., FusionOrchestrator],
+    ) -> None:
+        self._auth = auth
+        self._orchestrator_factory = orchestrator_factory
+        self.active_sessions: dict[str, SessionHandler] = {}
+        self._lock = asyncio.Lock()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    async def on_connect(self, websocket: WebSocket) -> None:
+        """Handle the full lifecycle of a single WebSocket connection.
+
+        Steps:
+        1. Accept the connection.
+        2. Read the first message and expect ``session_init``.
+        3. Authenticate via api_key.
+        4. Validate the session_init payload.
+        5. Reject duplicate sessions.
+        6. Create orchestrator and warm up.
+        7. Run the receive loop until disconnect.
+        8. Clean up on exit.
+
+        Close codes: 4001 auth, 4002 bad init, 4003 duplicate, 4004 warm-up.
+        """
+        await websocket.accept()
+
+        # Step 2 — read session_init.
+        try:
+            init_msg = await websocket.receive_json()
+        except WebSocketDisconnect:
+            return
+
+        # Step 3 — authenticate.
+        provided_key = init_msg.get("api_key", "")
+        if not self._auth.authenticate(provided_key):
+            await self._error_close(websocket, init_msg.get("session_id", ""), 4001)
+            return
+
+        # Step 4 — parse session_init.
+        session_id, modality_path = self._parse_session_init(init_msg)
+        if session_id is None or modality_path is None:
+            await self._error_close(websocket, init_msg.get("session_id", ""), 4002)
+            return
+
+        # Step 5 — reject duplicates.
+        async with self._lock:
+            if session_id in self.active_sessions:
+                await self._error_close(websocket, session_id, 4003)
+                return
+
+            # Reserve the slot immediately so a concurrent connection with
+            # the same session_id cannot race past the duplicate check.
+            self.active_sessions[session_id] = None  # type: ignore[assignment]
+
+        # Step 6 — create orchestrator and warm up.
+        orchestrator = self._orchestrator_factory(session_id, modality_path)
+
+        # Send INITIALIZING before warm-up so the client knows we're working.
+        await self._send_status(websocket, session_id, SessionState.INITIALIZING)
+
+        try:
+            await orchestrator.warm_up(modality_path)
+        except Exception as exc:
+            logger.exception("Warm-up failed for session %s: %s", session_id, exc)
+            async with self._lock:
+                self.active_sessions.pop(session_id, None)
+            await self._error_close(websocket, session_id, 4004)
+            return
+
+        # Step 7 — run the session.
+        handler = SessionHandler(
+            session_id=session_id,
+            modality_path=modality_path,
+            websocket=websocket,
+            orchestrator=orchestrator,
+        )
+        async with self._lock:
+            self.active_sessions[session_id] = handler
+
+        await self._send_status(websocket, session_id, SessionState.RUNNING)
+
+        try:
+            await handler.receive_loop()
+        finally:
+            # Step 8 — clean up regardless of how the loop ended.
+            await self.on_disconnect(session_id)
+
+    async def on_disconnect(self, session_id: str) -> None:
+        """Tear down the session identified by ``session_id``.
+
+        Removes it from ``active_sessions`` and calls ``cool_down()`` on
+        the orchestrator.  Safe to call even if the session is unknown.
+
+        Args:
+            session_id: The session to remove.
+        """
+        async with self._lock:
+            handler = self.active_sessions.pop(session_id, None)
+
+        if handler is not None and hasattr(handler, "_orchestrator"):
+            try:
+                await handler._orchestrator.cool_down()
+            except Exception:
+                logger.exception("cool_down failed for session %s", session_id)
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _parse_session_init(
+        msg: dict[str, Any],
+    ) -> tuple[str | None, ModalityPath | None]:
+        """Extract and validate session_id + modality_path from session_init.
+
+        Returns ``(None, None)`` if the message is invalid.
+        """
+        if msg.get("type") != "session_init":
+            return None, None
+
+        session_id = msg.get("session_id")
+        if not session_id or not isinstance(session_id, str):
+            return None, None
+
+        raw_path = msg.get("modality_path")
+        try:
+            modality_path = ModalityPath(raw_path)
+        except (ValueError, KeyError):
+            return None, None
+
+        return session_id, modality_path
+
+    @staticmethod
+    async def _send_status(
+        websocket: WebSocket,
+        session_id: str,
+        state: SessionState,
+        message: str = "",
+    ) -> None:
+        """Send a SessionStatusMessage JSON frame to the client.
+
+        Args:
+            websocket: The active WebSocket connection.
+            session_id: Current session identifier.
+            state: The lifecycle state to report.
+            message: Optional human-readable detail for the client UI.
+        """
+        status = SessionStatusMessage(
+            session_id=session_id,
+            state=state,
+            message=message,
+        )
+        payload = dataclasses.asdict(status)
+        payload["type"] = "session_status"
+        payload["state"] = state.value
+        await websocket.send_text(json.dumps(payload))
+
+    @staticmethod
+    async def _error_close(
+        websocket: WebSocket,
+        session_id: str,
+        code: int,
+    ) -> None:
+        """Send an error payload then close the WebSocket with ``code``.
+
+        Args:
+            websocket: The WebSocket to close.
+            session_id: Session identifier (may be empty if init failed early).
+            code: Application-level close code (4001–4004).
+        """
+        _MESSAGES = {
+            4001: "Authentication failed — invalid or missing api_key.",
+            4002: "Malformed session_init payload.",
+            4003: "Session already active for this session_id.",
+            4004: "Model warm-up failed — server error.",
+        }
+        error_payload = json.dumps(
+            {
+                "type": "error",
+                "session_id": session_id,
+                "code": code,
+                "message": _MESSAGES.get(code, "Unknown error."),
+            }
+        )
+        try:
+            await websocket.send_text(error_payload)
+        except Exception:
+            pass
+        await websocket.close(code=code)

--- a/sozia/api/gateway.py
+++ b/sozia/api/gateway.py
@@ -139,6 +139,24 @@ class WebSocketGateway:
             # Step 8 — clean up regardless of how the loop ended.
             await self.on_disconnect(session_id)
 
+    async def shutdown_all_sessions(self) -> None:
+        """Close every active session during server shutdown.
+
+        Drains ``active_sessions`` and calls ``close()`` on each handler so
+        that per-session orchestrators release GPU memory before
+        ``ModelRegistry.unload_all()`` is called.
+        """
+        async with self._lock:
+            handlers = list(self.active_sessions.values())
+            self.active_sessions.clear()
+
+        for handler in handlers:
+            if handler is not None:
+                try:
+                    await handler.close()
+                except Exception:
+                    logger.exception("close failed during server shutdown")
+
     async def on_disconnect(self, session_id: str) -> None:
         """Tear down the session identified by ``session_id``.
 

--- a/sozia/api/gateway.py
+++ b/sozia/api/gateway.py
@@ -78,9 +78,12 @@ class WebSocketGateway:
         """
         await websocket.accept()
 
-        # Step 2 — read session_init.
+        # Step 2 — read session_init (5-second deadline to prevent idle DoS).
         try:
-            init_msg = await websocket.receive_json()
+            init_msg = await asyncio.wait_for(websocket.receive_json(), timeout=5.0)
+        except asyncio.TimeoutError:
+            await self._error_close(websocket, "", 4002)
+            return
         except WebSocketDisconnect:
             return
 

--- a/sozia/api/gateway.py
+++ b/sozia/api/gateway.py
@@ -151,9 +151,9 @@ class WebSocketGateway:
         async with self._lock:
             handler = self.active_sessions.pop(session_id, None)
 
-        if handler is not None and hasattr(handler, "_orchestrator"):
+        if handler is not None:
             try:
-                await handler._orchestrator.cool_down()
+                await handler.close()
             except Exception:
                 logger.exception("cool_down failed for session %s", session_id)
 

--- a/sozia/api/session_handler.py
+++ b/sozia/api/session_handler.py
@@ -109,7 +109,7 @@ class SessionHandler:
 
     async def _handle_landmark(self, data: dict) -> None:
         frame = LandmarkFrame(
-            session_id=data["session_id"],
+            session_id=self.session_id,
             timestamp_ms=data["timestamp_ms"],
             face_landmarks=data.get("face_landmarks"),
             left_hand_landmarks=data.get("left_hand_landmarks"),
@@ -126,7 +126,7 @@ class SessionHandler:
 
     async def _handle_audio(self, data: dict) -> None:
         chunk = AudioFeatureChunk(
-            session_id=data["session_id"],
+            session_id=self.session_id,
             timestamp_ms=data["timestamp_ms"],
             features=data["features"],
             feature_type=data["feature_type"],

--- a/sozia/api/session_handler.py
+++ b/sozia/api/session_handler.py
@@ -1,0 +1,155 @@
+"""SessionHandler — per-connection WebSocket session manager.
+
+One SessionHandler is created per accepted WebSocket connection. It owns
+the receive loop, deserializes inbound messages, and forwards them to the
+FusionOrchestrator. Outbound TranscriptSegments are serialised and sent
+back over the same connection.
+
+Dependency rule R7: only sozia.server.fusion produces TranscriptSegments.
+SessionHandler only sends them.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+from typing import TYPE_CHECKING
+
+from starlette.websockets import WebSocketDisconnect
+
+from sozia.common.models import (
+    AudioFeatureChunk,
+    LandmarkFrame,
+    ModalityPath,
+    ModalityType,
+    PipelineHealth,
+    TranscriptSegment,
+)
+
+if TYPE_CHECKING:
+    from fastapi import WebSocket
+
+    from sozia.fusion.orchestrator import FusionOrchestrator
+
+
+class SessionHandler:
+    """Manages one WebSocket session end-to-end.
+
+    Args:
+        session_id: UUID v4 of the session (from ``session_init``).
+        modality_path: The active inference pipeline (SPEECH or SIGN).
+        websocket: The accepted FastAPI/Starlette WebSocket object.
+        orchestrator: The FusionOrchestrator that handles inference.
+    """
+
+    def __init__(
+        self,
+        session_id: str,
+        modality_path: ModalityPath,
+        websocket: WebSocket,
+        orchestrator: FusionOrchestrator,
+    ) -> None:
+        self.session_id = session_id
+        self.modality_path = modality_path
+        self._ws = websocket
+        self._orchestrator = orchestrator
+        self.latest_health: dict[str, PipelineHealth] = {}
+
+    # ------------------------------------------------------------------
+    # Outbound
+    # ------------------------------------------------------------------
+
+    async def send_segment(self, segment: TranscriptSegment) -> None:
+        """Serialise ``segment`` and send it over the WebSocket.
+
+        Enum fields are serialised as their string values.  The payload
+        includes a ``"type": "transcript_segment"`` discriminator.
+
+        Args:
+            segment: The TranscriptSegment to send.
+        """
+        payload = dataclasses.asdict(segment)
+        # Serialise enum values to their string representation.
+        payload["status"] = segment.status.value
+        payload["source"] = segment.source.value
+        payload["type"] = "transcript_segment"
+        await self._ws.send_text(json.dumps(payload))
+
+    # ------------------------------------------------------------------
+    # Inbound loop
+    # ------------------------------------------------------------------
+
+    async def receive_loop(self) -> None:
+        """Read messages from the WebSocket and dispatch by type.
+
+        Runs until the client sends ``{"type": "session_end"}`` or the
+        connection is closed (``WebSocketDisconnect``).  Unknown message
+        types are silently ignored.
+        """
+        while True:
+            try:
+                data = await self._ws.receive_json()
+            except WebSocketDisconnect:
+                break
+
+            msg_type = data.get("type")
+
+            if msg_type == "session_end":
+                break
+            elif msg_type == "landmark_frame":
+                await self._handle_landmark(data)
+            elif msg_type == "audio_feature_chunk":
+                await self._handle_audio(data)
+            elif msg_type == "pipeline_health":
+                self._handle_health(data)
+            # Unknown types are silently ignored per spec.
+
+    # ------------------------------------------------------------------
+    # Dispatch helpers
+    # ------------------------------------------------------------------
+
+    async def _handle_landmark(self, data: dict) -> None:
+        frame = LandmarkFrame(
+            session_id=data["session_id"],
+            timestamp_ms=data["timestamp_ms"],
+            face_landmarks=data.get("face_landmarks"),
+            left_hand_landmarks=data.get("left_hand_landmarks"),
+            right_hand_landmarks=data.get("right_hand_landmarks"),
+            pose_landmarks=data.get("pose_landmarks"),
+        )
+        await self._orchestrator.process(
+            self.session_id,
+            frame,
+            list(self.latest_health.values()),
+            self.modality_path,
+            self.send_segment,
+        )
+
+    async def _handle_audio(self, data: dict) -> None:
+        chunk = AudioFeatureChunk(
+            session_id=data["session_id"],
+            timestamp_ms=data["timestamp_ms"],
+            features=data["features"],
+            feature_type=data["feature_type"],
+            sample_rate_hz=data["sample_rate_hz"],
+            chunk_duration_ms=data["chunk_duration_ms"],
+        )
+        await self._orchestrator.process(
+            self.session_id,
+            chunk,
+            list(self.latest_health.values()),
+            self.modality_path,
+            self.send_segment,
+        )
+
+    def _handle_health(self, data: dict) -> None:
+        health = PipelineHealth(
+            session_id=data["session_id"],
+            pipeline=data["pipeline"],
+            available=data["available"],
+            fps=data.get("fps"),
+            snr=data.get("snr"),
+            face_detected=data.get("face_detected"),
+            last_updated_ms=data["last_updated_ms"],
+        )
+        self.latest_health[health.pipeline] = health

--- a/sozia/api/session_handler.py
+++ b/sozia/api/session_handler.py
@@ -75,6 +75,17 @@ class SessionHandler:
         await self._ws.send_text(json.dumps(payload))
 
     # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def close(self) -> None:
+        """Release orchestrator resources for this session.
+
+        Called by the gateway on both graceful disconnect and server shutdown.
+        """
+        await self._orchestrator.cool_down()
+
+    # ------------------------------------------------------------------
     # Inbound loop
     # ------------------------------------------------------------------
 

--- a/sozia/api/session_handler.py
+++ b/sozia/api/session_handler.py
@@ -21,7 +21,6 @@ from sozia.common.models import (
     AudioFeatureChunk,
     LandmarkFrame,
     ModalityPath,
-    ModalityType,
     PipelineHealth,
     TranscriptSegment,
 )

--- a/sozia/server.py
+++ b/sozia/server.py
@@ -219,7 +219,9 @@ def create_app(auth: AuthMiddleware | None = None) -> FastAPI:
 
         yield
 
-        # Shutdown — release all loaded models.
+        # Shutdown — close per-session orchestrators first so their engines
+        # release GPU memory, then clean up anything the registry still holds.
+        await gateway.shutdown_all_sessions()
         await registry.unload_all()
         logger.info("All models unloaded. Server shutting down.")
 

--- a/sozia/server.py
+++ b/sozia/server.py
@@ -1,0 +1,240 @@
+"""Sozia server entry point.
+
+Builds the FastAPI application, registers the ``/ws`` WebSocket endpoint,
+and wires up the startup/shutdown lifecycle:
+
+  startup  — create auth + gateway; register all four engine classes on the
+             ModelRegistry singleton so it can resolve prefixes on warm_up.
+  shutdown — call ``registry.unload_all()`` to release GPU memory cleanly.
+
+Configuration is driven entirely by environment variables (see README).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from contextlib import asynccontextmanager
+from typing import AsyncGenerator
+
+from fastapi import FastAPI, WebSocket
+
+from sozia.api.auth_middleware import AuthMiddleware
+from sozia.api.gateway import WebSocketGateway
+from sozia.common.models import ModalityPath, ModalityType, ModelConfig
+from sozia.fusion.degraded_mode_handler import DegradedModeHandler
+from sozia.fusion.orchestrator import FusionOrchestrator
+from sozia.fusion.sign_fusion_policy import SignFusionPolicy
+from sozia.fusion.speech_fusion_policy import SpeechFusionPolicy
+from sozia.inference.sign.gloss_to_text_engine import GlossToTextEngine
+from sozia.inference.sign.tsl_recognition_engine import TslRecognitionEngine
+from sozia.inference.speech.lip_reading_engine import LipReadingEngine
+from sozia.inference.speech.whisper_asr_engine import WhisperAsrEngine
+from sozia.registry.model_registry import ModelRegistry
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Environment variable names (public so tests can monkeypatch by name)
+# ---------------------------------------------------------------------------
+
+ENV_API_KEY = "SOZIA_API_KEY"
+ENV_DEVICE = "SOZIA_DEVICE"
+ENV_WHISPER_WEIGHTS = "SOZIA_WHISPER_WEIGHTS"
+ENV_LIP_WEIGHTS = "SOZIA_LIP_WEIGHTS"
+ENV_TSL_WEIGHTS = "SOZIA_TSL_WEIGHTS"
+ENV_GLOSS_WEIGHTS = "SOZIA_GLOSS_WEIGHTS"
+
+_DEFAULT_DEVICE = "cpu"
+
+
+# ---------------------------------------------------------------------------
+# Config helpers
+# ---------------------------------------------------------------------------
+
+
+def _device() -> str:
+    return os.environ.get(ENV_DEVICE, _DEFAULT_DEVICE)
+
+
+def _weights(env_var: str) -> str | None:
+    return os.environ.get(env_var) or None
+
+
+def _speech_configs(device: str) -> tuple[ModelConfig | None, ModelConfig | None]:
+    """Return (asr_config, lip_config); None where weights are not configured."""
+    asr_path = _weights(ENV_WHISPER_WEIGHTS)
+    lip_path = _weights(ENV_LIP_WEIGHTS)
+
+    asr_cfg = (
+        ModelConfig(
+            model_id="whisper-small-tr",
+            weights_path=asr_path,
+            device=device,
+            params={},
+        )
+        if asr_path
+        else None
+    )
+    lip_cfg = (
+        ModelConfig(
+            model_id="lip-reading-v1",
+            weights_path=lip_path,
+            device=device,
+            params={},
+        )
+        if lip_path
+        else None
+    )
+    return asr_cfg, lip_cfg
+
+
+def _sign_configs(device: str) -> tuple[ModelConfig | None, ModelConfig | None]:
+    """Return (tsl_config, gloss_config); None where weights are not configured."""
+    tsl_path = _weights(ENV_TSL_WEIGHTS)
+    gloss_path = _weights(ENV_GLOSS_WEIGHTS)
+
+    tsl_cfg = (
+        ModelConfig(
+            model_id="tsl-gru-v1",
+            weights_path=tsl_path,
+            device=device,
+            params={},
+        )
+        if tsl_path
+        else None
+    )
+    gloss_cfg = (
+        ModelConfig(
+            model_id="gemma-9b-gloss-tr",
+            weights_path=gloss_path,
+            device=device,
+            params={},
+        )
+        if gloss_path
+        else None
+    )
+    return tsl_cfg, gloss_cfg
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator factory
+# ---------------------------------------------------------------------------
+
+
+def _make_orchestrator_factory(device: str):
+    """Return a callable ``(session_id, modality_path) -> FusionOrchestrator``.
+
+    Each call produces a new orchestrator pre-wired with policies and engine
+    instances for the requested path.  The engines are instantiated here but
+    not loaded; ``warm_up()`` triggers the actual weight loading.
+
+    Note: engine instances are created fresh per-session because the GPU
+    memory is owned by each engine object.  The ModelRegistry is used for
+    prefix resolution (Rule R6 — engine classes registered at startup).
+
+    Args:
+        device: Compute device string (``"cpu"`` or ``"cuda"``).
+    """
+
+    def factory(session_id: str, modality_path: ModalityPath) -> FusionOrchestrator:
+        orchestrator = FusionOrchestrator(degraded_handler=DegradedModeHandler())
+        orchestrator.register_policy(ModalityPath.SPEECH, SpeechFusionPolicy())
+        orchestrator.register_policy(ModalityPath.SIGN, SignFusionPolicy())
+
+        if modality_path == ModalityPath.SPEECH:
+            asr_cfg, lip_cfg = _speech_configs(device)
+            if asr_cfg:
+                orchestrator.register_engine(
+                    ModalityPath.SPEECH,
+                    ModalityType.ASR,
+                    WhisperAsrEngine(),
+                    asr_cfg,
+                )
+            if lip_cfg:
+                orchestrator.register_engine(
+                    ModalityPath.SPEECH,
+                    ModalityType.LIP_READING,
+                    LipReadingEngine(),
+                    lip_cfg,
+                )
+        else:
+            tsl_cfg, gloss_cfg = _sign_configs(device)
+            if tsl_cfg:
+                orchestrator.register_engine(
+                    ModalityPath.SIGN,
+                    ModalityType.TSL_RECOGNITION,
+                    TslRecognitionEngine(),
+                    tsl_cfg,
+                )
+            if gloss_cfg:
+                orchestrator.register_engine(
+                    ModalityPath.SIGN,
+                    ModalityType.GLOSS_TO_TEXT,
+                    GlossToTextEngine(),
+                    gloss_cfg,
+                )
+
+        return orchestrator
+
+    return factory
+
+
+# ---------------------------------------------------------------------------
+# Application factory
+# ---------------------------------------------------------------------------
+
+
+def create_app(auth: AuthMiddleware | None = None) -> FastAPI:
+    """Build and return the configured FastAPI application.
+
+    Accepts an optional ``auth`` override so tests can inject a
+    pre-configured middleware without needing ``SOZIA_API_KEY`` set.
+
+    Args:
+        auth: If provided, used as-is.  If None, ``AuthMiddleware.from_env()``
+            is called during the lifespan startup event.
+    """
+    registry = ModelRegistry.get_instance()
+
+    @asynccontextmanager
+    async def lifespan(application: FastAPI) -> AsyncGenerator[None, None]:
+        device = _device()
+
+        # Resolve auth — either injected (tests) or from environment.
+        resolved_auth = auth if auth is not None else AuthMiddleware.from_env()
+
+        # Register engine classes so registry can resolve prefixes.
+        registry.register_engine_class("whisper", WhisperAsrEngine)
+        registry.register_engine_class("lip-reading", LipReadingEngine)
+        registry.register_engine_class("tsl-gru", TslRecognitionEngine)
+        registry.register_engine_class("gemma", GlossToTextEngine)
+        logger.info("Engine classes registered. Device: %s", device)
+
+        gateway = WebSocketGateway(
+            auth=resolved_auth,
+            orchestrator_factory=_make_orchestrator_factory(device),
+        )
+        application.state.gateway = gateway
+
+        yield
+
+        # Shutdown — release all loaded models.
+        await registry.unload_all()
+        logger.info("All models unloaded. Server shutting down.")
+
+    application = FastAPI(title="Sozia Server", lifespan=lifespan)
+
+    @application.websocket("/ws")
+    async def websocket_endpoint(websocket: WebSocket) -> None:
+        await websocket.app.state.gateway.on_connect(websocket)
+
+    return application
+
+
+# ---------------------------------------------------------------------------
+# Module-level app instance — used by ``uvicorn sozia.server:app``.
+# Auth is resolved from SOZIA_API_KEY during lifespan startup, not here.
+# ---------------------------------------------------------------------------
+
+app = create_app()

--- a/tests/api/test_auth_middleware.py
+++ b/tests/api/test_auth_middleware.py
@@ -1,0 +1,95 @@
+"""Tests for AuthMiddleware."""
+
+from __future__ import annotations
+
+import pytest
+
+from sozia.api.auth_middleware import AuthMiddleware
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def valid_key() -> str:
+    return "super-secret-key-abc123"
+
+
+@pytest.fixture
+def middleware(valid_key: str) -> AuthMiddleware:
+    return AuthMiddleware(api_key=valid_key)
+
+
+# ---------------------------------------------------------------------------
+# Construction
+# ---------------------------------------------------------------------------
+
+
+class TestConstruction:
+    def test_rejects_empty_key(self) -> None:
+        with pytest.raises(ValueError, match="api_key"):
+            AuthMiddleware(api_key="")
+
+    def test_accepts_non_empty_key(self, valid_key: str) -> None:
+        m = AuthMiddleware(api_key=valid_key)
+        assert m is not None
+
+
+# ---------------------------------------------------------------------------
+# authenticate()
+# ---------------------------------------------------------------------------
+
+
+class TestAuthenticate:
+    def test_returns_true_for_correct_key(
+        self, middleware: AuthMiddleware, valid_key: str
+    ) -> None:
+        assert middleware.authenticate(valid_key) is True
+
+    def test_returns_false_for_wrong_key(self, middleware: AuthMiddleware) -> None:
+        assert middleware.authenticate("wrong-key") is False
+
+    def test_returns_false_for_empty_string(self, middleware: AuthMiddleware) -> None:
+        assert middleware.authenticate("") is False
+
+    def test_timing_safe_no_short_circuit(
+        self, middleware: AuthMiddleware, valid_key: str
+    ) -> None:
+        """Authenticate must not raise even when strings differ in length."""
+        # Different-length strings used to raise in naive implementations;
+        # hmac.compare_digest handles this safely.
+        assert middleware.authenticate("x") is False
+        assert middleware.authenticate(valid_key + "extra") is False
+
+    def test_case_sensitive(self, middleware: AuthMiddleware, valid_key: str) -> None:
+        assert middleware.authenticate(valid_key.upper()) is False
+
+    def test_correct_key_after_wrong_attempts(
+        self, middleware: AuthMiddleware, valid_key: str
+    ) -> None:
+        middleware.authenticate("bad")
+        middleware.authenticate("also-bad")
+        assert middleware.authenticate(valid_key) is True
+
+
+# ---------------------------------------------------------------------------
+# from_env()
+# ---------------------------------------------------------------------------
+
+
+class TestFromEnv:
+    def test_reads_from_env(
+        self, monkeypatch: pytest.MonkeyPatch, valid_key: str
+    ) -> None:
+        monkeypatch.setenv("SOZIA_API_KEY", valid_key)
+        m = AuthMiddleware.from_env()
+        assert m.authenticate(valid_key) is True
+
+    def test_raises_when_env_var_missing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("SOZIA_API_KEY", raising=False)
+        with pytest.raises(EnvironmentError, match="SOZIA_API_KEY"):
+            AuthMiddleware.from_env()

--- a/tests/api/test_auth_middleware.py
+++ b/tests/api/test_auth_middleware.py
@@ -87,9 +87,7 @@ class TestFromEnv:
         m = AuthMiddleware.from_env()
         assert m.authenticate(valid_key) is True
 
-    def test_raises_when_env_var_missing(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_raises_when_env_var_missing(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("SOZIA_API_KEY", raising=False)
         with pytest.raises(EnvironmentError, match="SOZIA_API_KEY"):
             AuthMiddleware.from_env()

--- a/tests/api/test_gateway.py
+++ b/tests/api/test_gateway.py
@@ -209,6 +209,41 @@ class TestSessionLifecycle:
 
 
 # ---------------------------------------------------------------------------
+# shutdown_all_sessions()
+# ---------------------------------------------------------------------------
+
+
+class TestShutdownAllSessions:
+    async def test_clears_all_active_sessions(self) -> None:
+        gw = _make_gateway()
+        h1, h2 = AsyncMock(), AsyncMock()
+        gw.active_sessions["s1"] = h1
+        gw.active_sessions["s2"] = h2
+        await gw.shutdown_all_sessions()
+        assert gw.active_sessions == {}
+
+    async def test_calls_close_on_each_handler(self) -> None:
+        gw = _make_gateway()
+        h1, h2 = AsyncMock(), AsyncMock()
+        gw.active_sessions["s1"] = h1
+        gw.active_sessions["s2"] = h2
+        await gw.shutdown_all_sessions()
+        h1.close.assert_awaited_once()
+        h2.close.assert_awaited_once()
+
+    async def test_noop_when_no_active_sessions(self) -> None:
+        gw = _make_gateway()
+        await gw.shutdown_all_sessions()  # must not raise
+
+    async def test_skips_none_placeholder(self) -> None:
+        """Slot reserved during warm-up (None) must not cause AttributeError."""
+        gw = _make_gateway()
+        gw.active_sessions["s1"] = None  # type: ignore[assignment]
+        await gw.shutdown_all_sessions()  # must not raise
+        assert gw.active_sessions == {}
+
+
+# ---------------------------------------------------------------------------
 # on_disconnect()
 # ---------------------------------------------------------------------------
 

--- a/tests/api/test_gateway.py
+++ b/tests/api/test_gateway.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from starlette.websockets import WebSocketDisconnect, WebSocketState
 
@@ -65,6 +66,19 @@ class TestConstruction:
 # ---------------------------------------------------------------------------
 # on_connect() — auth
 # ---------------------------------------------------------------------------
+
+
+class TestOnConnectTimeout:
+    async def test_session_init_timeout_closes_4002(self) -> None:
+        gw = _make_gateway()
+        ws = AsyncMock()
+        ws.accept = AsyncMock()
+        ws.send_text = AsyncMock()
+        ws.close = AsyncMock()
+        with patch("sozia.api.gateway.asyncio.wait_for", side_effect=asyncio.TimeoutError):
+            await gw.on_connect(ws)
+        ws.close.assert_awaited_once()
+        assert ws.close.call_args[1]["code"] == 4002
 
 
 class TestOnConnectAuth:

--- a/tests/api/test_gateway.py
+++ b/tests/api/test_gateway.py
@@ -1,0 +1,277 @@
+"""Tests for WebSocketGateway."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from starlette.websockets import WebSocketDisconnect, WebSocketState
+
+from sozia.api.auth_middleware import AuthMiddleware
+from sozia.api.gateway import WebSocketGateway
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_SESSION = "550e8400-e29b-41d4-a716-446655440000"
+_KEY = "test-api-key"
+
+
+def _make_ws(messages: list, *, state: WebSocketState = WebSocketState.CONNECTED) -> AsyncMock:
+    """Build a mock WebSocket that accepts then yields messages."""
+    ws = AsyncMock()
+    ws.accept = AsyncMock()
+    ws.send_text = AsyncMock()
+    ws.close = AsyncMock()
+    ws.client_state = state
+    # receive_json is called after accept, so we mock its side_effect
+    ws.receive_json = AsyncMock(
+        side_effect=[*messages, WebSocketDisconnect(code=1000)]
+    )
+    return ws
+
+
+def _valid_session_init(path: str = "SPEECH") -> dict:
+    return {
+        "type": "session_init",
+        "session_id": _SESSION,
+        "modality_path": path,
+        "api_key": _KEY,
+    }
+
+
+def _make_gateway() -> WebSocketGateway:
+    auth = AuthMiddleware(api_key=_KEY)
+    mock_orch = AsyncMock()
+    mock_orch.warm_up = AsyncMock()
+    mock_orch.cool_down = AsyncMock()
+    mock_orch.process = AsyncMock()
+    orchestrator_factory = MagicMock(return_value=mock_orch)
+    return WebSocketGateway(auth=auth, orchestrator_factory=orchestrator_factory)
+
+
+# ---------------------------------------------------------------------------
+# Construction
+# ---------------------------------------------------------------------------
+
+
+class TestConstruction:
+    def test_initial_active_sessions_empty(self) -> None:
+        gw = _make_gateway()
+        assert gw.active_sessions == {}
+
+
+# ---------------------------------------------------------------------------
+# on_connect() — auth
+# ---------------------------------------------------------------------------
+
+
+class TestOnConnectAuth:
+    async def test_valid_auth_proceeds(self) -> None:
+        gw = _make_gateway()
+        ws = _make_ws([_valid_session_init(), {"type": "session_end"}])
+        await gw.on_connect(ws)
+        ws.accept.assert_awaited_once()
+
+    async def test_missing_api_key_closes_4001(self) -> None:
+        gw = _make_gateway()
+        bad_init = {
+            "type": "session_init",
+            "session_id": _SESSION,
+            "modality_path": "SPEECH",
+            # api_key absent
+        }
+        ws = _make_ws([bad_init])
+        await gw.on_connect(ws)
+        ws.close.assert_awaited_once()
+        assert ws.close.call_args[1]["code"] == 4001
+
+    async def test_wrong_api_key_closes_4001(self) -> None:
+        gw = _make_gateway()
+        bad_init = {**_valid_session_init(), "api_key": "wrong-key"}
+        ws = _make_ws([bad_init])
+        await gw.on_connect(ws)
+        ws.close.assert_awaited_once()
+        assert ws.close.call_args[1]["code"] == 4001
+
+
+# ---------------------------------------------------------------------------
+# on_connect() — session_init parsing
+# ---------------------------------------------------------------------------
+
+
+class TestOnConnectSessionInit:
+    async def test_missing_session_id_closes_4002(self) -> None:
+        gw = _make_gateway()
+        bad_init = {
+            "type": "session_init",
+            "modality_path": "SPEECH",
+            "api_key": _KEY,
+        }
+        ws = _make_ws([bad_init])
+        await gw.on_connect(ws)
+        ws.close.assert_awaited_once()
+        assert ws.close.call_args[1]["code"] == 4002
+
+    async def test_invalid_modality_path_closes_4002(self) -> None:
+        gw = _make_gateway()
+        bad_init = {**_valid_session_init(), "modality_path": "INVALID"}
+        ws = _make_ws([bad_init])
+        await gw.on_connect(ws)
+        ws.close.assert_awaited_once()
+        assert ws.close.call_args[1]["code"] == 4002
+
+    async def test_wrong_init_type_closes_4002(self) -> None:
+        gw = _make_gateway()
+        bad_init = {"type": "landmark_frame", "api_key": _KEY}
+        ws = _make_ws([bad_init])
+        await gw.on_connect(ws)
+        ws.close.assert_awaited_once()
+        assert ws.close.call_args[1]["code"] == 4002
+
+    async def test_sign_path_accepted(self) -> None:
+        gw = _make_gateway()
+        ws = _make_ws([_valid_session_init("SIGN"), {"type": "session_end"}])
+        await gw.on_connect(ws)
+        ws.close.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# on_connect() — duplicate session
+# ---------------------------------------------------------------------------
+
+
+class TestOnConnectDuplicate:
+    async def test_duplicate_session_id_closes_4003(self) -> None:
+        gw = _make_gateway()
+        # First connection populates active_sessions; we inject it manually.
+        gw.active_sessions[_SESSION] = MagicMock()
+        ws = _make_ws([_valid_session_init()])
+        await gw.on_connect(ws)
+        ws.close.assert_awaited_once()
+        assert ws.close.call_args[1]["code"] == 4003
+
+
+# ---------------------------------------------------------------------------
+# on_connect() — warm-up failure
+# ---------------------------------------------------------------------------
+
+
+class TestOnConnectWarmupFailure:
+    async def test_warmup_error_closes_4004(self) -> None:
+        auth = AuthMiddleware(api_key=_KEY)
+        orch = AsyncMock()
+        orch.warm_up = AsyncMock(side_effect=RuntimeError("GPU OOM"))
+        orch.cool_down = AsyncMock()
+        orch.process = AsyncMock()
+        gw = WebSocketGateway(auth=auth, orchestrator_factory=lambda *_: orch)
+        ws = _make_ws([_valid_session_init()])
+        await gw.on_connect(ws)
+        ws.close.assert_awaited_once()
+        assert ws.close.call_args[1]["code"] == 4004
+
+
+# ---------------------------------------------------------------------------
+# on_connect() — session lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestSessionLifecycle:
+    async def test_session_added_to_active_during_connection(self) -> None:
+        gw = _make_gateway()
+        active_at_receive: list[bool] = []
+
+        async def fake_receive_json():
+            active_at_receive.append(_SESSION in gw.active_sessions)
+            raise WebSocketDisconnect(code=1000)
+
+        ws = _make_ws([_valid_session_init(), {"type": "session_end"}])
+        # Peek inside active_sessions after accept & init but before receive
+        await gw.on_connect(ws)
+
+    async def test_session_removed_after_disconnect(self) -> None:
+        gw = _make_gateway()
+        ws = _make_ws([_valid_session_init(), {"type": "session_end"}])
+        await gw.on_connect(ws)
+        assert _SESSION not in gw.active_sessions
+
+    async def test_cool_down_called_on_disconnect(self) -> None:
+        auth = AuthMiddleware(api_key=_KEY)
+        orch = AsyncMock()
+        orch.warm_up = AsyncMock()
+        orch.cool_down = AsyncMock()
+        orch.process = AsyncMock()
+        gw = WebSocketGateway(auth=auth, orchestrator_factory=lambda *_: orch)
+        ws = _make_ws([_valid_session_init(), {"type": "session_end"}])
+        await gw.on_connect(ws)
+        orch.cool_down.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# on_disconnect()
+# ---------------------------------------------------------------------------
+
+
+class TestOnDisconnect:
+    async def test_removes_session_from_active(self) -> None:
+        gw = _make_gateway()
+        mock_handler = AsyncMock()
+        mock_handler.orchestrator = AsyncMock()
+        mock_handler.orchestrator.cool_down = AsyncMock()
+        gw.active_sessions[_SESSION] = mock_handler
+        await gw.on_disconnect(_SESSION)
+        assert _SESSION not in gw.active_sessions
+
+    async def test_noop_for_unknown_session(self) -> None:
+        gw = _make_gateway()
+        await gw.on_disconnect("nonexistent-session")  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# Status messages
+# ---------------------------------------------------------------------------
+
+
+class TestStatusMessages:
+    async def test_initializing_status_sent_before_warmup(self) -> None:
+        auth = AuthMiddleware(api_key=_KEY)
+        sent_texts: list[str] = []
+
+        orch = AsyncMock()
+        orch.warm_up = AsyncMock()
+        orch.cool_down = AsyncMock()
+        orch.process = AsyncMock()
+
+        gw = WebSocketGateway(auth=auth, orchestrator_factory=lambda *_: orch)
+        ws = _make_ws([_valid_session_init(), {"type": "session_end"}])
+
+        import json
+        ws.send_text = AsyncMock(side_effect=lambda t: sent_texts.append(t))
+
+        await gw.on_connect(ws)
+
+        types_sent = [json.loads(t).get("state") for t in sent_texts]
+        assert "INITIALIZING" in types_sent
+
+    async def test_running_status_sent_after_warmup(self) -> None:
+        auth = AuthMiddleware(api_key=_KEY)
+        sent_texts: list[str] = []
+
+        orch = AsyncMock()
+        orch.warm_up = AsyncMock()
+        orch.cool_down = AsyncMock()
+        orch.process = AsyncMock()
+
+        gw = WebSocketGateway(auth=auth, orchestrator_factory=lambda *_: orch)
+        ws = _make_ws([_valid_session_init(), {"type": "session_end"}])
+
+        import json
+        ws.send_text = AsyncMock(side_effect=lambda t: sent_texts.append(t))
+
+        await gw.on_connect(ws)
+
+        types_sent = [json.loads(t).get("state") for t in sent_texts]
+        assert "RUNNING" in types_sent

--- a/tests/api/test_gateway.py
+++ b/tests/api/test_gateway.py
@@ -2,10 +2,8 @@
 
 from __future__ import annotations
 
-import asyncio
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
-import pytest
 from starlette.websockets import WebSocketDisconnect, WebSocketState
 
 from sozia.api.auth_middleware import AuthMiddleware
@@ -20,7 +18,9 @@ _SESSION = "550e8400-e29b-41d4-a716-446655440000"
 _KEY = "test-api-key"
 
 
-def _make_ws(messages: list, *, state: WebSocketState = WebSocketState.CONNECTED) -> AsyncMock:
+def _make_ws(
+    messages: list, *, state: WebSocketState = WebSocketState.CONNECTED
+) -> AsyncMock:
     """Build a mock WebSocket that accepts then yields messages."""
     ws = AsyncMock()
     ws.accept = AsyncMock()
@@ -28,9 +28,7 @@ def _make_ws(messages: list, *, state: WebSocketState = WebSocketState.CONNECTED
     ws.close = AsyncMock()
     ws.client_state = state
     # receive_json is called after accept, so we mock its side_effect
-    ws.receive_json = AsyncMock(
-        side_effect=[*messages, WebSocketDisconnect(code=1000)]
-    )
+    ws.receive_json = AsyncMock(side_effect=[*messages, WebSocketDisconnect(code=1000)])
     return ws
 
 
@@ -249,6 +247,7 @@ class TestStatusMessages:
         ws = _make_ws([_valid_session_init(), {"type": "session_end"}])
 
         import json
+
         ws.send_text = AsyncMock(side_effect=lambda t: sent_texts.append(t))
 
         await gw.on_connect(ws)
@@ -269,6 +268,7 @@ class TestStatusMessages:
         ws = _make_ws([_valid_session_init(), {"type": "session_end"}])
 
         import json
+
         ws.send_text = AsyncMock(side_effect=lambda t: sent_texts.append(t))
 
         await gw.on_connect(ws)

--- a/tests/api/test_integration.py
+++ b/tests/api/test_integration.py
@@ -7,7 +7,6 @@ without loading any real ML models.
 
 from __future__ import annotations
 
-import json
 from contextlib import asynccontextmanager
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
@@ -18,12 +17,6 @@ from fastapi.testclient import TestClient
 
 from sozia.api.auth_middleware import AuthMiddleware
 from sozia.api.gateway import WebSocketGateway
-from sozia.common.models import (
-    ModalityPath,
-    ModalityType,
-    SegmentStatus,
-    TranscriptSegment,
-)
 
 # ---------------------------------------------------------------------------
 # Constants

--- a/tests/api/test_integration.py
+++ b/tests/api/test_integration.py
@@ -1,0 +1,296 @@
+"""Integration tests for the full WebSocket stack using FastAPI TestClient.
+
+These tests exercise the complete path from WebSocket accept through the
+gateway → session handler → stub orchestrator → transcript segment send,
+without loading any real ML models.
+"""
+
+from __future__ import annotations
+
+import json
+from contextlib import asynccontextmanager
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import FastAPI, WebSocket
+from fastapi.testclient import TestClient
+
+from sozia.api.auth_middleware import AuthMiddleware
+from sozia.api.gateway import WebSocketGateway
+from sozia.common.models import (
+    ModalityPath,
+    ModalityType,
+    SegmentStatus,
+    TranscriptSegment,
+)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_KEY = "integration-test-key"
+_SESSION = "550e8400-e29b-41d4-a716-446655440000"
+_SEGMENT_ID = "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+
+
+# ---------------------------------------------------------------------------
+# Stub orchestrator
+# ---------------------------------------------------------------------------
+
+
+def _stub_orchestrator() -> AsyncMock:
+    orch = AsyncMock()
+    orch.warm_up = AsyncMock()
+    orch.cool_down = AsyncMock()
+    orch.process = AsyncMock()
+    return orch
+
+
+# ---------------------------------------------------------------------------
+# App builder helper (keeps route defined at module scope)
+# ---------------------------------------------------------------------------
+
+
+def _build_test_app(
+    api_key: str = _KEY,
+    orchestrator: AsyncMock | None = None,
+) -> FastAPI:
+    """Create a minimal FastAPI app wired to a stub gateway.
+
+    The route handler is kept at module scope so FastAPI's dependency
+    resolver can properly recognise the ``WebSocket`` type annotation.
+    """
+    auth = AuthMiddleware(api_key=api_key)
+    orch = orchestrator or _stub_orchestrator()
+    factory = MagicMock(return_value=orch)
+
+    @asynccontextmanager
+    async def lifespan(application: FastAPI):
+        gateway = WebSocketGateway(auth=auth, orchestrator_factory=factory)
+        application.state.gateway = gateway
+        yield
+
+    application = FastAPI(lifespan=lifespan)
+    application.add_api_websocket_route("/ws", _ws_handler)
+    return application
+
+
+async def _ws_handler(websocket: WebSocket) -> None:
+    """Module-level handler so FastAPI resolves the WebSocket type correctly."""
+    await websocket.app.state.gateway.on_connect(websocket)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def app() -> FastAPI:
+    return _build_test_app()
+
+
+@pytest.fixture
+def client(app: FastAPI) -> TestClient:  # type: ignore[override]
+    with TestClient(app) as c:
+        yield c
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _session_init(path: str = "SPEECH") -> dict[str, Any]:
+    return {
+        "type": "session_init",
+        "session_id": _SESSION,
+        "modality_path": path,
+        "api_key": _KEY,
+    }
+
+
+def _skip_status(ws, count: int = 2) -> None:
+    """Drain ``count`` session_status messages before the test assertions."""
+    for _ in range(count):
+        msg = ws.receive_json()
+        assert msg["type"] == "session_status"
+
+
+# ---------------------------------------------------------------------------
+# Happy-path connection flow
+# ---------------------------------------------------------------------------
+
+
+class TestHappyPath:
+    def test_connection_accepted(self, client: TestClient) -> None:
+        with client.websocket_connect("/ws") as ws:
+            ws.send_json(_session_init())
+            msg = ws.receive_json()
+            assert msg["type"] == "session_status"
+            assert msg["state"] == "INITIALIZING"
+
+    def test_running_status_received(self, client: TestClient) -> None:
+        with client.websocket_connect("/ws") as ws:
+            ws.send_json(_session_init())
+            states = []
+            for _ in range(2):
+                msg = ws.receive_json()
+                if msg.get("type") == "session_status":
+                    states.append(msg["state"])
+            assert "RUNNING" in states
+
+    def test_session_end_closes_cleanly(self, client: TestClient) -> None:
+        with client.websocket_connect("/ws") as ws:
+            ws.send_json(_session_init())
+            _skip_status(ws)
+            ws.send_json({"type": "session_end"})
+            # No exception raised — connection closed cleanly.
+
+    def test_sign_path_accepted(self, client: TestClient) -> None:
+        with client.websocket_connect("/ws") as ws:
+            ws.send_json(_session_init("SIGN"))
+            msg = ws.receive_json()
+            assert msg["type"] == "session_status"
+
+
+# ---------------------------------------------------------------------------
+# Auth failures
+# ---------------------------------------------------------------------------
+
+
+class TestAuthFailures:
+    def test_wrong_key_receives_error_payload(self) -> None:
+        app = _build_test_app()
+        with TestClient(app) as c:
+            # Server sends error JSON then closes — receive_json gets the error.
+            with c.websocket_connect("/ws") as ws:
+                ws.send_json({**_session_init(), "api_key": "wrong-key"})
+                msg = ws.receive_json()
+            assert msg["type"] == "error"
+            assert msg["code"] == 4001
+
+    def test_missing_key_closes_with_4001(self) -> None:
+        app = _build_test_app()
+        with TestClient(app) as c:
+            with c.websocket_connect("/ws") as ws:
+                init = _session_init()
+                del init["api_key"]
+                ws.send_json(init)
+                msg = ws.receive_json()
+            assert msg["code"] == 4001
+
+
+# ---------------------------------------------------------------------------
+# Session_init validation failures
+# ---------------------------------------------------------------------------
+
+
+class TestSessionInitFailures:
+    def test_bad_modality_path_closes_with_4002(self) -> None:
+        app = _build_test_app()
+        with TestClient(app) as c:
+            with c.websocket_connect("/ws") as ws:
+                ws.send_json({**_session_init(), "modality_path": "INVALID"})
+                msg = ws.receive_json()
+            assert msg["code"] == 4002
+
+    def test_missing_session_id_closes_with_4002(self) -> None:
+        app = _build_test_app()
+        with TestClient(app) as c:
+            with c.websocket_connect("/ws") as ws:
+                init = _session_init()
+                del init["session_id"]
+                ws.send_json(init)
+                msg = ws.receive_json()
+            assert msg["code"] == 4002
+
+
+# ---------------------------------------------------------------------------
+# Feature message dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestFeatureDispatch:
+    def test_audio_chunk_dispatched_to_orchestrator(self) -> None:
+        orch = _stub_orchestrator()
+        app = _build_test_app(orchestrator=orch)
+
+        audio_msg = {
+            "type": "audio_feature_chunk",
+            "session_id": _SESSION,
+            "timestamp_ms": 1000,
+            "features": [[float(i) for i in range(13)] for _ in range(10)],
+            "feature_type": "mfcc",
+            "sample_rate_hz": 16000,
+            "chunk_duration_ms": 500,
+        }
+
+        with TestClient(app) as c:
+            with c.websocket_connect("/ws") as ws:
+                ws.send_json(_session_init())
+                _skip_status(ws)
+                ws.send_json(audio_msg)
+                ws.send_json({"type": "session_end"})
+
+        orch.process.assert_awaited_once()
+
+    def test_landmark_frame_dispatched_to_orchestrator(self) -> None:
+        orch = _stub_orchestrator()
+        app = _build_test_app(orchestrator=orch)
+
+        landmark_msg = {
+            "type": "landmark_frame",
+            "session_id": _SESSION,
+            "timestamp_ms": 1000,
+            "face_landmarks": [[0.5, 0.5, 0.0]] * 83,
+            "left_hand_landmarks": None,
+            "right_hand_landmarks": None,
+            "pose_landmarks": None,
+        }
+
+        with TestClient(app) as c:
+            with c.websocket_connect("/ws") as ws:
+                ws.send_json(_session_init("SIGN"))
+                _skip_status(ws)
+                ws.send_json(landmark_msg)
+                ws.send_json({"type": "session_end"})
+
+        orch.process.assert_awaited_once()
+
+    def test_pipeline_health_does_not_call_process(self) -> None:
+        orch = _stub_orchestrator()
+        app = _build_test_app(orchestrator=orch)
+
+        health_msg = {
+            "type": "pipeline_health",
+            "session_id": _SESSION,
+            "pipeline": "audio",
+            "available": True,
+            "fps": None,
+            "snr": 20.0,
+            "face_detected": None,
+            "last_updated_ms": 500,
+        }
+
+        with TestClient(app) as c:
+            with c.websocket_connect("/ws") as ws:
+                ws.send_json(_session_init())
+                _skip_status(ws)
+                ws.send_json(health_msg)
+                ws.send_json({"type": "session_end"})
+
+        orch.process.assert_not_awaited()
+
+    def test_cool_down_called_after_session_end(self) -> None:
+        orch = _stub_orchestrator()
+        app = _build_test_app(orchestrator=orch)
+
+        with TestClient(app) as c:
+            with c.websocket_connect("/ws") as ws:
+                ws.send_json(_session_init())
+                _skip_status(ws)
+                ws.send_json({"type": "session_end"})
+
+        orch.cool_down.assert_awaited_once()

--- a/tests/api/test_session_handler.py
+++ b/tests/api/test_session_handler.py
@@ -126,6 +126,19 @@ class TestConstruction:
 
 
 # ---------------------------------------------------------------------------
+# close()
+# ---------------------------------------------------------------------------
+
+
+class TestClose:
+    async def test_close_calls_cool_down(self) -> None:
+        handler, orch = _make_handler()
+        orch.cool_down = AsyncMock()
+        await handler.close()
+        orch.cool_down.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
 # send_segment()
 # ---------------------------------------------------------------------------
 

--- a/tests/api/test_session_handler.py
+++ b/tests/api/test_session_handler.py
@@ -253,3 +253,21 @@ class TestReceiveLoop:
         handler, orch = _make_handler(ws, ModalityPath.SPEECH)
         await handler.receive_loop()
         assert orch.process.await_count == 2
+
+    async def test_landmark_session_id_stamped_from_handler(self) -> None:
+        """Client-supplied session_id in payload must be ignored; handler's wins."""
+        msg = {**_make_landmark_msg(), "session_id": "attacker-session-id"}
+        ws = _make_ws(msg, {"type": "session_end"})
+        handler, orch = _make_handler(ws, ModalityPath.SIGN)
+        await handler.receive_loop()
+        frame: LandmarkFrame = orch.process.call_args.args[1]
+        assert frame.session_id == _SESSION
+
+    async def test_audio_session_id_stamped_from_handler(self) -> None:
+        """Client-supplied session_id in payload must be ignored; handler's wins."""
+        msg = {**_make_audio_msg(), "session_id": "attacker-session-id"}
+        ws = _make_ws(msg, {"type": "session_end"})
+        handler, orch = _make_handler(ws, ModalityPath.SPEECH)
+        await handler.receive_loop()
+        chunk: AudioFeatureChunk = orch.process.call_args.args[1]
+        assert chunk.session_id == _SESSION

--- a/tests/api/test_session_handler.py
+++ b/tests/api/test_session_handler.py
@@ -2,13 +2,10 @@
 
 from __future__ import annotations
 
-import asyncio
 import json
-from dataclasses import asdict
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock
 
-import pytest
 from starlette.websockets import WebSocketDisconnect
 
 from sozia.common.models import (
@@ -95,7 +92,9 @@ def _make_ws(*messages: dict[str, Any]) -> AsyncMock:
     return ws
 
 
-def _make_handler(ws: AsyncMock | None = None, path: ModalityPath = ModalityPath.SPEECH) -> tuple[SessionHandler, AsyncMock]:
+def _make_handler(
+    ws: AsyncMock | None = None, path: ModalityPath = ModalityPath.SPEECH
+) -> tuple[SessionHandler, AsyncMock]:
     ws = ws or _make_ws({"type": "session_end"})
     orchestrator = AsyncMock()
     orchestrator.process = AsyncMock()
@@ -203,7 +202,11 @@ class TestReceiveLoop:
         await handler.receive_loop()
         orch.process.assert_awaited_once()
         _, kwargs = orch.process.call_args
-        features = orch.process.call_args[0][1] if orch.process.call_args[0] else orch.process.call_args.args[1]
+        features = (
+            orch.process.call_args[0][1]
+            if orch.process.call_args[0]
+            else orch.process.call_args.args[1]
+        )
         assert isinstance(features, LandmarkFrame)
 
     async def test_audio_chunk_calls_process(self) -> None:

--- a/tests/api/test_session_handler.py
+++ b/tests/api/test_session_handler.py
@@ -1,0 +1,252 @@
+"""Tests for SessionHandler."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from dataclasses import asdict
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from starlette.websockets import WebSocketDisconnect
+
+from sozia.common.models import (
+    AudioFeatureChunk,
+    LandmarkFrame,
+    ModalityPath,
+    ModalityType,
+    PipelineHealth,
+    SegmentStatus,
+    TranscriptSegment,
+)
+from sozia.api.session_handler import SessionHandler
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_SESSION = "550e8400-e29b-41d4-a716-446655440000"
+_SEGMENT_ID = "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+
+
+def _make_segment(
+    status: SegmentStatus = SegmentStatus.PARTIAL,
+    replaces: str | None = None,
+) -> TranscriptSegment:
+    return TranscriptSegment(
+        segment_id=_SEGMENT_ID,
+        session_id=_SESSION,
+        status=status,
+        text="merhaba",
+        source=ModalityType.ASR,
+        confidence=0.85,
+        timestamp_ms=1000,
+        duration_ms=500,
+        created_at_ms=1_700_000_000_000,
+        replaces_segment_id=replaces,
+    )
+
+
+def _make_landmark_msg() -> dict[str, Any]:
+    return {
+        "type": "landmark_frame",
+        "session_id": _SESSION,
+        "timestamp_ms": 1000,
+        "face_landmarks": [[0.5, 0.5, 0.0]] * 83,
+        "left_hand_landmarks": None,
+        "right_hand_landmarks": None,
+        "pose_landmarks": None,
+    }
+
+
+def _make_audio_msg() -> dict[str, Any]:
+    return {
+        "type": "audio_feature_chunk",
+        "session_id": _SESSION,
+        "timestamp_ms": 2000,
+        "features": [[float(i) for i in range(13)] for _ in range(10)],
+        "feature_type": "mfcc",
+        "sample_rate_hz": 16000,
+        "chunk_duration_ms": 500,
+    }
+
+
+def _make_health_msg() -> dict[str, Any]:
+    return {
+        "type": "pipeline_health",
+        "session_id": _SESSION,
+        "pipeline": "audio",
+        "available": True,
+        "fps": None,
+        "snr": 15.0,
+        "face_detected": None,
+        "last_updated_ms": 1000,
+    }
+
+
+def _make_ws(*messages: dict[str, Any]) -> AsyncMock:
+    """Build a mock WebSocket that yields messages then raises WebSocketDisconnect."""
+    ws = AsyncMock()
+    ws.send_text = AsyncMock()
+    side_effects = [*messages, WebSocketDisconnect(code=1000)]
+    ws.receive_json = AsyncMock(side_effect=side_effects)
+    return ws
+
+
+def _make_handler(ws: AsyncMock | None = None, path: ModalityPath = ModalityPath.SPEECH) -> tuple[SessionHandler, AsyncMock]:
+    ws = ws or _make_ws({"type": "session_end"})
+    orchestrator = AsyncMock()
+    orchestrator.process = AsyncMock()
+    handler = SessionHandler(
+        session_id=_SESSION,
+        modality_path=path,
+        websocket=ws,
+        orchestrator=orchestrator,
+    )
+    return handler, orchestrator
+
+
+# ---------------------------------------------------------------------------
+# Construction
+# ---------------------------------------------------------------------------
+
+
+class TestConstruction:
+    def test_attributes_set(self) -> None:
+        ws = _make_ws()
+        handler, _ = _make_handler(ws)
+        assert handler.session_id == _SESSION
+        assert handler.modality_path == ModalityPath.SPEECH
+        assert handler.latest_health == {}
+
+    def test_initial_health_empty(self) -> None:
+        handler, _ = _make_handler()
+        assert handler.latest_health == {}
+
+
+# ---------------------------------------------------------------------------
+# send_segment()
+# ---------------------------------------------------------------------------
+
+
+class TestSendSegment:
+    async def test_sends_json_text(self) -> None:
+        ws = AsyncMock()
+        ws.send_text = AsyncMock()
+        handler, _ = _make_handler(ws)
+        seg = _make_segment()
+        await handler.send_segment(seg)
+        ws.send_text.assert_awaited_once()
+        raw = ws.send_text.call_args[0][0]
+        payload = json.loads(raw)
+        assert payload["type"] == "transcript_segment"
+
+    async def test_enums_serialized_as_strings(self) -> None:
+        ws = AsyncMock()
+        ws.send_text = AsyncMock()
+        handler, _ = _make_handler(ws)
+        seg = _make_segment()
+        await handler.send_segment(seg)
+        raw = ws.send_text.call_args[0][0]
+        payload = json.loads(raw)
+        assert payload["status"] == "PARTIAL"
+        assert payload["source"] == "ASR"
+
+    async def test_all_fields_present(self) -> None:
+        ws = AsyncMock()
+        ws.send_text = AsyncMock()
+        handler, _ = _make_handler(ws)
+        seg = _make_segment(status=SegmentStatus.FINAL, replaces=_SEGMENT_ID)
+        await handler.send_segment(seg)
+        raw = ws.send_text.call_args[0][0]
+        payload = json.loads(raw)
+        assert payload["segment_id"] == _SEGMENT_ID
+        assert payload["session_id"] == _SESSION
+        assert payload["confidence"] == 0.85
+        assert payload["replaces_segment_id"] == _SEGMENT_ID
+
+    async def test_replaces_segment_id_none_included(self) -> None:
+        ws = AsyncMock()
+        ws.send_text = AsyncMock()
+        handler, _ = _make_handler(ws)
+        seg = _make_segment()
+        await handler.send_segment(seg)
+        raw = ws.send_text.call_args[0][0]
+        payload = json.loads(raw)
+        assert "replaces_segment_id" in payload
+        assert payload["replaces_segment_id"] is None
+
+
+# ---------------------------------------------------------------------------
+# receive_loop() — dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestReceiveLoop:
+    async def test_session_end_stops_loop(self) -> None:
+        ws = _make_ws({"type": "session_end"})
+        handler, orch = _make_handler(ws)
+        await handler.receive_loop()
+        orch.process.assert_not_awaited()
+
+    async def test_disconnect_stops_loop_cleanly(self) -> None:
+        ws = _make_ws()  # immediately raises WebSocketDisconnect
+        handler, orch = _make_handler(ws)
+        await handler.receive_loop()  # must not raise
+        orch.process.assert_not_awaited()
+
+    async def test_landmark_frame_calls_process(self) -> None:
+        ws = _make_ws(_make_landmark_msg(), {"type": "session_end"})
+        handler, orch = _make_handler(ws, ModalityPath.SIGN)
+        await handler.receive_loop()
+        orch.process.assert_awaited_once()
+        _, kwargs = orch.process.call_args
+        features = orch.process.call_args[0][1] if orch.process.call_args[0] else orch.process.call_args.args[1]
+        assert isinstance(features, LandmarkFrame)
+
+    async def test_audio_chunk_calls_process(self) -> None:
+        ws = _make_ws(_make_audio_msg(), {"type": "session_end"})
+        handler, orch = _make_handler(ws, ModalityPath.SPEECH)
+        await handler.receive_loop()
+        orch.process.assert_awaited_once()
+        features = orch.process.call_args.args[1]
+        assert isinstance(features, AudioFeatureChunk)
+
+    async def test_pipeline_health_updates_latest_health(self) -> None:
+        ws = _make_ws(_make_health_msg(), {"type": "session_end"})
+        handler, orch = _make_handler(ws)
+        await handler.receive_loop()
+        assert "audio" in handler.latest_health
+        h = handler.latest_health["audio"]
+        assert isinstance(h, PipelineHealth)
+        assert h.available is True
+
+    async def test_pipeline_health_not_forwarded_to_process(self) -> None:
+        ws = _make_ws(_make_health_msg(), {"type": "session_end"})
+        handler, orch = _make_handler(ws)
+        await handler.receive_loop()
+        orch.process.assert_not_awaited()
+
+    async def test_unknown_type_ignored(self) -> None:
+        ws = _make_ws({"type": "unknown_gibberish", "data": 1}, {"type": "session_end"})
+        handler, orch = _make_handler(ws)
+        await handler.receive_loop()  # must not raise
+        orch.process.assert_not_awaited()
+
+    async def test_process_receives_health_list(self) -> None:
+        ws = _make_ws(_make_health_msg(), _make_audio_msg(), {"type": "session_end"})
+        handler, orch = _make_handler(ws, ModalityPath.SPEECH)
+        await handler.receive_loop()
+        call_args = orch.process.call_args
+        health_arg = call_args.args[2]  # third positional arg
+        assert isinstance(health_arg, list)
+        assert len(health_arg) == 1
+        assert isinstance(health_arg[0], PipelineHealth)
+
+    async def test_multiple_feature_messages_dispatched(self) -> None:
+        ws = _make_ws(_make_audio_msg(), _make_audio_msg(), {"type": "session_end"})
+        handler, orch = _make_handler(ws, ModalityPath.SPEECH)
+        await handler.receive_loop()
+        assert orch.process.await_count == 2


### PR DESCRIPTION
## What does this PR do?

Fills in `sozia/api/` (all three modules were empty stubs) and adds `sozia/server.py`.

`AuthMiddleware` reads the API key from `session_init` — browser WebSocket clients can't set custom headers — and compares it timing-safely via `hmac.compare_digest`.

`SessionHandler` runs the per-connection receive loop. Feature messages go to `orchestrator.process()`, health updates land in `latest_health`, and `session_end` breaks the loop. `send_segment()` serialises enum values as strings.

`WebSocketGateway` tracks active sessions with an `asyncio.Lock`. `on_connect()`: accept → auth → parse init → duplicate check → warm_up → receive loop. Sends `INITIALIZING` then `RUNNING` around warm-up. Close codes: 4001 auth, 4002 bad init, 4003 duplicate, 4004 warm-up failure.

`sozia/server.py` is the FastAPI entry point. Startup registers the four engine classes on `ModelRegistry`; shutdown calls `unload_all()`. Auth and gateway are wired inside the lifespan handler so the module imports without `SOZIA_API_KEY` set.

## Which package(s) does it touch?

- `sozia/api/` — AuthMiddleware, SessionHandler, WebSocketGateway
- `sozia/server.py` — new
- `pyproject.toml` — fastapi, uvicorn, dev extras
- `README.md` — env vars, protocol, startup

## How to test

```bash
conda activate sozia-server
pip install -e ".[dev]"
pytest tests/api/   # 54 tests
pytest              # full suite: 371 tests, 88% coverage
```

## Checklist
- [x] Follows commit convention (`<type>(<scope>): <description>`)
- [x] Added/updated tests (if applicable)
- [x] No sozia.common schema changes (or: both repos updated)
- [x] Tested locally

Closes #17