### PR TITLE
feat(tsl-engine): wire SOZIA_TSL_SCALER env var and add .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,21 @@
+# Sozia Server — environment variables
+# Copy this file to .env and fill in the paths for your local setup.
+# .env is gitignored; never commit real paths or secrets.
+
+# Required
+SOZIA_API_KEY=dev-only-key-change-in-production
+
+# Compute device: "cpu" or "cuda" (default: cpu)
+SOZIA_DEVICE=cpu
+
+# Model weights — omit any path you don't have locally.
+# The corresponding modality is disabled when a weights var is unset.
+
+# Speech path
+# SOZIA_WHISPER_WEIGHTS=/path/to/whisper-small-tr.pt
+# SOZIA_LIP_WEIGHTS=/path/to/lip-reading-v1.pt
+
+# Sign path
+# SOZIA_TSL_WEIGHTS=/path/to/sozia-research/models/recognition/run_autsl_signer
+# SOZIA_TSL_SCALER=/path/to/sozia-research/scalers/AUTSL/scaler_signer.pkl
+# SOZIA_GLOSS_WEIGHTS=/path/to/gemma-9b-gloss-tr/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         run: pip install -e ".[dev]"
 
       - name: Check dependency rules
-        run: pytest tests/registry/ -v
+        run: pytest tests/registry/ tests/common/ -v
 
       - name: Run tests
-        run: pytest --ignore=tests/registry/ --cov-fail-under=80
+        run: pytest --ignore=tests/registry/ --ignore=tests/common/ --cov-fail-under=80

--- a/README.md
+++ b/README.md
@@ -31,22 +31,16 @@ All config comes from environment variables.
 | `SOZIA_DEVICE` | no | `cpu` | `"cpu"` or `"cuda"`. |
 | `SOZIA_WHISPER_WEIGHTS` | no | — | Path to Whisper ASR weights. Speech path is disabled if unset. |
 | `SOZIA_LIP_WEIGHTS` | no | — | Path to lip-reading weights. Optional — speech path works without it. |
-| `SOZIA_TSL_WEIGHTS` | no | — | Path to TSL recognition weights. Sign path is disabled if unset. |
+| `SOZIA_TSL_WEIGHTS` | no | — | Path to TSL recognition `run_*` directory containing `best_model.pt` and `config.json`. Sign path is disabled if unset. |
+| `SOZIA_TSL_SCALER` | no | — | Path to the StandardScaler `.pkl` for TSL features (e.g. `scalers/AUTSL/scaler_signer.pkl`). Falls back to searching the run directory if unset. |
 | `SOZIA_GLOSS_WEIGHTS` | no | — | Path to Gemma-9B LoRA weights. Sign path falls back to raw gloss if unset. |
 
 ### Local development
 
-Create a `.env` in the project root (already in `.gitignore`):
+Copy `.env.example` to `.env` (already in `.gitignore`) and fill in the paths you have locally:
 
