### PR TITLE
lip-engine: fix decoder mismatch, zero timestamps, and face frame shape

### DIFF
--- a/sozia/server/fusion/orchestrator.py
+++ b/sozia/server/fusion/orchestrator.py
@@ -253,12 +253,8 @@ class FusionOrchestrator:
             if lip_entry is None or face_np is None:
                 return None
             lip_engine, _ = lip_entry
-            # _face_cache stores the latest single frame as (83, 3).
-            # Expand to (1, 249) so LipReadingEngine receives a valid sequence.
-            # DEV-07: MVP — single-frame sequence; replace with temporal buffer later.
-            face_seq = face_np.reshape(1, -1) if face_np.ndim == 2 else face_np
             try:
-                return await lip_engine.predict(face_seq)
+                return await lip_engine.predict(face_np)
             except InferenceTimeoutError:
                 return None
 

--- a/sozia/server/fusion/orchestrator.py
+++ b/sozia/server/fusion/orchestrator.py
@@ -13,6 +13,7 @@ it only touches the ``InferenceEngine`` interface (``load_model``,
 from __future__ import annotations
 
 import asyncio
+import dataclasses
 import time
 import uuid
 from typing import TYPE_CHECKING, Awaitable, Callable
@@ -252,8 +253,12 @@ class FusionOrchestrator:
             if lip_entry is None or face_np is None:
                 return None
             lip_engine, _ = lip_entry
+            # _face_cache stores the latest single frame as (83, 3).
+            # Expand to (1, 249) so LipReadingEngine receives a valid sequence.
+            # DEV-07: MVP — single-frame sequence; replace with temporal buffer later.
+            face_seq = face_np.reshape(1, -1) if face_np.ndim == 2 else face_np
             try:
-                return await lip_engine.predict(face_np)
+                return await lip_engine.predict(face_seq)
             except InferenceTimeoutError:
                 return None
 
@@ -261,6 +266,21 @@ class FusionOrchestrator:
 
         if asr_result is None:
             return  # ASR timed out or missing — nothing to emit.
+
+        # Stamp the session-timeline position from the AudioFeatureChunk.
+        # Engines return timestamp_ms=0 / duration_ms=0 (they have no timeline context);
+        # the orchestrator is the correct layer to fill this in.
+        asr_result = dataclasses.replace(
+            asr_result,
+            timestamp_ms=features.timestamp_ms,
+            duration_ms=features.chunk_duration_ms,
+        )
+        if lip_result is not None:
+            lip_result = dataclasses.replace(
+                lip_result,
+                timestamp_ms=features.timestamp_ms,
+                duration_ms=features.chunk_duration_ms,
+            )
 
         results = [asr_result]
         if lip_result is not None:

--- a/sozia/server/inference/speech/lip_reading_engine.py
+++ b/sozia/server/inference/speech/lip_reading_engine.py
@@ -255,7 +255,7 @@ class LipReadingEngine(InferenceEngine):
         if arr.ndim == 3:
             # (T, 83, 3) → (T, 249)
             arr = arr.reshape(arr.shape[0], -1)
-        elif arr.ndim == 2 and arr.shape[1] == 3:
+        elif arr.shape == (83, 3):
             # Single frame (83, 3) → (1, 249)
             arr = arr.reshape(1, -1)
 

--- a/sozia/server/inference/speech/lip_reading_engine.py
+++ b/sozia/server/inference/speech/lip_reading_engine.py
@@ -86,7 +86,9 @@ class LipReadingModel(nn.Module):
         )
 
     def forward(
-        self, x: torch.Tensor, lengths: torch.Tensor | None = None,
+        self,
+        x: torch.Tensor,
+        lengths: torch.Tensor | None = None,
     ) -> torch.Tensor:
         """Forward pass.
 
@@ -104,8 +106,10 @@ class LipReadingModel(nn.Module):
 
         if lengths is not None:
             packed = nn.utils.rnn.pack_padded_sequence(
-                out, lengths.cpu().clamp(min=1),
-                batch_first=True, enforce_sorted=False,
+                out,
+                lengths.cpu().clamp(min=1),
+                batch_first=True,
+                enforce_sorted=False,
             )
             packed_out, _ = self.gru(packed)
             out, _ = nn.utils.rnn.pad_packed_sequence(packed_out, batch_first=True)
@@ -157,8 +161,10 @@ class LipReadingEngine(InferenceEngine):
         )
 
         state_dict = await asyncio.to_thread(
-            torch.load, config.weights_path,
-            map_location=device, weights_only=True,
+            torch.load,
+            config.weights_path,
+            map_location=device,
+            weights_only=True,
         )
         model.load_state_dict(state_dict)
         model.to(device)
@@ -234,7 +240,8 @@ class LipReadingEngine(InferenceEngine):
     # ------------------------------------------------------------------
 
     def _prepare_input(
-        self, features: np.ndarray,
+        self,
+        features: np.ndarray,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """Normalise input shape and convert to batched tensor.
 
