### PR TITLE
fix: four runtime bugs blocking SPEECH path warm-up

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,8 @@ dependencies = [
     "fastapi>=0.115",
     "uvicorn[standard]>=0.34",
     "numpy>=1.26",
+    "transformers>=4.40",
+    "huggingface_hub>=0.20",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,8 @@ uvicorn>=0.23.0
 websockets>=12.0
 torch>=2.0.0
 numpy>=1.24.0
+transformers>=4.40
+huggingface_hub>=0.20
 
 # dev
 pytest>=8.0.0

--- a/sozia/common/models.py
+++ b/sozia/common/models.py
@@ -306,28 +306,28 @@ class LandmarkFrame:
                 self.face_landmarks,
                 FACE_LANDMARK_COUNT,
                 "face_landmarks",
-                check_xy_unit_range=True,
+                check_xy_unit_range=False,
             )
         if self.left_hand_landmarks is not None:
             _validate_landmark_array(
                 self.left_hand_landmarks,
                 HAND_LANDMARK_COUNT,
                 "left_hand_landmarks",
-                check_xy_unit_range=True,
+                check_xy_unit_range=False,
             )
         if self.right_hand_landmarks is not None:
             _validate_landmark_array(
                 self.right_hand_landmarks,
                 HAND_LANDMARK_COUNT,
                 "right_hand_landmarks",
-                check_xy_unit_range=True,
+                check_xy_unit_range=False,
             )
         if self.pose_landmarks is not None:
             _validate_landmark_array(
                 self.pose_landmarks,
                 POSE_LANDMARK_COUNT,
                 "pose_landmarks",
-                check_xy_unit_range=True,
+                check_xy_unit_range=False,
             )
 
 

--- a/sozia/server/inference/speech/lip_reading_engine.py
+++ b/sozia/server/inference/speech/lip_reading_engine.py
@@ -46,43 +46,44 @@ _FACE_FEATURE_DIM = 249
 
 
 class LipReadingModel(nn.Module):
-    """CNN-GRU word classifier for lip-motion features.
+    """GRU word classifier for lip-motion features (ActionGRU small).
 
-    Architecture:
-        1-D Conv block (temporal smoothing) → GRU encoder
-        → last real-frame hidden state → classifier head (BN → ReLU → Dropout → Linear)
+    Mirrors the ActionGRU architecture trained in sozia-research:
+        GRU encoder (4 layers, hidden=256, input=249)
+        → last real-frame hidden state
+        → head: Linear(256,512) → BN → ReLU → Dropout
+                → Linear(512,256) → BN → ReLU → Dropout
+                → Linear(256, num_classes)
 
-    Output is ``(batch, num_classes)`` — one class prediction per input sequence.
-    Training uses cross-entropy with word-level labels from TSL sign class names.
+    No Conv1d frontend — the GRU receives raw 249-dim landmark features.
     """
 
     def __init__(
         self,
         input_dim: int = _FACE_FEATURE_DIM,
         hidden_dim: int = 256,
-        num_layers: int = 3,
+        num_layers: int = 4,
         num_classes: int = 226,
-        dropout: float = 0.3,
+        dropout: float = 0.4,
     ) -> None:
         super().__init__()
-        self.conv = nn.Sequential(
-            nn.Conv1d(input_dim, hidden_dim, kernel_size=3, padding=1),
-            nn.BatchNorm1d(hidden_dim),
-            nn.ReLU(),
-            nn.Dropout(dropout),
-        )
         self.gru = nn.GRU(
-            input_size=hidden_dim,
+            input_size=input_dim,
             hidden_size=hidden_dim,
             num_layers=num_layers,
             batch_first=True,
             dropout=dropout if num_layers > 1 else 0.0,
         )
         self.head = nn.Sequential(
-            nn.BatchNorm1d(hidden_dim),
+            nn.Linear(hidden_dim, 512),
+            nn.BatchNorm1d(512),
             nn.ReLU(),
             nn.Dropout(dropout),
-            nn.Linear(hidden_dim, num_classes),
+            nn.Linear(512, 256),
+            nn.BatchNorm1d(256),
+            nn.ReLU(),
+            nn.Dropout(dropout),
+            nn.Linear(256, num_classes),
         )
 
     def forward(
@@ -101,26 +102,22 @@ class LipReadingModel(nn.Module):
         Returns:
             Class logits of shape ``(batch, num_classes)``.
         """
