### PR TITLE
fix(speech): stop CUDA memory accumulating on ASR and lip-reading inference

### DIFF
--- a/sozia/server/inference/speech/lip_reading_engine.py
+++ b/sozia/server/inference/speech/lip_reading_engine.py
@@ -40,6 +40,7 @@ if TYPE_CHECKING:
     from sozia.common.models import ModelConfig
 
 _DEFAULT_TIMEOUT_MS = 1200
+_CACHE_CLEAR_INTERVAL = 10
 
 # Face landmark subset used by Sozia (83 points × 3 coords = 249 features).
 _FACE_FEATURE_DIM = 249
@@ -138,6 +139,7 @@ class LipReadingEngine(InferenceEngine):
         self._device: torch.device = torch.device("cpu")
         self._max_seq_len: int = 150
         self._vocab: list[str] | None = None
+        self._inference_count: int = 0
 
     # ------------------------------------------------------------------
     # InferenceEngine interface
@@ -206,9 +208,23 @@ class LipReadingEngine(InferenceEngine):
             raise InferenceTimeoutError(
                 f"LipReadingEngine exceeded {timeout_ms}ms budget."
             )
+        finally:
+            # On timeout the thread still holds a reference to `tensor` via its
+            # call frame; this del only drops the event-loop copy. GPU memory is
+            # released when the thread returns naturally.
+            del tensor
 
         latency_ms = int((time.perf_counter() - start) * 1000)
         text, confidence = self._decode_output(logits)
+
+        # _inference_count is only incremented from the asyncio event loop (after
+        # await), so no locking is needed. One counter per engine instance.
+        self._inference_count += 1
+        if (
+            self._inference_count % _CACHE_CLEAR_INTERVAL == 0
+            and torch.cuda.is_available()
+        ):
+            torch.cuda.empty_cache()
 
         return ModalityResult(
             modality_type=ModalityType.LIP_READING,
@@ -284,9 +300,14 @@ class LipReadingEngine(InferenceEngine):
         tensor: torch.Tensor,
         length: torch.Tensor,
     ) -> torch.Tensor:
-        """Synchronous forward pass — called inside ``to_thread``."""
-        with torch.no_grad():
-            return self._model(tensor, lengths=length)
+        """Synchronous forward pass — called inside ``to_thread``.
+
+        Returns logits on CPU so the CUDA allocation is released before the
+        result crosses back to the event loop.
+        """
+        with torch.inference_mode():
+            logits = self._model(tensor, lengths=length)
+        return logits.cpu()
 
     def _decode_output(
         self,

--- a/sozia/server/inference/speech/whisper_asr_engine.py
+++ b/sozia/server/inference/speech/whisper_asr_engine.py
@@ -27,6 +27,7 @@ if TYPE_CHECKING:
     from sozia.common.models import ModelConfig
 
 _DEFAULT_TIMEOUT_MS = 800
+_CACHE_CLEAR_INTERVAL = 10
 
 
 class WhisperAsrEngine(InferenceEngine):
@@ -49,6 +50,7 @@ class WhisperAsrEngine(InferenceEngine):
         self._language: str = "tr"
         self._task: str = "transcribe"
         self._num_beams: int = 1
+        self._inference_count: int = 0
 
     # ------------------------------------------------------------------
     # InferenceEngine interface
@@ -98,8 +100,20 @@ class WhisperAsrEngine(InferenceEngine):
             raise InferenceTimeoutError(
                 f"WhisperAsrEngine exceeded {timeout_ms}ms budget."
             )
+        finally:
+            # On timeout the thread is still running and holds its own reference
+            # to `mel` via the call frame; this del only drops the event-loop
+            # copy. GPU memory is released when the thread returns naturally.
+            del mel
 
         latency_ms = int((time.perf_counter() - start) * 1000)
+
+        self._inference_count += 1
+        if (
+            self._inference_count % _CACHE_CLEAR_INTERVAL == 0
+            and torch.cuda.is_available()
+        ):
+            torch.cuda.empty_cache()
 
         return ModalityResult(
             modality_type=ModalityType.ASR,
@@ -180,7 +194,7 @@ class WhisperAsrEngine(InferenceEngine):
         forced_ids = self._processor.get_decoder_prompt_ids(
             language=self._language, task=self._task
         )
-        with torch.no_grad():
+        with torch.inference_mode():
             output = self._model.generate(
                 mel,
                 forced_decoder_ids=forced_ids,
@@ -188,12 +202,14 @@ class WhisperAsrEngine(InferenceEngine):
                 return_dict_in_generate=True,
                 output_scores=True,
             )
+            text = self._processor.tokenizer.batch_decode(
+                output.sequences, skip_special_tokens=True
+            )[0].strip()
+            confidence = self._extract_confidence(output)
 
-        text = self._processor.tokenizer.batch_decode(
-            output.sequences, skip_special_tokens=True
-        )[0].strip()
-
-        confidence = self._extract_confidence(output)
+        # Explicitly release GPU tensors held in the generate output (scores
+        # tuple, sequences) before returning to the event loop.
+        del output
         return text, confidence
 
     def _extract_confidence(self, output) -> float:
@@ -204,9 +220,9 @@ class WhisperAsrEngine(InferenceEngine):
             # sequences_scores is the sum of log-probs normalised by length
             score = output.sequences_scores[0].item()
         elif output.scores:
-            # Fallback: mean of per-step max log-prob
+            # Fallback: mean of per-step max log-prob (CPU to avoid CUDA intermediates).
             log_probs = [
-                torch.log_softmax(s, dim=-1).max(dim=-1).values.item()
+                torch.log_softmax(s.cpu().float(), dim=-1).max(dim=-1).values.item()
                 for s in output.scores
             ]
             score = sum(log_probs) / len(log_probs) if log_probs else -1.0


### PR DESCRIPTION
## What does this PR do?

Fixes CUDA OOM on the SPEECH path. `generate()` output was holding a tuple of GPU score tensors across GC cycles, and `LipReadingEngine` was handing a live CUDA tensor back to the event loop. Memory grew with every chunk and didn't come back.

`del output` after extraction, `logits.cpu()` before the thread returns, `inference_mode` in both engines, `empty_cache()` every 10 calls.

## Which package(s) does it touch?

`sozia.server.inference.speech` — both engine files.

## How to test

`pytest tests/inference/speech/` — 35 tests pass. Start server in SPEECH mode, watch `nvidia-smi`, memory should stay flat.

## Checklist
- [x] Follows commit convention (`<type>(<scope>): <description>`)
- [x] Added/updated tests (if applicable)
- [x] No sozia.common schema changes (or: both repos updated)
- [x] Tested locally

Closes #31