@@ -276,14 +283,17 @@ class LipReadingEngine(InferenceEngine):
         return tensor, length
 
     def _run_inference(
-        self, tensor: torch.Tensor, length: torch.Tensor,
+        self,
+        tensor: torch.Tensor,
+        length: torch.Tensor,
     ) -> torch.Tensor:
         """Synchronous forward pass — called inside ``to_thread``."""
         with torch.no_grad():
             return self._model(tensor, lengths=length)
 
     def _decode_output(
-        self, logits: torch.Tensor,
+        self,
+        logits: torch.Tensor,
     ) -> tuple[str, float]:
         """Argmax-decode classifier logits into a word label and confidence.
 

--- a/sozia/server/inference/speech/lip_reading_engine.py
+++ b/sozia/server/inference/speech/lip_reading_engine.py
@@ -1,8 +1,16 @@
 """LipReadingEngine — visual speech recognition from facial landmarks.
 
 Receives a sequence of 83-point facial landmark frames (extracted by
-MediaPipe Face Mesh on the client), runs them through a CNN/RNN encoder-
-decoder, and returns a ModalityResult with recognised text.
+MediaPipe Face Mesh on the client), runs them through a CNN-GRU word
+classifier, and returns a ModalityResult with the predicted word label.
+
+Architecture (word classifier, not CTC):
+    Conv1d temporal smoother → GRU encoder → last real-frame hidden state
+    → BN → ReLU → Dropout → Linear(num_classes)
+
+The model is trained offline on face landmarks from the TSL datasets
+(AUTSL / BosphorusSign22k) using weak supervision: sign class names
+(Turkish words) serve as word-level labels.
 
 In the speech pipeline this is the *secondary* (slower) modality: ASR emits
 PARTIAL immediately, lip-reading arrives later and the fusion layer produces
@@ -38,12 +46,14 @@ _FACE_FEATURE_DIM = 249
 
 
 class LipReadingModel(nn.Module):
-    """Lightweight CNN-GRU encoder with CTC-style linear head.
+    """CNN-GRU word classifier for lip-motion features.
 
     Architecture:
-        1-D Conv block (temporal smoothing) → GRU encoder → FC → output vocab
-    The model is intentionally small so that inference fits within 1200 ms on
-    CPU.  Weights are trained offline and loaded via ``state_dict``.
+        1-D Conv block (temporal smoothing) → GRU encoder
+        → last real-frame hidden state → classifier head (BN → ReLU → Dropout → Linear)
+
+    Output is ``(batch, num_classes)`` — one class prediction per input sequence.
+    Training uses cross-entropy with word-level labels from TSL sign class names.
     """
 
     def __init__(
@@ -51,7 +61,7 @@ class LipReadingModel(nn.Module):
         input_dim: int = _FACE_FEATURE_DIM,
         hidden_dim: int = 256,
         num_layers: int = 3,
-        vocab_size: int = 1024,
+        num_classes: int = 226,
         dropout: float = 0.3,
     ) -> None:
         super().__init__()
@@ -66,10 +76,14 @@ class LipReadingModel(nn.Module):
             hidden_size=hidden_dim,
             num_layers=num_layers,
             batch_first=True,
-            dropout=dropout if num_layers > 1 else 0,
-            bidirectional=True,
+            dropout=dropout if num_layers > 1 else 0.0,
         )
-        self.fc = nn.Linear(hidden_dim * 2, vocab_size)
+        self.head = nn.Sequential(
+            nn.BatchNorm1d(hidden_dim),
+            nn.ReLU(),
+            nn.Dropout(dropout),
+            nn.Linear(hidden_dim, num_classes),
+        )
 
     def forward(
         self, x: torch.Tensor, lengths: torch.Tensor | None = None,
@@ -78,12 +92,14 @@ class LipReadingModel(nn.Module):
 
         Args:
             x: ``(batch, seq_len, input_dim)``
-            lengths: actual sequence lengths ``(batch,)``
+            lengths: Actual sequence lengths ``(batch,)``. When provided,
+                the last *real* frame's hidden state is used as the sequence
+                representation, avoiding zero-pad contamination.
 
         Returns:
-            Logits of shape ``(batch, seq_len, vocab_size)``.
+            Class logits of shape ``(batch, num_classes)``.
         """
-        # Conv expects (batch, channels, seq_len)
+        # Conv expects (batch, channels, seq_len).
         out = self.conv(x.transpose(1, 2)).transpose(1, 2)
 
         if lengths is not None:
@@ -93,21 +109,26 @@ class LipReadingModel(nn.Module):
             )
             packed_out, _ = self.gru(packed)
             out, _ = nn.utils.rnn.pad_packed_sequence(packed_out, batch_first=True)
+            # Index the last real frame for each sample in the batch.
+            idx = (lengths - 1).clamp(min=0).to(out.device)
+            last = out[torch.arange(out.size(0), device=out.device), idx]
         else:
             out, _ = self.gru(out)
+            last = out[:, -1, :]  # (batch, hidden_dim)
 
-        return self.fc(out)
+        return self.head(last)  # (batch, num_classes)
 
 
 class LipReadingEngine(InferenceEngine):
-    """InferenceEngine implementation for visual speech recognition.
+    """InferenceEngine implementation for word-level lip-motion classification.
 
     Expected ``ModelConfig.params`` keys (all optional):
         hidden_dim (int): GRU hidden size, default ``256``.
         num_layers (int): GRU layers, default ``3``.
-        vocab_size (int): Output vocabulary size, default ``1024``.
+        num_classes (int): Number of word classes, default ``226`` (AUTSL).
         max_seq_len (int): Max input frames, default ``150``.
-        vocab_path (str): Path to token→text vocabulary file.
+        vocab_path (str): Path to newline-delimited vocabulary file (class
+            index → word label, one word per line).
     """
 
     def __init__(self) -> None:
@@ -125,14 +146,14 @@ class LipReadingEngine(InferenceEngine):
         device = torch.device(config.device)
         hidden_dim = config.params.get("hidden_dim", 256)
         num_layers = config.params.get("num_layers", 3)
-        vocab_size = config.params.get("vocab_size", 1024)
+        num_classes = config.params.get("num_classes", 226)
         self._max_seq_len = config.params.get("max_seq_len", 150)
 
         model = LipReadingModel(
             input_dim=_FACE_FEATURE_DIM,
             hidden_dim=hidden_dim,
             num_layers=num_layers,
-            vocab_size=vocab_size,
+            num_classes=num_classes,
         )
 
         state_dict = await asyncio.to_thread(
@@ -160,12 +181,12 @@ class LipReadingEngine(InferenceEngine):
 
         Args:
             features: Numpy array of shape ``(T, 249)`` — T frames of 83
-                landmarks × 3 coordinates each. Alternatively ``(T, 83, 3)``
-                which is reshaped automatically.
+                landmarks × 3 coordinates each. Accepts ``(T, 83, 3)`` and
+                single-frame inputs ``(83, 3)`` which are reshaped automatically.
             timeout_ms: Maximum wall-clock time in ms (default 1200).
 
         Returns:
-            ModalityResult with recognised text and confidence.
+            ModalityResult with predicted word label and softmax confidence.
         """
         if self._model is None:
             raise ModelNotLoadedError("LipReadingEngine: no model loaded.")
@@ -184,7 +205,7 @@ class LipReadingEngine(InferenceEngine):
             )
 
         latency_ms = int((time.perf_counter() - start) * 1000)
