### PR TITLE
feat(lip-engine): wire SOZIA_LIP_VOCAB so lip predictions return word labels

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,7 +13,8 @@ SOZIA_DEVICE=cpu
 
 # Speech path
 # SOZIA_WHISPER_WEIGHTS=/path/to/whisper-small-tr.pt
-# SOZIA_LIP_WEIGHTS=/path/to/lip-reading-v1.pt
+# SOZIA_LIP_WEIGHTS=/path/to/AUTSL_lip_best_model.pt
+# SOZIA_LIP_VOCAB=/path/to/AUTSL_lip_vocab.txt   # newline-delimited, index → word label
 
 # Sign path
 # SOZIA_TSL_WEIGHTS=/path/to/sozia-research/models/recognition/run_autsl_signer

--- a/sozia/server/__init__.py
+++ b/sozia/server/__init__.py
@@ -42,6 +42,7 @@ ENV_API_KEY = "SOZIA_API_KEY"
 ENV_DEVICE = "SOZIA_DEVICE"
 ENV_WHISPER_WEIGHTS = "SOZIA_WHISPER_WEIGHTS"
 ENV_LIP_WEIGHTS = "SOZIA_LIP_WEIGHTS"
+ENV_LIP_VOCAB = "SOZIA_LIP_VOCAB"
 ENV_TSL_WEIGHTS = "SOZIA_TSL_WEIGHTS"
 ENV_TSL_SCALER = "SOZIA_TSL_SCALER"
 ENV_GLOSS_WEIGHTS = "SOZIA_GLOSS_WEIGHTS"
@@ -66,6 +67,7 @@ def _speech_configs(device: str) -> tuple[ModelConfig | None, ModelConfig | None
     """Return (asr_config, lip_config); None where weights are not configured."""
     asr_path = _weights(ENV_WHISPER_WEIGHTS)
     lip_path = _weights(ENV_LIP_WEIGHTS)
+    lip_vocab = _weights(ENV_LIP_VOCAB)
 
     asr_cfg = (
         ModelConfig(
@@ -77,12 +79,15 @@ def _speech_configs(device: str) -> tuple[ModelConfig | None, ModelConfig | None
         if asr_path
         else None
     )
+    lip_params: dict = {}
+    if lip_vocab:
+        lip_params["vocab_path"] = lip_vocab
     lip_cfg = (
         ModelConfig(
             model_id="lip-reading-v1",
             weights_path=lip_path,
             device=device,
-            params={},
+            params=lip_params,
         )
         if lip_path
         else None


### PR DESCRIPTION
## What does this PR do?

Without a vocab file, `_decode_output` falls back to `str(class_idx)` — lip-reading predictions come back as bare numbers. Adds `SOZIA_LIP_VOCAB` and passes it as `vocab_path` in the `LipReadingEngine` config. The vocab (226 AUTSL classes, index → word) comes from `vocab.json` in the sozia-research training output.

## Which package(s) does it touch?

`sozia/server/__init__.py`, `.env.example`

## How to test

Set `SOZIA_LIP_VOCAB=/path/to/AUTSL_lip_vocab.txt` in `.env`, start the server, run a SPEECH path session. Lip-reading results should be Turkish words, not integers.

## Checklist
- [x] Follows commit convention (`<type>(<scope>): <description>`)
- [x] No new tests needed — `_load_vocab` path already covered
- [x] No sozia.common schema changes
- [x] Tested locally

Closes #33