-        # Conv expects (batch, channels, seq_len).
-        out = self.conv(x.transpose(1, 2)).transpose(1, 2)
-
         if lengths is not None:
             packed = nn.utils.rnn.pack_padded_sequence(
-                out,
+                x,
                 lengths.cpu().clamp(min=1),
                 batch_first=True,
                 enforce_sorted=False,
             )
             packed_out, _ = self.gru(packed)
             out, _ = nn.utils.rnn.pad_packed_sequence(packed_out, batch_first=True)
-            # Index the last real frame for each sample in the batch.
             idx = (lengths - 1).clamp(min=0).to(out.device)
             last = out[torch.arange(out.size(0), device=out.device), idx]
         else:
-            out, _ = self.gru(out)
-            last = out[:, -1, :]  # (batch, hidden_dim)
+            out, _ = self.gru(x)
+            last = out[:, -1, :]
 
-        return self.head(last)  # (batch, num_classes)
+        return self.head(last)
 
 
 class LipReadingEngine(InferenceEngine):
@@ -149,7 +146,7 @@ class LipReadingEngine(InferenceEngine):
     async def load_model(self, config: ModelConfig) -> None:
         device = torch.device(config.device)
         hidden_dim = config.params.get("hidden_dim", 256)
-        num_layers = config.params.get("num_layers", 3)
+        num_layers = config.params.get("num_layers", 4)
         num_classes = config.params.get("num_classes", 226)
         self._max_seq_len = config.params.get("max_seq_len", 150)
 

--- a/sozia/server/inference/speech/whisper_asr_engine.py
+++ b/sozia/server/inference/speech/whisper_asr_engine.py
@@ -1,8 +1,8 @@
-"""WhisperAsrEngine — Whisper-based automatic speech recognition.
+"""WhisperAsrEngine — HuggingFace Whisper-based automatic speech recognition.
 
-Wraps OpenAI Whisper (small) for Turkish ASR. Receives preprocessed audio
-features (mel spectrogram) from the client, runs encoder-decoder inference,
-and returns a ModalityResult.
+Wraps a fine-tuned WhisperForConditionalGeneration model (ogulcanakca/whisper-small-tr)
+for Turkish ASR. Receives preprocessed mel-spectrogram features from the client,
+runs encoder-decoder inference, and returns a ModalityResult.
 
 Latency budget: ≤ 800 ms.
 """
@@ -30,41 +30,41 @@ _DEFAULT_TIMEOUT_MS = 800
 
 
 class WhisperAsrEngine(InferenceEngine):
-    """InferenceEngine implementation backed by OpenAI Whisper.
+    """InferenceEngine backed by a HuggingFace WhisperForConditionalGeneration.
+
+    ``ModelConfig.weights_path`` must point to the model directory containing
+    ``config.json``, ``model.safetensors``, and tokenizer files.
 
     Expected ``ModelConfig.params`` keys (all optional):
         language (str): Target language code, default ``"tr"``.
-        beam_size (int): Beam search width, default ``5``.
         task (str): ``"transcribe"`` or ``"translate"``, default ``"transcribe"``.
+        num_beams (int): Beam search width, default ``1`` (greedy).
     """
 
     def __init__(self) -> None:
-        self._model: torch.nn.Module | None = None
+        self._model = None
+        self._processor = None
         self._model_id: str = ""
         self._device: torch.device = torch.device("cpu")
         self._language: str = "tr"
-        self._beam_size: int = 5
         self._task: str = "transcribe"
-        self._tokenizer = None
-        self._decoder = None
+        self._num_beams: int = 1
 
     # ------------------------------------------------------------------
     # InferenceEngine interface
     # ------------------------------------------------------------------
 
     async def load_model(self, config: ModelConfig) -> None:
-        import whisper  # lazy import — not needed at module scope
 
         self._device = torch.device(config.device)
         self._language = config.params.get("language", "tr")
-        self._beam_size = config.params.get("beam_size", 5)
         self._task = config.params.get("task", "transcribe")
+        self._num_beams = config.params.get("num_beams", 1)
 
