### PR TITLE
gateway: send ready message to unblock client connect()

### DIFF
--- a/sozia/server/api/gateway.py
+++ b/sozia/server/api/gateway.py
@@ -135,6 +135,7 @@ class WebSocketGateway:
             self.active_sessions[session_id] = handler
 
         await self._send_status(websocket, session_id, SessionState.RUNNING)
+        await websocket.send_text('{"type": "ready"}')
 
         try:
             await handler.receive_loop()

--- a/tests/api/test_gateway.py
+++ b/tests/api/test_gateway.py
@@ -76,7 +76,8 @@ class TestOnConnectTimeout:
         ws.send_text = AsyncMock()
         ws.close = AsyncMock()
         with patch(
-            "sozia.server.api.gateway.asyncio.wait_for", side_effect=asyncio.TimeoutError
+            "sozia.server.api.gateway.asyncio.wait_for",
+            side_effect=asyncio.TimeoutError,
         ):
             await gw.on_connect(ws)
         ws.close.assert_awaited_once()
@@ -349,7 +350,11 @@ class TestStatusMessages:
         assert "ready" in types_sent
         # ready must come after RUNNING status
         running_idx = next(
-            i for i, t in enumerate(sent_texts) if json.loads(t).get("state") == "RUNNING"
+            i
+            for i, t in enumerate(sent_texts)
+            if json.loads(t).get("state") == "RUNNING"
         )
-        ready_idx = next(i for i, t in enumerate(sent_texts) if json.loads(t).get("type") == "ready")
+        ready_idx = next(
+            i for i, t in enumerate(sent_texts) if json.loads(t).get("type") == "ready"
+        )
         assert ready_idx == running_idx + 1

--- a/tests/api/test_gateway.py
+++ b/tests/api/test_gateway.py
@@ -326,3 +326,30 @@ class TestStatusMessages:
 
         types_sent = [json.loads(t).get("state") for t in sent_texts]
         assert "RUNNING" in types_sent
+
+    async def test_ready_message_sent_after_running_status(self) -> None:
+        auth = AuthMiddleware(api_key=_KEY)
+        sent_texts: list[str] = []
+
+        orch = AsyncMock()
+        orch.warm_up = AsyncMock()
+        orch.cool_down = AsyncMock()
+        orch.process = AsyncMock()
+
+        gw = WebSocketGateway(auth=auth, orchestrator_factory=lambda *_: orch)
+        ws = _make_ws([_valid_session_init(), {"type": "session_end"}])
+
+        import json
+
+        ws.send_text = AsyncMock(side_effect=lambda t: sent_texts.append(t))
+
+        await gw.on_connect(ws)
+
+        types_sent = [json.loads(t).get("type") for t in sent_texts]
+        assert "ready" in types_sent
+        # ready must come after RUNNING status
+        running_idx = next(
+            i for i, t in enumerate(sent_texts) if json.loads(t).get("state") == "RUNNING"
+        )
+        ready_idx = next(i for i, t in enumerate(sent_texts) if json.loads(t).get("type") == "ready")
+        assert ready_idx == running_idx + 1


### PR DESCRIPTION
## What does this PR do?

The server entered the receive loop after sending RUNNING but never sent `{ "type": "ready" }`. The client's `TransmissionManager` gates its buffer flush on that message, so every connection timed out at 10 s with nothing transmitted.

One line added in `on_connect()` right after the RUNNING status:

    await websocket.send_text('{"type": "ready"}')

## Which package(s) does it touch?

`sozia/server/api` (gateway only)

## How to test

`pytest tests/api/test_gateway.py` — 23 tests pass, including a new one that checks the message is present and ordered after RUNNING.

## Checklist
- [x] Follows commit convention (`<type>(<scope>): <description>`)
- [x] Added/updated tests (if applicable)
- [x] No sozia.common schema changes (or: both repos updated)
- [x] Tested locally

Closes #27