-        text, confidence = self._decode_output(logits, length)
+        text, confidence = self._decode_output(logits)
 
         return ModalityResult(
             modality_type=ModalityType.LIP_READING,
@@ -215,12 +236,21 @@ class LipReadingEngine(InferenceEngine):
     def _prepare_input(
         self, features: np.ndarray,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        """Normalise input shape and convert to batched tensor."""
+        """Normalise input shape and convert to batched tensor.
+
+        Accepted input shapes:
+            ``(T, 249)``     — T frames already flattened
+            ``(T, 83, 3)``   — T frames as landmark arrays (reshaped to flat)
+            ``(83, 3)``      — single frame (expanded to ``(1, 249)``)
+        """
         arr = np.asarray(features, dtype=np.float32)
 
         if arr.ndim == 3:
             # (T, 83, 3) → (T, 249)
             arr = arr.reshape(arr.shape[0], -1)
+        elif arr.ndim == 2 and arr.shape[1] == 3:
+            # Single frame (83, 3) → (1, 249)
+            arr = arr.reshape(1, -1)
 
         if arr.ndim != 2 or arr.shape[1] != _FACE_FEATURE_DIM:
             raise ValueError(
@@ -253,41 +283,35 @@ class LipReadingEngine(InferenceEngine):
             return self._model(tensor, lengths=length)
 
     def _decode_output(
-        self, logits: torch.Tensor, length: torch.Tensor,
+        self, logits: torch.Tensor,
     ) -> tuple[str, float]:
-        """Greedy-decode logits into text and derive a confidence score."""
-        # logits: (1, seq_len, vocab_size)
-        probs = torch.softmax(logits[0], dim=-1)
-        pred_ids = torch.argmax(probs, dim=-1)  # (seq_len,)
-        max_probs = probs.gather(1, pred_ids.unsqueeze(-1)).squeeze(-1)
+        """Argmax-decode classifier logits into a word label and confidence.
 
-        actual_len = int(length[0].item())
-        pred_ids = pred_ids[:actual_len]
-        max_probs = max_probs[:actual_len]
+        Args:
+            logits: ``(1, num_classes)`` raw logits from the model.
 
-        # CTC blank-collapse: remove consecutive duplicates and blank (id=0).
-        collapsed: list[int] = []
-        conf_scores: list[float] = []
-        prev = -1
-        for i, tok_id in enumerate(pred_ids.tolist()):
-            if tok_id != 0 and tok_id != prev:
-                collapsed.append(tok_id)
-                conf_scores.append(max_probs[i].item())
-            prev = tok_id
+        Returns:
+            ``(text, confidence)`` where ``text`` is the predicted word
+            (or class index string when no vocab is loaded) and
+            ``confidence`` is the softmax probability at the predicted class.
+        """
+        # logits: (1, num_classes)
+        probs = torch.softmax(logits[0], dim=-1)  # (num_classes,)
+        class_idx = int(torch.argmax(probs).item())
+        confidence = float(probs[class_idx].item())
 
-        if self._vocab and collapsed:
-            text = " ".join(
-                self._vocab[tid] if tid < len(self._vocab) else f"<{tid}>"
-                for tid in collapsed
-            )
+        if self._vocab and class_idx < len(self._vocab):
+            text = self._vocab[class_idx]
         else:
-            text = " ".join(str(tid) for tid in collapsed)
+            text = str(class_idx)
 
-        confidence = float(np.mean(conf_scores)) if conf_scores else 0.0
         return text, max(0.0, min(1.0, confidence))
 
     @staticmethod
     def _load_vocab(path: str) -> list[str]:
-        """Load a newline-delimited vocabulary file."""
+        """Load a newline-delimited vocabulary file.
+
+        Line number = class index. Each line is the word label for that class.
+        """
         with open(path, encoding="utf-8") as f:
             return [line.strip() for line in f]

--- a/tests/fusion/test_orchestrator_process.py
+++ b/tests/fusion/test_orchestrator_process.py
@@ -463,7 +463,11 @@ class TestProcessSpeech:
 
         sent: list[TranscriptSegment] = []
         await orch.process(
-            _SESSION, chunk, [_audio_health()], ModalityPath.SPEECH, sent.append,
+            _SESSION,
+            chunk,
+            [_audio_health()],
+            ModalityPath.SPEECH,
+            sent.append,
         )
 
         assert len(sent) >= 1
@@ -482,23 +486,35 @@ class TestProcessSpeech:
             chunk_duration_ms=500,
         )
         asr = _StubEngine(_result(ModalityType.ASR, "hello", 0.75), model_id="w")
-        lip = _StubEngine(_result(ModalityType.LIP_READING, "hello", 0.80), model_id="l")
+        lip = _StubEngine(
+            _result(ModalityType.LIP_READING, "hello", 0.80), model_id="l"
+        )
         asr._loaded = True
         lip._loaded = True
 
         orch = FusionOrchestrator()
         orch.register_policy(ModalityPath.SPEECH, SpeechFusionPolicy())
         orch.register_engine(ModalityPath.SPEECH, ModalityType.ASR, asr, _cfg("w"))
-        orch.register_engine(ModalityPath.SPEECH, ModalityType.LIP_READING, lip, _cfg("l"))
+        orch.register_engine(
+            ModalityPath.SPEECH, ModalityType.LIP_READING, lip, _cfg("l")
+        )
 
         # Prime face cache.
         await orch.process(
-            _SESSION, _landmark_frame(), [_video_health()], ModalityPath.SPEECH, lambda _: None,
+            _SESSION,
+            _landmark_frame(),
+            [_video_health()],
+            ModalityPath.SPEECH,
+            lambda _: None,
         )
 
         sent: list[TranscriptSegment] = []
         await orch.process(
-            _SESSION, chunk, [_audio_health()], ModalityPath.SPEECH, sent.append,
+            _SESSION,
+            chunk,
+            [_audio_health()],
+            ModalityPath.SPEECH,
+            sent.append,
         )
 
         assert any(s.status == SegmentStatus.FINAL for s in sent)

--- a/tests/fusion/test_orchestrator_process.py
+++ b/tests/fusion/test_orchestrator_process.py
@@ -444,6 +444,68 @@ class TestProcessSpeech:
         )
         assert sent == []
 
+    async def test_segments_carry_timestamp_from_audio_chunk(self):
+        """Orchestrator stamps timestamp_ms/duration_ms from AudioFeatureChunk."""
+        chunk = AudioFeatureChunk(
+            session_id=_SESSION,
+            timestamp_ms=5000,
+            features=[[0.1, 0.2]] * 10,
+            feature_type="mfcc",
+            sample_rate_hz=16000,
+            chunk_duration_ms=750,
+        )
+        asr = _StubEngine(_result(ModalityType.ASR, "test", 0.85), model_id="w")
+        asr._loaded = True
+
+        orch = FusionOrchestrator()
+        orch.register_policy(ModalityPath.SPEECH, SpeechFusionPolicy())
+        orch.register_engine(ModalityPath.SPEECH, ModalityType.ASR, asr, _cfg("w"))
+
+        sent: list[TranscriptSegment] = []
+        await orch.process(
+            _SESSION, chunk, [_audio_health()], ModalityPath.SPEECH, sent.append,
+        )
+
+        assert len(sent) >= 1
+        for seg in sent:
+            assert seg.timestamp_ms == 5000
+            assert seg.duration_ms == 750
+
+    async def test_lip_result_also_carries_audio_chunk_timing(self):
+        """Both ASR and LipReading results get stamped with the same AudioFeatureChunk timing."""
+        chunk = AudioFeatureChunk(
+            session_id=_SESSION,
+            timestamp_ms=3000,
+            features=[[0.1]] * 5,
+            feature_type="mfcc",
+            sample_rate_hz=16000,
+            chunk_duration_ms=500,
+        )
+        asr = _StubEngine(_result(ModalityType.ASR, "hello", 0.75), model_id="w")
+        lip = _StubEngine(_result(ModalityType.LIP_READING, "hello", 0.80), model_id="l")
+        asr._loaded = True
+        lip._loaded = True
+
+        orch = FusionOrchestrator()
+        orch.register_policy(ModalityPath.SPEECH, SpeechFusionPolicy())
+        orch.register_engine(ModalityPath.SPEECH, ModalityType.ASR, asr, _cfg("w"))
+        orch.register_engine(ModalityPath.SPEECH, ModalityType.LIP_READING, lip, _cfg("l"))
+
+        # Prime face cache.
+        await orch.process(
+            _SESSION, _landmark_frame(), [_video_health()], ModalityPath.SPEECH, lambda _: None,
+        )
+
+        sent: list[TranscriptSegment] = []
+        await orch.process(
+            _SESSION, chunk, [_audio_health()], ModalityPath.SPEECH, sent.append,
+        )
+
+        assert any(s.status == SegmentStatus.FINAL for s in sent)
+        for seg in sent:
+            assert seg.timestamp_ms == 3000
+            assert seg.duration_ms == 500
+
 
 # ---------------------------------------------------------------------------
 # process() — Path B (SIGN)

--- a/tests/inference/speech/test_lip_reading_engine.py
+++ b/tests/inference/speech/test_lip_reading_engine.py
@@ -52,7 +52,10 @@ class TestLipReadingModel:
         from sozia.server.inference.speech.lip_reading_engine import LipReadingModel
 
         model = LipReadingModel(
-            input_dim=_FACE_DIM, hidden_dim=64, num_layers=1, num_classes=_NUM_CLASSES,
+            input_dim=_FACE_DIM,
+            hidden_dim=64,
+            num_layers=1,
+            num_classes=_NUM_CLASSES,
         )
         x = torch.randn(2, 50, _FACE_DIM)
         lengths = torch.tensor([50, 30])
@@ -64,7 +67,10 @@ class TestLipReadingModel:
         from sozia.server.inference.speech.lip_reading_engine import LipReadingModel
 
         model = LipReadingModel(
-            input_dim=_FACE_DIM, hidden_dim=64, num_layers=1, num_classes=_NUM_CLASSES,
+            input_dim=_FACE_DIM,
+            hidden_dim=64,
+            num_layers=1,
+            num_classes=_NUM_CLASSES,
         )
         model.eval()
         x = torch.randn(1, 50, _FACE_DIM)
@@ -76,7 +82,10 @@ class TestLipReadingModel:
         from sozia.server.inference.speech.lip_reading_engine import LipReadingModel
 
         model = LipReadingModel(
-            input_dim=_FACE_DIM, hidden_dim=64, num_layers=1, num_classes=_NUM_CLASSES,
+            input_dim=_FACE_DIM,
+            hidden_dim=64,
+            num_layers=1,
+            num_classes=_NUM_CLASSES,
         )
         model.eval()
         x = torch.randn(1, 30, _FACE_DIM)
@@ -105,7 +114,10 @@ class TestLipReadingEngineState:
         )
 
         model = LipReadingModel(
-            input_dim=_FACE_DIM, hidden_dim=64, num_layers=1, num_classes=_NUM_CLASSES,
+            input_dim=_FACE_DIM,
+            hidden_dim=64,
+            num_layers=1,
+            num_classes=_NUM_CLASSES,
         )
         state_dict = model.state_dict()
 