-        model_size = config.params.get("model_size", "small")
-        model = await asyncio.to_thread(
-            whisper.load_model, model_size, device=config.device,
-            download_root=config.weights_path,
+        processor, model = await asyncio.to_thread(
+            self._load_from_directory, config.weights_path, config.device
         )
+        self._processor = processor
         self._model = model
         self._model_id = config.model_id
 
@@ -77,22 +77,20 @@ class WhisperAsrEngine(InferenceEngine):
 
         Args:
             features: Mel-spectrogram numpy array of shape ``(80, T)`` or
-                ``(T, 80)`` (auto-transposed). Alternatively a 2-D MFCC
-                array — the engine pads/trims to Whisper's expected 80-mel
-                format internally.
+                ``(T, 80)`` (auto-transposed). Padded/trimmed to ``(80, 3000)``.
             timeout_ms: Maximum wall-clock time in ms (default 800).
 
         Returns:
             ModalityResult with recognised text, confidence, and timing.
         """
-        if self._model is None:
+        if self._model is None or self._processor is None:
             raise ModelNotLoadedError("WhisperAsrEngine: no model loaded.")
 
         mel = self._prepare_mel(features)
         start = time.perf_counter()
 
         try:
-            result = await asyncio.wait_for(
+            text, confidence = await asyncio.wait_for(
                 asyncio.to_thread(self._run_inference, mel),
                 timeout=timeout_ms / 1000.0,
             )
@@ -102,8 +100,6 @@ class WhisperAsrEngine(InferenceEngine):
             )
 
         latency_ms = int((time.perf_counter() - start) * 1000)
-        text: str = result.get("text", "").strip()
-        confidence = self._extract_confidence(result)
 
         return ModalityResult(
             modality_type=ModalityType.ASR,
@@ -116,6 +112,7 @@ class WhisperAsrEngine(InferenceEngine):
 
     async def unload_model(self) -> None:
         self._model = None
+        self._processor = None
         self._model_id = ""
         if torch.cuda.is_available():
             torch.cuda.empty_cache()
@@ -130,12 +127,20 @@ class WhisperAsrEngine(InferenceEngine):
     # Internal helpers
     # ------------------------------------------------------------------
 
+    @staticmethod
+    def _load_from_directory(model_dir: str, device: str):
+        from transformers import WhisperForConditionalGeneration, WhisperProcessor
+
+        processor = WhisperProcessor.from_pretrained(model_dir)
+        model = WhisperForConditionalGeneration.from_pretrained(model_dir)
+        model = model.to(device)
+        model.eval()
+        return processor, model
+
     def _prepare_mel(self, features: np.ndarray) -> torch.Tensor:
         """Convert incoming feature array to a Whisper-compatible mel tensor.
 
-        Whisper expects a float32 tensor of shape ``(80, 3000)`` (80 mel bins,
-        30 s at 100 Hz). This helper handles common input shapes and pads /
-        trims to the expected length.
+        Returns a float32 tensor of shape ``(1, 80, 3000)`` (batch=1).
         """
         arr = np.asarray(features, dtype=np.float32)
 
@@ -144,61 +149,61 @@ class WhisperAsrEngine(InferenceEngine):
                 f"WhisperAsrEngine: expected 2-D features, got shape {arr.shape}"
             )
 
-        # If shape is (T, 80), transpose to (80, T).
+        # Transpose (T, 80) → (80, T)
         if arr.ndim == 2 and arr.shape[1] <= 80 and arr.shape[0] > 80:
             arr = arr.T
 
-        n_mels = arr.shape[0]
-        t_len = arr.shape[1] if arr.ndim == 2 else arr.shape[0]
+        n_mels, t_len = arr.shape[0], arr.shape[1]
 
-        # Pad to 80 mel bins if fewer (e.g. 13-dim MFCC → zero-pad upper bins).
+        # Zero-pad to 80 mel bins if fewer (e.g. 13-dim MFCC input)
         if n_mels < 80:
-            pad = np.zeros((80 - n_mels, t_len), dtype=np.float32)
-            arr = np.vstack([arr, pad])
+            arr = np.vstack([arr, np.zeros((80 - n_mels, t_len), dtype=np.float32)])
 
-        # Whisper expects exactly 3000 time frames (30 s * 100 Hz).
+        # Whisper expects exactly 3000 time frames (30 s × 100 Hz)
         target_t = 3000
         if arr.shape[1] < target_t:
             arr = np.pad(arr, ((0, 0), (0, target_t - arr.shape[1])))
         elif arr.shape[1] > target_t:
             arr = arr[:, :target_t]
 
-        return torch.from_numpy(arr).to(self._device)
+        return torch.from_numpy(arr).unsqueeze(0).to(self._device)
 
-    def _run_inference(self, mel: torch.Tensor) -> dict:
-        """Synchronous Whisper decode — called inside ``to_thread``."""
-        import whisper
-
-        options = whisper.DecodingOptions(
-            language=self._language,
-            beam_size=self._beam_size,
-            task=self._task,
-            without_timestamps=True,
+    def _run_inference(self, mel: torch.Tensor) -> tuple[str, float]:
+        """Synchronous HF Whisper decode — called inside ``to_thread``."""
+        forced_ids = self._processor.get_decoder_prompt_ids(
+            language=self._language, task=self._task
         )
         with torch.no_grad():
-            result = whisper.decode(self._model, mel, options)
+            output = self._model.generate(
+                mel,
+                forced_decoder_ids=forced_ids,
+                num_beams=self._num_beams,
+                return_dict_in_generate=True,
+                output_scores=True,
+            )
 
-        # whisper.decode returns a DecodingResult or list thereof.
-        if isinstance(result, list):
-            result = result[0]
+        text = self._processor.tokenizer.batch_decode(
+            output.sequences, skip_special_tokens=True
+        )[0].strip()
 
-        return {
-            "text": result.text,
-            "avg_logprob": getattr(result, "avg_logprob", -1.0),
-            "no_speech_prob": getattr(result, "no_speech_prob", 0.0),
-        }
+        confidence = self._extract_confidence(output)
+        return text, confidence
 
-    @staticmethod
-    def _extract_confidence(result: dict) -> float:
-        """Derive a [0, 1] confidence score from Whisper's log-probabilities."""
-        avg_logprob = result.get("avg_logprob", -1.0)
-        no_speech = result.get("no_speech_prob", 0.0)
-
-        # avg_logprob is negative; closer to 0 → higher confidence.
-        # Map roughly: -0.0 → 1.0, -1.0 → ~0.37, -3.0 → ~0.05
+    def _extract_confidence(self, output) -> float:
+        """Derive a [0, 1] confidence from generation sequence score."""
         import math
 
-        raw = math.exp(avg_logprob)
-        # Penalise high no-speech probability.
-        confidence = raw * (1.0 - no_speech)
-        return max(0.0, min(1.0, confidence))
+        if hasattr(output, "sequences_scores") and output.sequences_scores is not None:
+            # sequences_scores is the sum of log-probs normalised by length
+            score = output.sequences_scores[0].item()
+        elif output.scores:
+            # Fallback: mean of per-step max log-prob
+            log_probs = [
+                torch.log_softmax(s, dim=-1).max(dim=-1).values.item()
+                for s in output.scores
+            ]
+            score = sum(log_probs) / len(log_probs) if log_probs else -1.0
+        else:
+            score = -1.0
+
+        return max(0.0, min(1.0, math.exp(score)))

--- a/sozia/server/inference/speech/whisper_asr_engine.py
+++ b/sozia/server/inference/speech/whisper_asr_engine.py
@@ -166,6 +166,13 @@ class WhisperAsrEngine(InferenceEngine):
         elif arr.shape[1] > target_t:
             arr = arr[:, :target_t]
 
+        # Global log-mel normalisation matching WhisperFeatureExtractor.
+        # Must be applied after the full segment is assembled — frame-level
+        # normalisation on the client produces inconsistent scale.
+        max_val = float(arr.max())
+        arr = np.clip(arr, max_val - 8.0, max_val)
+        arr = (arr + 4.0) / 4.0
+
         return torch.from_numpy(arr).unsqueeze(0).to(self._device)
 
     def _run_inference(self, mel: torch.Tensor) -> tuple[str, float]:

--- a/tests/common/test_models.py
+++ b/tests/common/test_models.py
@@ -329,10 +329,11 @@ class TestLandmarkFrame:
         with pytest.raises(ValueError):
             self._make(face_landmarks=bad)
 
-    def test_face_xy_out_of_range_raises(self):
-        bad = [[1.5, 0.5, 0.0]] * 83  # x > 1
-        with pytest.raises(ValueError):
-            self._make(face_landmarks=bad)
+    def test_face_xy_out_of_range_allowed(self):
+        # MediaPipe produces x/y outside [0, 1] when a landmark exits the frame.
+        ok = [[1.5, 0.5, 0.0]] * 83
+        f = self._make(face_landmarks=ok)
+        assert f.face_landmarks[0][0] == 1.5
 
     def test_face_z_out_of_range_allowed(self):
         # z is MediaPipe relative depth — not constrained to [0, 1]
@@ -340,10 +341,11 @@ class TestLandmarkFrame:
         f = self._make(face_landmarks=ok)
         assert f.face_landmarks[0][2] == -2.5
 
-    def test_hand_xy_out_of_range_raises(self):
-        bad = [[0.5, 1.2, 0.0]] * 21  # y > 1
-        with pytest.raises(ValueError):
-            self._make(left_hand_landmarks=bad)
+    def test_hand_xy_out_of_range_allowed(self):
+        # MediaPipe produces out-of-range coords when a hand exits the frame.
+        ok = [[0.5, 1.2, 0.0]] * 21
+        f = self._make(left_hand_landmarks=ok)
+        assert f.left_hand_landmarks[0][1] == pytest.approx(1.2)
 
 
 # ===========================================================================

--- a/tests/inference/speech/test_whisper_asr_engine.py
+++ b/tests/inference/speech/test_whisper_asr_engine.py
@@ -1,12 +1,12 @@
-"""Tests for WhisperAsrEngine."""
+"""Tests for WhisperAsrEngine (HuggingFace transformers backend)."""
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
+import torch
 
 from sozia.common.interfaces import InferenceTimeoutError, ModelNotLoadedError
 from sozia.common.models import ModelConfig, ModalityType
@@ -20,32 +20,49 @@ from sozia.common.models import ModelConfig, ModalityType
 def _make_config(model_id: str = "whisper-small-tr") -> ModelConfig:
     return ModelConfig(
         model_id=model_id,
-        weights_path="/tmp/whisper",
+        weights_path="/tmp/whisper-small-tr",
         device="cpu",
-        params={"model_size": "small", "language": "tr"},
+        params={"language": "tr"},
     )
 
 
 def _make_mel_features(n_mels: int = 80, t_frames: int = 100) -> np.ndarray:
-    """Fake mel spectrogram of shape (n_mels, t_frames)."""
     return np.random.randn(n_mels, t_frames).astype(np.float32)
 
 
-@dataclass
-class FakeDecodingResult:
-    text: str = "merhaba dünya"
-    avg_logprob: float = -0.3
-    no_speech_prob: float = 0.01
+def _make_mock_engine() -> tuple:
+    """Return (engine, mock_model, mock_processor) with load_model already called."""
+    from sozia.server.inference.speech.whisper_asr_engine import WhisperAsrEngine
+
+    mock_processor = MagicMock()
+    mock_processor.get_decoder_prompt_ids.return_value = [[1, 2]]
+    mock_processor.tokenizer.batch_decode.return_value = ["merhaba dünya"]
+
+    mock_model = MagicMock()
+    mock_output = MagicMock()
+    mock_output.sequences = torch.zeros(1, 10, dtype=torch.long)
+    mock_output.sequences_scores = torch.tensor([-0.3])
+    mock_output.scores = None
+    mock_model.generate.return_value = mock_output
+
+    with patch.object(
+        WhisperAsrEngine,
+        "_load_from_directory",
+        return_value=(mock_processor, mock_model),
+    ):
+        engine = WhisperAsrEngine()
+        import asyncio
+        asyncio.get_event_loop().run_until_complete(engine.load_model(_make_config()))
+
+    return engine, mock_model, mock_processor
 
 
 # ---------------------------------------------------------------------------
-# Tests
+# State management
 # ---------------------------------------------------------------------------
 
 
 class TestWhisperAsrEngineState:
-    """State management: is_loaded, get_model_id, load/unload lifecycle."""
-
     async def test_not_loaded_initially(self):
         from sozia.server.inference.speech.whisper_asr_engine import WhisperAsrEngine
 
@@ -56,9 +73,11 @@ class TestWhisperAsrEngineState:
     async def test_load_sets_state(self):
         from sozia.server.inference.speech.whisper_asr_engine import WhisperAsrEngine
 
-        mock_whisper = MagicMock()
-        mock_whisper.load_model.return_value = MagicMock()
-        with patch.dict("sys.modules", {"whisper": mock_whisper}):
+        with patch.object(
+            WhisperAsrEngine,
+            "_load_from_directory",
+            return_value=(MagicMock(), MagicMock()),
+        ):
             engine = WhisperAsrEngine()
             await engine.load_model(_make_config())
             assert engine.is_loaded() is True
@@ -67,9 +86,11 @@ class TestWhisperAsrEngineState:
     async def test_unload_clears_state(self):
         from sozia.server.inference.speech.whisper_asr_engine import WhisperAsrEngine
 
-        mock_whisper = MagicMock()
-        mock_whisper.load_model.return_value = MagicMock()
-        with patch.dict("sys.modules", {"whisper": mock_whisper}):
+        with patch.object(
+            WhisperAsrEngine,
+            "_load_from_directory",
+            return_value=(MagicMock(), MagicMock()),
+        ):
             engine = WhisperAsrEngine()
             await engine.load_model(_make_config())
             await engine.unload_model()
@@ -77,9 +98,12 @@ class TestWhisperAsrEngineState:
             assert engine.get_model_id() == ""
 
 
-class TestWhisperAsrEnginePredict:
-    """Predict behaviour with mocked whisper backend."""
+# ---------------------------------------------------------------------------
+# Predict
+# ---------------------------------------------------------------------------
 
+
+class TestWhisperAsrEnginePredict:
     async def test_predict_raises_when_not_loaded(self):
         from sozia.server.inference.speech.whisper_asr_engine import WhisperAsrEngine
 
@@ -90,13 +114,22 @@ class TestWhisperAsrEnginePredict:
     async def test_predict_returns_modality_result(self):
         from sozia.server.inference.speech.whisper_asr_engine import WhisperAsrEngine
 
-        mock_whisper = MagicMock()
-        mock_whisper.load_model.return_value = MagicMock()
-        fake_result = FakeDecodingResult()
-        mock_whisper.decode.return_value = fake_result
-        mock_whisper.DecodingOptions.return_value = MagicMock()
+        mock_processor = MagicMock()
+        mock_processor.get_decoder_prompt_ids.return_value = [[1, 2]]
+        mock_processor.tokenizer.batch_decode.return_value = ["merhaba dünya"]
 
-        with patch.dict("sys.modules", {"whisper": mock_whisper}):
+        mock_output = MagicMock()
+        mock_output.sequences = torch.zeros(1, 10, dtype=torch.long)
+        mock_output.sequences_scores = torch.tensor([-0.3])
+        mock_output.scores = None
+        mock_model = MagicMock()
+        mock_model.generate.return_value = mock_output
+
+        with patch.object(
+            WhisperAsrEngine,
+            "_load_from_directory",
+            return_value=(mock_processor, mock_model),
+        ):
             engine = WhisperAsrEngine()
             await engine.load_model(_make_config())
             result = await engine.predict(_make_mel_features())
@@ -106,79 +139,111 @@ class TestWhisperAsrEnginePredict:
         assert 0.0 <= result.confidence <= 1.0
         assert result.inference_latency_ms >= 0
 
-    async def test_predict_handles_list_decode_result(self):
+    async def test_predict_timeout_raises(self):
+        import time as _time
+
         from sozia.server.inference.speech.whisper_asr_engine import WhisperAsrEngine
 
-        mock_whisper = MagicMock()
-        mock_whisper.load_model.return_value = MagicMock()
-        mock_whisper.decode.return_value = [FakeDecodingResult(text="test")]
-        mock_whisper.DecodingOptions.return_value = MagicMock()
+        mock_processor = MagicMock()
+        mock_processor.get_decoder_prompt_ids.return_value = []
 
-        with patch.dict("sys.modules", {"whisper": mock_whisper}):
+        def _slow(*_a, **_kw):
+            _time.sleep(10)
+
+        mock_model = MagicMock()
+        mock_model.generate.side_effect = _slow
+
+        with patch.object(
+            WhisperAsrEngine,
+            "_load_from_directory",
+            return_value=(mock_processor, mock_model),
+        ):
             engine = WhisperAsrEngine()
             await engine.load_model(_make_config())
-            result = await engine.predict(_make_mel_features())
-        assert result.text == "test"
+
+        with pytest.raises(InferenceTimeoutError):
+            await engine.predict(_make_mel_features(), timeout_ms=1)
+
+
+# ---------------------------------------------------------------------------
+# Mel preparation
+# ---------------------------------------------------------------------------
 
 
 class TestWhisperAsrEngineMelPrep:
-    """Feature preparation edge cases."""
-
-    async def test_transpose_t_by_80_input(self):
+    def _make_engine(self):
         from sozia.server.inference.speech.whisper_asr_engine import WhisperAsrEngine
-
         engine = WhisperAsrEngine()
         engine._model = MagicMock()
-        engine._device = "cpu"
-        # (T=200, 80) → should be transposed to (80, T)
-        features = np.random.randn(200, 80).astype(np.float32)
-        mel = engine._prepare_mel(features)
-        assert mel.shape == (80, 3000)
+        engine._processor = MagicMock()
+        engine._device = torch.device("cpu")
+        return engine
 
-    async def test_pads_short_mel_bins(self):
-        from sozia.server.inference.speech.whisper_asr_engine import WhisperAsrEngine
+    def test_output_shape_is_batched(self):
+        engine = self._make_engine()
+        mel = engine._prepare_mel(np.random.randn(80, 200).astype(np.float32))
+        assert mel.shape == (1, 80, 3000)
 
-        engine = WhisperAsrEngine()
-        engine._model = MagicMock()
-        engine._device = "cpu"
-        # 13-dim MFCC
-        features = np.random.randn(13, 100).astype(np.float32)
-        mel = engine._prepare_mel(features)
-        assert mel.shape == (80, 3000)
+    def test_transpose_t_by_80_input(self):
+        engine = self._make_engine()
+        mel = engine._prepare_mel(np.random.randn(200, 80).astype(np.float32))
+        assert mel.shape == (1, 80, 3000)
 
-    async def test_rejects_1d_input(self):
-        from sozia.server.inference.speech.whisper_asr_engine import WhisperAsrEngine
+    def test_pads_short_mel_bins(self):
+        engine = self._make_engine()
+        mel = engine._prepare_mel(np.random.randn(13, 100).astype(np.float32))
+        assert mel.shape == (1, 80, 3000)
 
-        engine = WhisperAsrEngine()
-        engine._model = MagicMock()
-        engine._device = "cpu"
+    def test_trims_long_time_axis(self):
+        engine = self._make_engine()
+        mel = engine._prepare_mel(np.random.randn(80, 5000).astype(np.float32))
+        assert mel.shape == (1, 80, 3000)
+
+    def test_rejects_1d_input(self):
+        engine = self._make_engine()
         with pytest.raises(ValueError, match="2-D"):
             engine._prepare_mel(np.zeros(100, dtype=np.float32))
 
 
-class TestWhisperAsrEngineConfidence:
-    """Confidence extraction from log-probabilities."""
+# ---------------------------------------------------------------------------
+# Confidence extraction
+# ---------------------------------------------------------------------------
 
-    def test_high_logprob_gives_high_confidence(self):
+
+class TestWhisperAsrEngineConfidence:
+    def _make_output(self, seq_score: float | None = None, scores=None):
+        out = MagicMock()
+        out.sequences_scores = (
+            torch.tensor([seq_score]) if seq_score is not None else None
+        )
+        out.scores = scores
+        return out
+
+    def test_high_score_gives_high_confidence(self):
         from sozia.server.inference.speech.whisper_asr_engine import WhisperAsrEngine
 
-        c = WhisperAsrEngine._extract_confidence(
-            {"avg_logprob": -0.1, "no_speech_prob": 0.0}
-        )
+        engine = WhisperAsrEngine()
+        c = engine._extract_confidence(self._make_output(seq_score=-0.1))
         assert c > 0.8
 
-    def test_low_logprob_gives_low_confidence(self):
+    def test_low_score_gives_low_confidence(self):
         from sozia.server.inference.speech.whisper_asr_engine import WhisperAsrEngine
 
-        c = WhisperAsrEngine._extract_confidence(
-            {"avg_logprob": -3.0, "no_speech_prob": 0.0}
-        )
+        engine = WhisperAsrEngine()
+        c = engine._extract_confidence(self._make_output(seq_score=-5.0))
         assert c < 0.1
 
-    def test_high_no_speech_penalises(self):
+    def test_fallback_to_per_step_scores(self):
         from sozia.server.inference.speech.whisper_asr_engine import WhisperAsrEngine
 
-        c = WhisperAsrEngine._extract_confidence(
-            {"avg_logprob": -0.1, "no_speech_prob": 0.9}
-        )
-        assert c < 0.15
+        engine = WhisperAsrEngine()
+        step_scores = [torch.randn(1, 50_000) for _ in range(5)]
+        c = engine._extract_confidence(self._make_output(seq_score=None, scores=step_scores))
+        assert 0.0 <= c <= 1.0
+
+    def test_confidence_always_clamped(self):
+        from sozia.server.inference.speech.whisper_asr_engine import WhisperAsrEngine
+
+        engine = WhisperAsrEngine()
+        c = engine._extract_confidence(self._make_output(seq_score=0.0))
+        assert 0.0 <= c <= 1.0

--- a/tests/inference/speech/test_whisper_asr_engine.py
+++ b/tests/inference/speech/test_whisper_asr_engine.py
@@ -52,6 +52,7 @@ def _make_mock_engine() -> tuple:
     ):
         engine = WhisperAsrEngine()
         import asyncio