-```dotenv
-SOZIA_API_KEY=dev-only-key-change-in-production
-SOZIA_DEVICE=cpu
-
-# Omit these if you don't have weights locally
-# SOZIA_WHISPER_WEIGHTS=/path/to/whisper-small-tr.pt
-# SOZIA_LIP_WEIGHTS=/path/to/lip-reading-v1.pt
-# SOZIA_TSL_WEIGHTS=/path/to/tsl-gru-v1.pt
-# SOZIA_GLOSS_WEIGHTS=/path/to/gemma-9b-gloss-tr/
+```bash
+cp .env.example .env
 ```
 
 Load it before starting:

--- a/sozia/inference/sign/tsl_recognition_engine.py
+++ b/sozia/inference/sign/tsl_recognition_engine.py
@@ -121,7 +121,9 @@ class TslRecognitionEngine(InferenceEngine):
         try:
             top_preds, probs = await asyncio.wait_for(
                 asyncio.to_thread(
-                    self._run_inference, kp_array, actual_length,
+                    self._run_inference,
+                    kp_array,
+                    actual_length,
                 ),
                 timeout=timeout_ms / 1000.0,
             )
@@ -161,7 +163,8 @@ class TslRecognitionEngine(InferenceEngine):
     # ------------------------------------------------------------------
 
     def _preprocess(
-        self, features: np.ndarray,
+        self,
+        features: np.ndarray,
     ) -> tuple[np.ndarray, int]:
         """Preprocess landmark frames identically to the training pipeline."""
         arr = np.asarray(features, dtype=np.float32)
@@ -179,6 +182,7 @@ class TslRecognitionEngine(InferenceEngine):
                 from sozia.inference.sign._interpolation import (
                     interpolate_missing_keypoints,
                 )
+
                 arr = interpolate_missing_keypoints(arr).astype(np.float32)
             except ImportError:
                 pass
@@ -190,9 +194,15 @@ class TslRecognitionEngine(InferenceEngine):
         # Truncate or sample long sequences.
         if n_frames > self._max_seq_len:
             if self._sequence_handling == "uniform_sample":
-                indices = np.linspace(
-                    0, n_frames - 1, self._max_seq_len,
-                ).round().astype(int)
+                indices = (
+                    np.linspace(
+                        0,
+                        n_frames - 1,
+                        self._max_seq_len,
+                    )
+                    .round()
+                    .astype(int)
+                )
                 arr = arr[indices]
             else:
                 arr = arr[: self._max_seq_len]
@@ -211,7 +221,9 @@ class TslRecognitionEngine(InferenceEngine):
         return arr, actual_length
 
     def _run_inference(
-        self, kp_array: np.ndarray, actual_length: int,
+        self,
+        kp_array: np.ndarray,
+        actual_length: int,
     ) -> tuple[list[tuple[str, float]], np.ndarray]:
         """Synchronous GRU forward pass + softmax — called inside ``to_thread``."""
         x = torch.tensor(kp_array, dtype=torch.float32).unsqueeze(0).to(self._device)
@@ -227,7 +239,9 @@ class TslRecognitionEngine(InferenceEngine):
         return preds, probs
 
     @staticmethod
-    def _load_run(run_dir: Path, device: torch.device, scaler_path: Path | None = None) -> dict:
+    def _load_run(
+        run_dir: Path, device: torch.device, scaler_path: Path | None = None
+    ) -> dict:
         """Load model, scaler, and metadata from a training run directory.
 
         Mirrors ``sozia-research/tsl_recognition/evaluation/inference._load_run``
@@ -272,10 +286,12 @@ class TslRecognitionEngine(InferenceEngine):
             scaler_candidates: list[Path] = []
             if scaler_path is not None:
                 scaler_candidates.append(scaler_path)
-            scaler_candidates.extend([
-                run_dir / f"scaler_{split_mode}.pkl",
-                run_dir / "scaler.pkl",
-            ])
+            scaler_candidates.extend(
+                [
+                    run_dir / f"scaler_{split_mode}.pkl",
+                    run_dir / "scaler.pkl",
+                ]
+            )
             # Also check dataset processed dir if metadata has dataset name.
             dataset_name = meta.get("dataset", "bosphorus")
             data_root = Path(meta.get("data_root", ""))

--- a/sozia/inference/sign/tsl_recognition_engine.py
+++ b/sozia/inference/sign/tsl_recognition_engine.py
@@ -56,6 +56,8 @@ class TslRecognitionEngine(InferenceEngine):
             normalize (bool): Apply StandardScaler, default ``True``.
             apply_interpolation (bool): Interpolate missing landmarks,
                 default ``True``.
+            scaler_path (str): Explicit path to a ``.pkl`` scaler file.
+                Takes priority over the candidate search in the run dir.
     """
 
     def __init__(self) -> None:
@@ -79,8 +81,10 @@ class TslRecognitionEngine(InferenceEngine):
         device = torch.device(config.device)
         self._normalize = config.params.get("normalize", True)
         self._apply_interpolation = config.params.get("apply_interpolation", True)
+        scaler_path_str = config.params.get("scaler_path")
+        scaler_path = Path(scaler_path_str) if scaler_path_str else None
 
-        run_data = await asyncio.to_thread(self._load_run, run_dir, device)
+        run_data = await asyncio.to_thread(self._load_run, run_dir, device, scaler_path)
 
         self._model = run_data["model"]
         self._scaler = run_data["scaler"]
@@ -223,7 +227,7 @@ class TslRecognitionEngine(InferenceEngine):
         return preds, probs
 
     @staticmethod
-    def _load_run(run_dir: Path, device: torch.device) -> dict:
+    def _load_run(run_dir: Path, device: torch.device, scaler_path: Path | None = None) -> dict:
         """Load model, scaler, and metadata from a training run directory.
 
         Mirrors ``sozia-research/tsl_recognition/evaluation/inference._load_run``
@@ -265,10 +269,13 @@ class TslRecognitionEngine(InferenceEngine):
         # Load scaler.
         scaler = None
         if normalize:
-            scaler_candidates = [
+            scaler_candidates: list[Path] = []
+            if scaler_path is not None:
+                scaler_candidates.append(scaler_path)
+            scaler_candidates.extend([
                 run_dir / f"scaler_{split_mode}.pkl",
                 run_dir / "scaler.pkl",
-            ]
+            ])
             # Also check dataset processed dir if metadata has dataset name.
             dataset_name = meta.get("dataset", "bosphorus")
             data_root = Path(meta.get("data_root", ""))

--- a/sozia/server.py
+++ b/sozia/server.py
@@ -43,6 +43,7 @@ ENV_DEVICE = "SOZIA_DEVICE"
 ENV_WHISPER_WEIGHTS = "SOZIA_WHISPER_WEIGHTS"
 ENV_LIP_WEIGHTS = "SOZIA_LIP_WEIGHTS"
 ENV_TSL_WEIGHTS = "SOZIA_TSL_WEIGHTS"
+ENV_TSL_SCALER = "SOZIA_TSL_SCALER"
 ENV_GLOSS_WEIGHTS = "SOZIA_GLOSS_WEIGHTS"
 
 _DEFAULT_DEVICE = "cpu"
@@ -93,13 +94,18 @@ def _sign_configs(device: str) -> tuple[ModelConfig | None, ModelConfig | None]:
     """Return (tsl_config, gloss_config); None where weights are not configured."""
     tsl_path = _weights(ENV_TSL_WEIGHTS)
     gloss_path = _weights(ENV_GLOSS_WEIGHTS)
+    tsl_scaler = _weights(ENV_TSL_SCALER)
+
+    tsl_params: dict = {}
+    if tsl_scaler:
+        tsl_params["scaler_path"] = tsl_scaler
 
     tsl_cfg = (
         ModelConfig(
             model_id="tsl-gru-v1",
             weights_path=tsl_path,
             device=device,
-            params={},
+            params=tsl_params,
         )
         if tsl_path
         else None

--- a/tests/inference/sign/test_tsl_recognition_engine.py
+++ b/tests/inference/sign/test_tsl_recognition_engine.py
@@ -25,12 +25,19 @@ _NUM_CLASSES = 10
 _MAX_SEQ_LEN = 150
 
 
-def _make_config(run_dir: str, model_id: str = "tsl-gru-v1") -> ModelConfig:
+class _FakeScaler:
+    """Picklable scaler stub — identity transform."""
+
+    def transform(self, x):
+        return x
+
+
+def _make_config(run_dir: str, model_id: str = "tsl-gru-v1", params: dict | None = None) -> ModelConfig:
     return ModelConfig(
         model_id=model_id,
         weights_path=run_dir,
         device="cpu",
-        params={},
+        params=params or {},
     )
 
 
@@ -179,6 +186,53 @@ class TestTslRecognitionEnginePreprocess:
         arr, length = engine._preprocess(_make_features(200))
         assert arr.shape == (150, _FEATURE_DIM)
         assert length == 150
+
+
+class TestTslRecognitionEngineScalerPath:
+    async def test_explicit_scaler_path_is_used(self, tmp_path):
+        """scaler_path in params takes priority over run-dir candidate search."""
+        import json
+        import pickle
+
+        from sozia.inference.sign.tsl_recognition_engine import TslRecognitionEngine
+
+        run_dir = _create_fake_run_dir(tmp_path)
+
+        # Write a picklable stub scaler to a separate dir (mimics scalers/AUTSL/).
+        scaler_dir = tmp_path / "scalers" / "AUTSL"
+        scaler_dir.mkdir(parents=True)
+        scaler_file = scaler_dir / "scaler_signer.pkl"
+        with open(scaler_file, "wb") as f:
+            pickle.dump(_FakeScaler(), f)
+
+        # Enable normalisation in the run dir config.
+        config_path = run_dir / "config.json"
+        with open(config_path) as f:
+            meta = json.load(f)
+        meta["normalize_features"] = True
+        with open(config_path, "w") as f:
+            json.dump(meta, f)
+
+        engine = TslRecognitionEngine()
+        await engine.load_model(
+            _make_config(str(run_dir), params={"scaler_path": str(scaler_file)})
+        )
+
+        assert engine._scaler is not None
+        assert engine.is_loaded()
+
+    async def test_missing_explicit_scaler_path_falls_back(self, tmp_path):
+        """If scaler_path points to a non-existent file, fall back to candidates."""
+        from sozia.inference.sign.tsl_recognition_engine import TslRecognitionEngine
+
+        run_dir = _create_fake_run_dir(tmp_path)
+        engine = TslRecognitionEngine()
+        # Fake path that doesn't exist — engine should load fine (scaler stays None).
+        await engine.load_model(
+            _make_config(str(run_dir), params={"scaler_path": "/nonexistent/scaler.pkl"})
+        )
+        assert engine.is_loaded()
+        assert engine._scaler is None
 
 
 class TestTslRecognitionEngineLoadErrors:

--- a/tests/inference/sign/test_tsl_recognition_engine.py
+++ b/tests/inference/sign/test_tsl_recognition_engine.py
@@ -3,16 +3,14 @@
 from __future__ import annotations
 
 import json
-import os
-import tempfile
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import numpy as np
 import pytest
 import torch
 
-from sozia.common.interfaces import InferenceTimeoutError, ModelNotLoadedError
+from sozia.common.interfaces import ModelNotLoadedError
 from sozia.common.models import ModelConfig, ModalityType
 
 
@@ -32,7 +30,9 @@ class _FakeScaler:
         return x
 
 
-def _make_config(run_dir: str, model_id: str = "tsl-gru-v1", params: dict | None = None) -> ModelConfig:
+def _make_config(
+    run_dir: str, model_id: str = "tsl-gru-v1", params: dict | None = None
+) -> ModelConfig:
     return ModelConfig(
         model_id=model_id,
         weights_path=run_dir,
@@ -229,7 +229,9 @@ class TestTslRecognitionEngineScalerPath:
         engine = TslRecognitionEngine()
         # Fake path that doesn't exist — engine should load fine (scaler stays None).
         await engine.load_model(
-            _make_config(str(run_dir), params={"scaler_path": "/nonexistent/scaler.pkl"})
+            _make_config(
+                str(run_dir), params={"scaler_path": "/nonexistent/scaler.pkl"}
+            )
         )
         assert engine.is_loaded()
         assert engine._scaler is None
@@ -252,8 +254,10 @@ class TestTslRecognitionEngineLoadErrors:
         run_dir = tmp_path / "run_no_ckpt"
         run_dir.mkdir()
         config = {
-            "model_arch": "gru", "model_size": "small",
-            "feature_dim": _FEATURE_DIM, "classes_to_process": ["A", "B"],
+            "model_arch": "gru",
+            "model_size": "small",
+            "feature_dim": _FEATURE_DIM,
+            "classes_to_process": ["A", "B"],
             "max_sequence_length": 150,
         }
         with open(run_dir / "config.json", "w") as f:
@@ -271,8 +275,10 @@ class TestGruModel:
         from sozia.inference.sign._gru_model import ActionGRU
 
         model = ActionGRU(
-            input_size=_FEATURE_DIM, num_classes=_NUM_CLASSES,
-            model_size="small", dropout=0.4,
+            input_size=_FEATURE_DIM,
+            num_classes=_NUM_CLASSES,
+            model_size="small",
+            dropout=0.4,
         )
         x = torch.randn(2, 50, _FEATURE_DIM)
         lengths = torch.tensor([50, 30])
@@ -283,7 +289,8 @@ class TestGruModel:
         from sozia.inference.sign._gru_model import ActionGRU
 
         model = ActionGRU(
-            input_size=_FEATURE_DIM, num_classes=_NUM_CLASSES,
+            input_size=_FEATURE_DIM,
+            num_classes=_NUM_CLASSES,
         )
         model.eval()  # BatchNorm requires eval mode for batch_size=1
         x = torch.randn(1, 50, _FEATURE_DIM)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,106 @@
+"""Tests for sozia.server config helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from sozia.server import (
+    ENV_GLOSS_WEIGHTS,
+    ENV_LIP_WEIGHTS,
+    ENV_TSL_SCALER,
+    ENV_TSL_WEIGHTS,
+    ENV_WHISPER_WEIGHTS,
+    _sign_configs,
+    _speech_configs,
+)
+
+
+class TestSpeechConfigs:
+    def test_both_none_when_env_unset(self, monkeypatch):
+        monkeypatch.delenv(ENV_WHISPER_WEIGHTS, raising=False)
+        monkeypatch.delenv(ENV_LIP_WEIGHTS, raising=False)
+
+        asr, lip = _speech_configs("cpu")
+        assert asr is None
+        assert lip is None
+
+    def test_asr_config_built_from_env(self, monkeypatch):
+        monkeypatch.setenv(ENV_WHISPER_WEIGHTS, "/models/whisper.pt")
+        monkeypatch.delenv(ENV_LIP_WEIGHTS, raising=False)
+
+        asr, lip = _speech_configs("cpu")
+        assert asr is not None
+        assert asr.weights_path == "/models/whisper.pt"
+        assert asr.device == "cpu"
+        assert asr.model_id == "whisper-small-tr"
+        assert lip is None
+
+    def test_lip_config_built_from_env(self, monkeypatch):
+        monkeypatch.delenv(ENV_WHISPER_WEIGHTS, raising=False)
+        monkeypatch.setenv(ENV_LIP_WEIGHTS, "/models/lip.pt")
+
+        asr, lip = _speech_configs("cuda")
+        assert asr is None
+        assert lip is not None
+        assert lip.weights_path == "/models/lip.pt"
+        assert lip.device == "cuda"
+
+    def test_both_configs_when_both_set(self, monkeypatch):
+        monkeypatch.setenv(ENV_WHISPER_WEIGHTS, "/models/whisper.pt")
+        monkeypatch.setenv(ENV_LIP_WEIGHTS, "/models/lip.pt")
+
+        asr, lip = _speech_configs("cpu")
+        assert asr is not None
+        assert lip is not None
+
+
+class TestSignConfigs:
+    def test_both_none_when_env_unset(self, monkeypatch):
+        monkeypatch.delenv(ENV_TSL_WEIGHTS, raising=False)
+        monkeypatch.delenv(ENV_TSL_SCALER, raising=False)
+        monkeypatch.delenv(ENV_GLOSS_WEIGHTS, raising=False)
+
+        tsl, gloss = _sign_configs("cpu")
+        assert tsl is None
+        assert gloss is None
+
+    def test_tsl_config_without_scaler(self, monkeypatch):
+        monkeypatch.setenv(ENV_TSL_WEIGHTS, "/models/run_autsl")
+        monkeypatch.delenv(ENV_TSL_SCALER, raising=False)
+        monkeypatch.delenv(ENV_GLOSS_WEIGHTS, raising=False)
+
+        tsl, gloss = _sign_configs("cpu")
+        assert tsl is not None
+        assert tsl.weights_path == "/models/run_autsl"
+        assert tsl.params == {}
+        assert gloss is None
+
+    def test_tsl_config_with_scaler(self, monkeypatch):
+        monkeypatch.setenv(ENV_TSL_WEIGHTS, "/models/run_autsl")
+        monkeypatch.setenv(ENV_TSL_SCALER, "/models/scalers/AUTSL/scaler_signer.pkl")
+        monkeypatch.delenv(ENV_GLOSS_WEIGHTS, raising=False)
+
+        tsl, _ = _sign_configs("cpu")
+        assert tsl is not None
+        assert tsl.params["scaler_path"] == "/models/scalers/AUTSL/scaler_signer.pkl"
+
+    def test_gloss_config_built_from_env(self, monkeypatch):
+        monkeypatch.delenv(ENV_TSL_WEIGHTS, raising=False)
+        monkeypatch.delenv(ENV_TSL_SCALER, raising=False)
+        monkeypatch.setenv(ENV_GLOSS_WEIGHTS, "/models/gemma-9b-gloss-tr")
+
+        tsl, gloss = _sign_configs("cuda")
+        assert tsl is None
+        assert gloss is not None
+        assert gloss.weights_path == "/models/gemma-9b-gloss-tr"
+        assert gloss.device == "cuda"
+
+    def test_both_configs_when_both_set(self, monkeypatch):
+        monkeypatch.setenv(ENV_TSL_WEIGHTS, "/models/run_autsl")
+        monkeypatch.setenv(ENV_TSL_SCALER, "/models/scalers/AUTSL/scaler_signer.pkl")
+        monkeypatch.setenv(ENV_GLOSS_WEIGHTS, "/models/gemma-9b-gloss-tr")
+
+        tsl, gloss = _sign_configs("cuda")
+        assert tsl is not None
+        assert gloss is not None
+        assert tsl.params["scaler_path"] == "/models/scalers/AUTSL/scaler_signer.pkl"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import pytest
 
 from sozia.server import (
     ENV_GLOSS_WEIGHTS,


### PR DESCRIPTION
## What does this PR do?

sozia-research moved scalers to \`scalers/AUTSL/\` but the TSL engine's
candidate search only looked inside the run directory, so it silently
skipped normalisation. The engine now accepts an explicit \`scaler_path\`
in \`ModelConfig.params\` (checked first, before the fallback candidates).
\`server.py\` reads it from a new \`SOZIA_TSL_SCALER\` env var.

Also adds \`.env.example\` — the README described a \`.env\` setup but there
was no template to copy from.

## Which package(s) does it touch?

\`sozia/inference/sign\`, \`sozia/server.py\`, \`README.md\`, \`.env.example\`

## How to test

Copy \`.env.example\` to \`.env\`, set \`SOZIA_TSL_WEIGHTS\` and
\`SOZIA_TSL_SCALER\` to real paths, start the server, and send a SIGN
session. Without weights, run \`pytest tests/test_server.py
tests/inference/sign/test_tsl_recognition_engine.py\`.

## Checklist
- [x] Follows commit convention (\`<type>(<scope>): <description>\`)
- [x] Added/updated tests (if applicable)
- [x] No sozia.common schema changes (or: both repos updated)
- [x] Tested locally