@@ -140,7 +152,10 @@ class TestLipReadingEnginePredict:
         )
 
         model = LipReadingModel(
-            input_dim=_FACE_DIM, hidden_dim=64, num_layers=1, num_classes=_NUM_CLASSES,
+            input_dim=_FACE_DIM,
+            hidden_dim=64,
+            num_layers=1,
+            num_classes=_NUM_CLASSES,
         )
         state_dict = model.state_dict()
 
@@ -161,7 +176,10 @@ class TestLipReadingEnginePredict:
         )
 
         model = LipReadingModel(
-            input_dim=_FACE_DIM, hidden_dim=64, num_layers=1, num_classes=_NUM_CLASSES,
+            input_dim=_FACE_DIM,
+            hidden_dim=64,
+            num_layers=1,
+            num_classes=_NUM_CLASSES,
         )
         state_dict = model.state_dict()
 
@@ -180,7 +198,10 @@ class TestLipReadingEnginePredict:
         )
 
         model = LipReadingModel(
-            input_dim=_FACE_DIM, hidden_dim=64, num_layers=1, num_classes=_NUM_CLASSES,
+            input_dim=_FACE_DIM,
+            hidden_dim=64,
+            num_layers=1,
+            num_classes=_NUM_CLASSES,
         )
         state_dict = model.state_dict()
 