+
         asyncio.get_event_loop().run_until_complete(engine.load_model(_make_config()))
 
     return engine, mock_model, mock_processor
@@ -173,6 +174,7 @@ class TestWhisperAsrEnginePredict:
 class TestWhisperAsrEngineMelPrep:
     def _make_engine(self):
         from sozia.server.inference.speech.whisper_asr_engine import WhisperAsrEngine
+
         engine = WhisperAsrEngine()
         engine._model = MagicMock()
         engine._processor = MagicMock()
@@ -238,7 +240,9 @@ class TestWhisperAsrEngineConfidence:
 
         engine = WhisperAsrEngine()
         step_scores = [torch.randn(1, 50_000) for _ in range(5)]
-        c = engine._extract_confidence(self._make_output(seq_score=None, scores=step_scores))
+        c = engine._extract_confidence(
+            self._make_output(seq_score=None, scores=step_scores)
+        )
         assert 0.0 <= c <= 1.0
 
     def test_confidence_always_clamped(self):

--- a/tests/inference/speech/test_whisper_asr_engine.py
+++ b/tests/inference/speech/test_whisper_asr_engine.py
@@ -206,6 +206,26 @@ class TestWhisperAsrEngineMelPrep:
         with pytest.raises(ValueError, match="2-D"):
             engine._prepare_mel(np.zeros(100, dtype=np.float32))
 
+    def test_normalisation_applied_globally(self):
+        engine = self._make_engine()
+        # Known array: all values 0.0 except one cell = 8.0 → max_val = 8.0
+        # clip(x, 0, 8) → (x+4)/4 → range [1.0, 3.0]
+        arr = np.zeros((80, 100), dtype=np.float32)
+        arr[0, 0] = 8.0
+        mel = engine._prepare_mel(arr)
+        tensor_vals = mel[0].numpy()
+        assert float(tensor_vals.max()) == pytest.approx(3.0, abs=1e-5)
+        assert float(tensor_vals.min()) == pytest.approx(1.0, abs=1e-5)
+
+    def test_normalisation_span_is_exactly_two(self):
+        # clip window is 8 units wide; after (x+4)/4 the span collapses to 8/4 = 2.0
+        engine = self._make_engine()
+        rng = np.random.default_rng(42)
+        arr = rng.uniform(-10, 10, (80, 3000)).astype(np.float32)
+        mel = engine._prepare_mel(arr)
+        span = mel.max().item() - mel.min().item()
+        assert span == pytest.approx(2.0, abs=1e-4)
+
 
 # ---------------------------------------------------------------------------
 # Confidence extraction


### PR DESCRIPTION
## What does this PR do?

Four fixes from the first live client-server test on the SPEECH path.