@@ -201,7 +222,10 @@ class TestLipReadingEnginePredict:
         )
 
         model = LipReadingModel(
-            input_dim=_FACE_DIM, hidden_dim=64, num_layers=1, num_classes=_NUM_CLASSES,
+            input_dim=_FACE_DIM,
+            hidden_dim=64,
+            num_layers=1,
+            num_classes=_NUM_CLASSES,
         )
         state_dict = model.state_dict()
 

--- a/tests/inference/speech/test_lip_reading_engine.py
+++ b/tests/inference/speech/test_lip_reading_engine.py
@@ -17,14 +17,15 @@ from sozia.common.models import ModelConfig, ModalityType
 # ---------------------------------------------------------------------------
 
 _FACE_DIM = 249  # 83 points × 3 coords
+_NUM_CLASSES = 32
 
 
-def _make_config(model_id: str = "lipreading-cnn-gru-v1") -> ModelConfig:
+def _make_config(model_id: str = "lipreading-gru-v1") -> ModelConfig:
     return ModelConfig(
         model_id=model_id,
         weights_path="/tmp/lipreading.pt",
         device="cpu",
-        params={"hidden_dim": 64, "num_layers": 1, "vocab_size": 32},
+        params={"hidden_dim": 64, "num_layers": 1, "num_classes": _NUM_CLASSES},
     )
 
 
@@ -39,7 +40,53 @@ def _make_landmarks_3d(n_frames: int = 30) -> np.ndarray:
 
 
 # ---------------------------------------------------------------------------
-# Tests
+# Model architecture tests
+# ---------------------------------------------------------------------------
+
+
+class TestLipReadingModel:
+    """Smoke-test the model architecture."""
+
+    def test_forward_output_shape(self):
+        """Classifier outputs (batch, num_classes) — one prediction per sequence."""
+        from sozia.server.inference.speech.lip_reading_engine import LipReadingModel
+
+        model = LipReadingModel(
+            input_dim=_FACE_DIM, hidden_dim=64, num_layers=1, num_classes=_NUM_CLASSES,
+        )
+        x = torch.randn(2, 50, _FACE_DIM)
+        lengths = torch.tensor([50, 30])
+        out = model(x, lengths=lengths)
+        assert out.shape == (2, _NUM_CLASSES)
+
+    def test_forward_without_lengths(self):
+        """Without lengths, last sequence step is used. eval() required for batch_size=1."""
+        from sozia.server.inference.speech.lip_reading_engine import LipReadingModel
+
+        model = LipReadingModel(
+            input_dim=_FACE_DIM, hidden_dim=64, num_layers=1, num_classes=_NUM_CLASSES,
+        )
+        model.eval()
+        x = torch.randn(1, 50, _FACE_DIM)
+        out = model(x)
+        assert out.shape == (1, _NUM_CLASSES)
+
+    def test_forward_batch_size_one(self):
+        """eval() required: BatchNorm1d needs running stats for single-sample batches."""
+        from sozia.server.inference.speech.lip_reading_engine import LipReadingModel
+
+        model = LipReadingModel(
+            input_dim=_FACE_DIM, hidden_dim=64, num_layers=1, num_classes=_NUM_CLASSES,
+        )
+        model.eval()
+        x = torch.randn(1, 30, _FACE_DIM)
+        lengths = torch.tensor([30])
+        out = model(x, lengths=lengths)
+        assert out.shape == (1, _NUM_CLASSES)
+
+
+# ---------------------------------------------------------------------------
+# Engine lifecycle tests
 # ---------------------------------------------------------------------------
 
 