The ASR engine needed a full rewrite. The conda env had Graphite's `whisper` installed — a time-series DB with no `load_model` — and the model is in HuggingFace safetensors format, so `openai-whisper` wouldn't have worked anyway. Switched to `transformers.WhisperForConditionalGeneration` + `WhisperProcessor`.

`LipReadingModel` didn't match the checkpoint. Server had a Conv1d frontend and 3 GRU layers; the trained `ActionGRU` small has no conv layer, 4 GRU layers, and a two-stage FC head (256→512→256→num_classes). Fixed by aligning the architecture.

The landmark validator enforced `x, y ∈ [0.0, 1.0]` on all arrays. MediaPipe returns values outside that range when a body part exits the frame — a partially visible elbow can have `y = 1.31`. Disabled the range check; count and shape checks stay.

## Which package(s) does it touch?

`sozia.common`, `sozia.server.inference.speech` (ASR + lip-reading engines), `pyproject.toml`, `requirements.txt`

## How to test

Start the server with `SOZIA_WHISPER_WEIGHTS` pointing to the `whisper-small-tr` model directory and `SOZIA_LIP_WEIGHTS` pointing to `AUTSL_lip_best_model.pt`. Connect a client on the SPEECH path. Warm-up should complete and the server should send `{"type": "ready"}` without errors.

## Checklist
- [x] Follows commit convention (`<type>(<scope>): <description>`)
- [x] Added/updated tests (if applicable)
- [x] No sozia.common schema changes (or: both repos updated)
- [x] Tested locally

Closes #29.