@@ -58,7 +105,7 @@ class TestLipReadingEngineState:
         )
 
         model = LipReadingModel(
-            input_dim=_FACE_DIM, hidden_dim=64, num_layers=1, vocab_size=32,
+            input_dim=_FACE_DIM, hidden_dim=64, num_layers=1, num_classes=_NUM_CLASSES,
         )
         state_dict = model.state_dict()
 
@@ -66,11 +113,16 @@ class TestLipReadingEngineState:
             engine = LipReadingEngine()
             await engine.load_model(_make_config())
             assert engine.is_loaded() is True
-            assert engine.get_model_id() == "lipreading-cnn-gru-v1"
+            assert engine.get_model_id() == "lipreading-gru-v1"
 
             await engine.unload_model()
             assert engine.is_loaded() is False
             assert engine.get_model_id() == ""
+
+
+# ---------------------------------------------------------------------------
+# Predict tests
+# ---------------------------------------------------------------------------
 
 
 class TestLipReadingEnginePredict:
@@ -88,7 +140,7 @@ class TestLipReadingEnginePredict:
         )
 
         model = LipReadingModel(
-            input_dim=_FACE_DIM, hidden_dim=64, num_layers=1, vocab_size=32,
+            input_dim=_FACE_DIM, hidden_dim=64, num_layers=1, num_classes=_NUM_CLASSES,
         )
         state_dict = model.state_dict()
 
@@ -109,7 +161,7 @@ class TestLipReadingEnginePredict:
         )
 
         model = LipReadingModel(
-            input_dim=_FACE_DIM, hidden_dim=64, num_layers=1, vocab_size=32,
+            input_dim=_FACE_DIM, hidden_dim=64, num_layers=1, num_classes=_NUM_CLASSES,
         )
         state_dict = model.state_dict()
 
@@ -119,6 +171,72 @@ class TestLipReadingEnginePredict:
 
         result = await engine.predict(_make_landmarks_3d())
         assert result.modality_type == ModalityType.LIP_READING
+
+    async def test_predict_with_vocab_returns_word_text(self):
+        """When vocab is loaded, text should be the word at the predicted class index."""
+        from sozia.server.inference.speech.lip_reading_engine import (
+            LipReadingEngine,
+            LipReadingModel,
+        )
+
+        model = LipReadingModel(
+            input_dim=_FACE_DIM, hidden_dim=64, num_layers=1, num_classes=_NUM_CLASSES,
+        )
+        state_dict = model.state_dict()
+
+        with patch("torch.load", return_value=state_dict):
+            engine = LipReadingEngine()
+            await engine.load_model(_make_config())
+
+        # Inject a vocab so we can verify word lookup.
+        engine._vocab = [f"word_{i}" for i in range(_NUM_CLASSES)]
+
+        result = await engine.predict(_make_landmarks())
+        assert result.text.startswith("word_")
+
+    async def test_predict_without_vocab_returns_class_index_string(self):
+        from sozia.server.inference.speech.lip_reading_engine import (
+            LipReadingEngine,
+            LipReadingModel,
+        )
+
+        model = LipReadingModel(
+            input_dim=_FACE_DIM, hidden_dim=64, num_layers=1, num_classes=_NUM_CLASSES,
+        )
+        state_dict = model.state_dict()
+
+        with patch("torch.load", return_value=state_dict):
+            engine = LipReadingEngine()
+            await engine.load_model(_make_config())
+
+        # No vocab — should fall back to class index string.
+        engine._vocab = None
+        result = await engine.predict(_make_landmarks())
+        assert result.text.isdigit()
+
+    async def test_predict_timeout_raises(self):
+        import time as _time
+
+        from sozia.server.inference.speech.lip_reading_engine import LipReadingEngine
+
+        engine = LipReadingEngine()
+        engine._model = MagicMock()
+        engine._device = torch.device("cpu")
+        engine._max_seq_len = 150
+
+        def _slow_inference(*_):
+            # Synchronous sleep — mimics a slow model inside to_thread.
+            _time.sleep(10)
+            return torch.randn(1, _NUM_CLASSES)
+
+        with patch.object(engine, "_run_inference", side_effect=_slow_inference):
+            with pytest.raises(InferenceTimeoutError):
+                await engine.predict(_make_landmarks(), timeout_ms=1)
+
+
+# ---------------------------------------------------------------------------
+# Input preparation tests
+# ---------------------------------------------------------------------------
 
 
 class TestLipReadingEngineInput:
@@ -152,27 +270,61 @@ class TestLipReadingEngineInput:
         assert tensor.shape == (1, 150, _FACE_DIM)
         assert length.item() == 150
 
+    async def test_accepts_single_frame_83x3(self):
+        """Single frame (83, 3) from _face_cache is expanded to (1, 249) — DEV-07 MVP path."""
+        from sozia.server.inference.speech.lip_reading_engine import LipReadingEngine
 
-class TestLipReadingModel:
-    """Smoke test the model architecture itself."""
+        engine = LipReadingEngine()
+        engine._model = MagicMock()
+        engine._device = torch.device("cpu")
+        engine._max_seq_len = 150
+        single_frame = np.random.randn(83, 3).astype(np.float32)
+        tensor, length = engine._prepare_input(single_frame)
+        assert tensor.shape == (1, 150, _FACE_DIM)
+        assert length.item() == 1
 
-    def test_forward_shape(self):
-        from sozia.server.inference.speech.lip_reading_engine import LipReadingModel
 
-        model = LipReadingModel(
-            input_dim=_FACE_DIM, hidden_dim=64, num_layers=1, vocab_size=32,
-        )
-        x = torch.randn(2, 50, _FACE_DIM)
-        lengths = torch.tensor([50, 30])
-        out = model(x, lengths=lengths)
-        assert out.shape == (2, 50, 32)
+# ---------------------------------------------------------------------------
+# Decode tests
+# ---------------------------------------------------------------------------
 
-    def test_forward_without_lengths(self):
-        from sozia.server.inference.speech.lip_reading_engine import LipReadingModel
 
-        model = LipReadingModel(
-            input_dim=_FACE_DIM, hidden_dim=64, num_layers=1, vocab_size=32,
-        )
-        x = torch.randn(1, 50, _FACE_DIM)
-        out = model(x)
-        assert out.shape == (1, 50, 32)
+class TestLipReadingEngineDecode:
+    def test_decode_with_vocab_returns_word(self):
+        from sozia.server.inference.speech.lip_reading_engine import LipReadingEngine
+
+        engine = LipReadingEngine()
+        vocab = [f"word_{i}" for i in range(_NUM_CLASSES)]
+        engine._vocab = vocab
+
+        # Force class 5 to be highest probability.
+        logits = torch.full((1, _NUM_CLASSES), -1.0)
+        logits[0, 5] = 10.0
+        text, confidence = engine._decode_output(logits)
+
+        assert text == "word_5"
+        assert confidence > 0.9
+
+    def test_decode_without_vocab_returns_index_string(self):
+        from sozia.server.inference.speech.lip_reading_engine import LipReadingEngine
+
+        engine = LipReadingEngine()
+        engine._vocab = None
+
+        logits = torch.full((1, _NUM_CLASSES), -1.0)
+        logits[0, 3] = 10.0
+        text, confidence = engine._decode_output(logits)
+
+        assert text == "3"
+        assert confidence > 0.9
+
+    def test_decode_confidence_is_clamped(self):
+        from sozia.server.inference.speech.lip_reading_engine import LipReadingEngine
+
+        engine = LipReadingEngine()
+        engine._vocab = None
+
+        # Even with extreme logits, confidence stays in [0, 1].
+        logits = torch.zeros(1, _NUM_CLASSES)
+        _, confidence = engine._decode_output(logits)
+        assert 0.0 <= confidence <= 1.0


### PR DESCRIPTION
## What does this PR do?

LipReadingModel used CTC decoding, but the training labels are word-level (sign class names). CTC needs character-aligned per-frame targets — we don't have those. Swapped to a word classifier: Conv1d + GRU + argmax head, output (batch, num_classes).

ModalityResult.timestamp_ms and duration_ms were always 0 — engines have no timeline context, and the orchestrator never filled them in. Fixed by stamping values from AudioFeatureChunk in _process_speech before fusion runs.

The face cache stores a single frame (83, 3). The engine expects a sequence (T, 249). The orchestrator now reshapes before calling predict.

Closes #25

## Which package(s) does it touch?

sozia.server.inference.speech (LipReadingEngine, LipReadingModel)
sozia.server.fusion (FusionOrchestrator._process_speech)

## How to test

```
conda run -n sozia-server python -m pytest tests/inference/speech/test_lip_reading_engine.py tests/fusion/test_orchestrator_process.py -v
```

Full suite: `conda run -n sozia-server python -m pytest`

## Checklist
- [x] Follows commit convention (`<type>(<scope>): <description>`)
- [x] Added/updated tests (if applicable)
- [x] No sozia.common schema changes (or: both repos updated)
- [x] Tested locally