### PR TITLE
fix(asr-engine): mel-spectrogram dimensions swapped on short chunks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,7 +12,7 @@ SOZIA_DEVICE=cpu
 # The corresponding modality is disabled when a weights var is unset.
 
 # Speech path
-# SOZIA_WHISPER_WEIGHTS=/path/to/whisper-small-tr.pt
+# SOZIA_WHISPER_WEIGHTS=/path/to/whisper-large-v3-turbo
 # SOZIA_LIP_WEIGHTS=/path/to/AUTSL_lip_best_model.pt
 # SOZIA_LIP_VOCAB=/path/to/AUTSL_lip_vocab.txt   # newline-delimited, index → word label
 

--- a/scripts/smoke_asr.py
+++ b/scripts/smoke_asr.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 
 import argparse
 import asyncio
-import sys
 import time
 
 import numpy as np
@@ -27,7 +26,12 @@ def _make_silence_mel(n_mels: int = 128, t_frames: int = 200) -> np.ndarray:
     return np.full((t_frames, n_mels), -10.0, dtype=np.float32)
 
 
-def _make_tone_mel(weights_path: str, n_mels: int = 128, duration_s: float = 3.0, sample_rate: int = 16_000) -> np.ndarray:
+def _make_tone_mel(
+    weights_path: str,
+    n_mels: int = 128,
+    duration_s: float = 3.0,
+    sample_rate: int = 16_000,
+) -> np.ndarray:
     """Compute log10-mel from a 440 Hz sine wave using WhisperFeatureExtractor.
 
     This is the ground-truth mel pipeline — identical to what Whisper was trained on.
@@ -36,7 +40,9 @@ def _make_tone_mel(weights_path: str, n_mels: int = 128, duration_s: float = 3.0
     """
     from transformers import WhisperFeatureExtractor
 
-    samples = np.sin(2 * np.pi * 440 * np.arange(int(duration_s * sample_rate)) / sample_rate).astype(np.float32)
+    samples = np.sin(
+        2 * np.pi * 440 * np.arange(int(duration_s * sample_rate)) / sample_rate
+    ).astype(np.float32)
 
     extractor = WhisperFeatureExtractor.from_pretrained(weights_path)
     # Returns (1, n_mels, 3000) as a tensor-like object; grab the numpy array.
@@ -49,7 +55,9 @@ def _make_tone_mel(weights_path: str, n_mels: int = 128, duration_s: float = 3.0
     return raw.T  # (3000, n_mels) — client sends (T, N)
 
 
-def _make_wav_mel(wav_path: str, weights_path: str, n_mels: int = 128, sample_rate: int = 16_000) -> np.ndarray:
+def _make_wav_mel(
+    wav_path: str, weights_path: str, n_mels: int = 128, sample_rate: int = 16_000
+) -> np.ndarray:
     """Load a WAV file, compute mel via WhisperFeatureExtractor, return (T, N)."""
     import soundfile as sf
     from transformers import WhisperFeatureExtractor
@@ -86,7 +94,7 @@ async def run(weights_path: str, audio_path: str | None) -> None:
     print("Loading model …")
     t0 = time.perf_counter()
     await engine.load_model(config)
-    print(f"  Loaded in {(time.perf_counter() - t0)*1000:.0f} ms")
+    print(f"  Loaded in {(time.perf_counter() - t0) * 1000:.0f} ms")
 
     n_mels = engine._n_mels
     print(f"  n_mels from model config: {n_mels}")
@@ -95,7 +103,9 @@ async def run(weights_path: str, audio_path: str | None) -> None:
     print("\n[1] Silence probe")
     silence = _make_silence_mel(n_mels=n_mels)
     result = await engine.predict(silence)
-    print(f"  text='{result.text}'  confidence={result.confidence:.4f}  latency={result.inference_latency_ms} ms")
+    print(
+        f"  text='{result.text}'  confidence={result.confidence:.4f}  latency={result.inference_latency_ms} ms"
+    )
     if result.text != "":
         print("  WARN: expected empty text for silence — possible VAD threshold issue")
     else:
@@ -105,7 +115,9 @@ async def run(weights_path: str, audio_path: str | None) -> None:
     print("\n[2] Synthetic tone probe (440 Hz, 3 s via WhisperFeatureExtractor)")
     tone_mel = _make_tone_mel(weights_path, n_mels=n_mels)
     result = await engine.predict(tone_mel, timeout_ms=10_000)
-    print(f"  text='{result.text}'  confidence={result.confidence:.4f}  latency={result.inference_latency_ms} ms")
+    print(
+        f"  text='{result.text}'  confidence={result.confidence:.4f}  latency={result.inference_latency_ms} ms"
+    )
     if result.confidence > 0.0 and result.confidence < 0.99:
         print("  OK: confidence is non-trivial (output_scores=True is working)")
     elif result.confidence == 0.0 and result.text == "":
@@ -118,16 +130,28 @@ async def run(weights_path: str, audio_path: str | None) -> None:
         print(f"\n[3] Real audio probe: {audio_path}")
         wav_mel = _make_wav_mel(audio_path, weights_path, n_mels=n_mels)
         result = await engine.predict(wav_mel, timeout_ms=15_000)
-        print(f"  text='{result.text}'  confidence={result.confidence:.4f}  latency={result.inference_latency_ms} ms")
+        print(
+            f"  text='{result.text}'  confidence={result.confidence:.4f}  latency={result.inference_latency_ms} ms"
+        )
 
     await engine.unload_model()
     print("\nDone.")
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Smoke-test WhisperAsrEngine with real weights.")
-    parser.add_argument("--weights", required=True, help="Path to model directory (config.json + safetensors)")
-    parser.add_argument("--audio", default=None, help="Optional WAV file (16 kHz mono) for a real transcription test")
+    parser = argparse.ArgumentParser(
+        description="Smoke-test WhisperAsrEngine with real weights."
+    )
+    parser.add_argument(
+        "--weights",
+        required=True,
+        help="Path to model directory (config.json + safetensors)",
+    )
+    parser.add_argument(
+        "--audio",
+        default=None,
+        help="Optional WAV file (16 kHz mono) for a real transcription test",
+    )
     args = parser.parse_args()
 
     asyncio.run(run(args.weights, args.audio))

--- a/scripts/smoke_asr.py
+++ b/scripts/smoke_asr.py
@@ -1,0 +1,133 @@
+"""ASR smoke test — verifies WhisperAsrEngine end-to-end with real weights.
+
+Runs three probes:
+  1. Silence  → engine must return empty text, confidence near 0.
+  2. Reference mel from WhisperFeatureExtractor on a synthetic 440 Hz tone
+     → engine must return a ModalityResult without crashing.
+  3. If --audio is given, transcribes a real WAV and prints the result.
+
+Usage on remote:
+    conda activate sozia-server
+    python scripts/smoke_asr.py --weights /home/monica/mehmet-altintas/Sozia/weights/whisper-large-v3-turbo
+    python scripts/smoke_asr.py --weights /path/to/weights --audio /path/to/speech.wav
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+import time
+
+import numpy as np
+
+
+def _make_silence_mel(n_mels: int = 128, t_frames: int = 200) -> np.ndarray:
+    """Log10-mel array that looks like silence to the energy VAD (all values below -4)."""
+    return np.full((t_frames, n_mels), -10.0, dtype=np.float32)
+
+
+def _make_tone_mel(weights_path: str, n_mels: int = 128, duration_s: float = 3.0, sample_rate: int = 16_000) -> np.ndarray:
+    """Compute log10-mel from a 440 Hz sine wave using WhisperFeatureExtractor.
+
+    This is the ground-truth mel pipeline — identical to what Whisper was trained on.
+    If the server pipeline is correct, feeding this array into WhisperAsrEngine should
+    not crash and should produce a valid (if nonsensical) ModalityResult.
+    """
+    from transformers import WhisperFeatureExtractor
+
+    samples = np.sin(2 * np.pi * 440 * np.arange(int(duration_s * sample_rate)) / sample_rate).astype(np.float32)
+
+    extractor = WhisperFeatureExtractor.from_pretrained(weights_path)
+    # Returns (1, n_mels, 3000) as a tensor-like object; grab the numpy array.
+    result = extractor(samples, sampling_rate=sample_rate, return_tensors="np")
+    mel_nd = result.input_features[0]  # shape (n_mels, 3000) — already normalised
+
+    # Convert back to raw (un-normalised) log10-mel so _prepare_mel can apply its own
+    # normalisation, matching the client's output.  Reverse: (x * 4.0) - 4.0
+    raw = mel_nd * 4.0 - 4.0  # (n_mels, 3000)
+    return raw.T  # (3000, n_mels) — client sends (T, N)
+
+
+def _make_wav_mel(wav_path: str, weights_path: str, n_mels: int = 128, sample_rate: int = 16_000) -> np.ndarray:
+    """Load a WAV file, compute mel via WhisperFeatureExtractor, return (T, N)."""
+    import soundfile as sf
+    from transformers import WhisperFeatureExtractor
+
+    audio, sr = sf.read(wav_path, dtype="float32")
+    if audio.ndim > 1:
+        audio = audio.mean(axis=1)
+    if sr != sample_rate:
+        raise ValueError(f"WAV sample rate {sr} != {sample_rate}. Resample first.")
+
+    extractor = WhisperFeatureExtractor.from_pretrained(weights_path)
+    result = extractor(audio, sampling_rate=sample_rate, return_tensors="np")
+    mel_nd = result.input_features[0]  # (n_mels, 3000)
+    raw = mel_nd * 4.0 - 4.0
+    return raw.T  # (T, N)
+
+
+async def run(weights_path: str, audio_path: str | None) -> None:
+    import torch
+    from sozia.common.models import ModelConfig
+    from sozia.server.inference.speech.whisper_asr_engine import WhisperAsrEngine
+
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    print(f"Device: {device}")
+
+    engine = WhisperAsrEngine()
+    config = ModelConfig(
+        model_id="whisper-smoke-test",
+        weights_path=weights_path,
+        device=device,
+        params={"language": "tr", "task": "transcribe", "num_beams": 1},
+    )
+
+    print("Loading model …")
+    t0 = time.perf_counter()
+    await engine.load_model(config)
+    print(f"  Loaded in {(time.perf_counter() - t0)*1000:.0f} ms")
+
+    n_mels = engine._n_mels
+    print(f"  n_mels from model config: {n_mels}")
+
+    # --- Probe 1: silence ---------------------------------------------------
+    print("\n[1] Silence probe")
+    silence = _make_silence_mel(n_mels=n_mels)
+    result = await engine.predict(silence)
+    print(f"  text='{result.text}'  confidence={result.confidence:.4f}  latency={result.inference_latency_ms} ms")
+    if result.text != "":
+        print("  WARN: expected empty text for silence — possible VAD threshold issue")
+    else:
+        print("  OK: returned empty text as expected")
+
+    # --- Probe 2: synthetic tone mel ----------------------------------------
+    print("\n[2] Synthetic tone probe (440 Hz, 3 s via WhisperFeatureExtractor)")
+    tone_mel = _make_tone_mel(weights_path, n_mels=n_mels)
+    result = await engine.predict(tone_mel, timeout_ms=10_000)
+    print(f"  text='{result.text}'  confidence={result.confidence:.4f}  latency={result.inference_latency_ms} ms")
+    if result.confidence > 0.0 and result.confidence < 0.99:
+        print("  OK: confidence is non-trivial (output_scores=True is working)")
+    elif result.confidence == 0.0 and result.text == "":
+        print("  OK (suppressed as silence/noise)")
+    else:
+        print(f"  NOTE: confidence={result.confidence:.4f} — check _extract_confidence")
+
+    # --- Probe 3: real audio ------------------------------------------------
+    if audio_path:
+        print(f"\n[3] Real audio probe: {audio_path}")
+        wav_mel = _make_wav_mel(audio_path, weights_path, n_mels=n_mels)
+        result = await engine.predict(wav_mel, timeout_ms=15_000)
+        print(f"  text='{result.text}'  confidence={result.confidence:.4f}  latency={result.inference_latency_ms} ms")
+
+    await engine.unload_model()
+    print("\nDone.")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Smoke-test WhisperAsrEngine with real weights.")
+    parser.add_argument("--weights", required=True, help="Path to model directory (config.json + safetensors)")
+    parser.add_argument("--audio", default=None, help="Optional WAV file (16 kHz mono) for a real transcription test")
+    args = parser.parse_args()
+
+    asyncio.run(run(args.weights, args.audio))

--- a/sozia/server/__init__.py
+++ b/sozia/server/__init__.py
@@ -250,4 +250,9 @@ def create_app(auth: AuthMiddleware | None = None) -> FastAPI:
 # Auth is resolved from SOZIA_API_KEY during lifespan startup, not here.
 # ---------------------------------------------------------------------------
 
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s — %(message)s",
+)
+
 app = create_app()

--- a/sozia/server/api/session_handler.py
+++ b/sozia/server/api/session_handler.py
@@ -13,7 +13,10 @@ from __future__ import annotations
 
 import dataclasses
 import json
+import logging
 from typing import TYPE_CHECKING
+
+logger = logging.getLogger(__name__)
 
 from starlette.websockets import WebSocketDisconnect
 
@@ -136,10 +139,18 @@ class SessionHandler:
         )
 
     async def _handle_audio(self, data: dict) -> None:
+        features = data["features"]
+        rows = len(features)
+        cols = len(features[0]) if rows else 0
+        flat_max = max((max(row) for row in features), default=float("-inf"))
+        logger.info(
+            "audio_chunk received: shape=(%d, %d) max=%.3f feature_type=%s",
+            rows, cols, flat_max, data.get("feature_type", "?"),
+        )
         chunk = AudioFeatureChunk(
             session_id=self.session_id,
             timestamp_ms=data["timestamp_ms"],
-            features=data["features"],
+            features=features,
             feature_type=data["feature_type"],
             sample_rate_hz=data["sample_rate_hz"],
             chunk_duration_ms=data["chunk_duration_ms"],

--- a/sozia/server/api/session_handler.py
+++ b/sozia/server/api/session_handler.py
@@ -145,7 +145,10 @@ class SessionHandler:
         flat_max = max((max(row) for row in features), default=float("-inf"))
         logger.info(
             "audio_chunk received: shape=(%d, %d) max=%.3f feature_type=%s",
-            rows, cols, flat_max, data.get("feature_type", "?"),
+            rows,
+            cols,
+            flat_max,
+            data.get("feature_type", "?"),
         )
         chunk = AudioFeatureChunk(
             session_id=self.session_id,

--- a/sozia/server/fusion/mel_accumulator.py
+++ b/sozia/server/fusion/mel_accumulator.py
@@ -16,13 +16,13 @@ from __future__ import annotations
 import numpy as np
 
 # log10-mel floor for speech detection. Client sends Math.log10(energy + 1e-10);
-# speech peaks above −1, background noise stays below −3. -2.0 sits in the gap
-# and prevents weak-signal flushes that cause Whisper hallucinations.
-_SPEECH_ENERGY_THRESHOLD: float = -2.0
+# real speech peaks at +1 to +3, background noise stays below −1.
+_SPEECH_ENERGY_THRESHOLD: float = -1.0
 
-# Ignore silence flushes shorter than this — avoids firing on a single quiet
-# frame in the middle of continuous speech.
-_MIN_FLUSH_FRAMES: int = 50  # 500 ms at 100 Hz
+# Minimum accumulated frames before a silence flush is honoured. At 100 Hz this
+# is 1.5 s — long enough that a single loud transient won't trigger ASR, but
+# short enough to capture brief utterances like "Benim adım Mehmet."
+_MIN_FLUSH_FRAMES: int = 150  # 1500 ms at 100 Hz
 
 
 class MelAccumulator:

--- a/sozia/server/fusion/mel_accumulator.py
+++ b/sozia/server/fusion/mel_accumulator.py
@@ -1,0 +1,126 @@
+"""MelAccumulator — per-session mel-spectrogram buffer for the speech pipeline.
+
+WhisperAsrEngine produces better, sentence-level transcriptions when given a
+full utterance rather than 500 ms chunks. MelAccumulator holds incoming mel
+frames per session and flushes when one of two conditions is met:
+
+  1. Silence detected after speech (utterance boundary).
+  2. Buffer reaches ``max_frames`` (15 s ceiling at 100 Hz).
+
+Lip-reading continues to fire on every short chunk (PARTIAL updates).
+ASR fires on each flush (FINAL output).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+# log10-mel floor for speech detection. Client sends Math.log10(energy + 1e-10);
+# speech peaks above −3, background noise stays below −5.
+_SPEECH_ENERGY_THRESHOLD: float = -4.0
+
+# Ignore silence flushes shorter than this — avoids firing on a single quiet
+# frame in the middle of continuous speech.
+_MIN_FLUSH_FRAMES: int = 50  # 500 ms at 100 Hz
+
+
+class MelAccumulator:
+    """Buffers mel-spectrogram chunks per session; emits on utterance boundary.
+
+    Usage::
+
+        acc = MelAccumulator(max_frames=1500)
+        batch = acc.push(session_id, chunk_features)
+        if batch is not None:
+            result = await asr_engine.predict(batch)  # shape (T_total, N)
+
+    Args:
+        max_frames: Hard ceiling (frames). Default 1500 = 15 s at 100 Hz.
+        speech_threshold: log10-mel peak below which a chunk is silence.
+        min_flush_frames: Minimum accumulated frames before a silence flush
+            is honoured. Prevents spurious flushes on inter-word pauses.
+    """
+
+    def __init__(
+        self,
+        max_frames: int = 1500,
+        speech_threshold: float = _SPEECH_ENERGY_THRESHOLD,
+        min_flush_frames: int = _MIN_FLUSH_FRAMES,
+    ) -> None:
+        self._max_frames = max_frames
+        self._speech_threshold = speech_threshold
+        self._min_flush_frames = min_flush_frames
+
+        # Per-session state.
+        self._buffers: dict[str, list[np.ndarray]] = {}
+        self._has_seen_speech: dict[str, bool] = {}
+        self._frame_counts: dict[str, int] = {}
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def push(self, session_id: str, chunk: np.ndarray) -> np.ndarray | None:
+        """Append mel chunk and return the full buffer when ready to fire.
+
+        Args:
+            session_id: Active session identifier.
+            chunk: Raw log10-mel array from the client, shape ``(T, N)``
+                (AudioFeatureChunk.features is always ``[T, D]``).
+
+        Returns:
+            Concatenated buffer of shape ``(T_total, N)`` on flush;
+            ``None`` otherwise.
+        """
+        is_speech = float(np.max(chunk)) > self._speech_threshold
+
+        buf = self._buffers.setdefault(session_id, [])
+        seen = self._has_seen_speech.get(session_id, False)
+        count = self._frame_counts.get(session_id, 0)
+
+        if is_speech:
+            self._has_seen_speech[session_id] = True
+            buf.append(chunk)
+            # Client always sends (T, N) — AudioFeatureChunk.features is [T, D].
+            # WhisperAsrEngine._prepare_mel handles orientation; we just count rows.
+            count += chunk.shape[0]
+            self._frame_counts[session_id] = count
+
+            if count >= self._max_frames:
+                return self._flush(session_id)
+
+        else:
+            # Silence after speech + minimum frames met → flush.
+            if seen and count >= self._min_flush_frames:
+                return self._flush(session_id)
+            # Silence before speech, or pause too short → discard frame.
+
+        return None
+
+    def reset(self, session_id: str) -> None:
+        """Discard all buffered state for a session.
+
+        Safe to call even if no frames have been accumulated yet.
+        """
+        self._buffers.pop(session_id, None)
+        self._has_seen_speech.pop(session_id, None)
+        self._frame_counts.pop(session_id, None)
+
+    def pending_frames(self, session_id: str) -> int:
+        """Return buffered frame count for a session (0 if none)."""
+        return self._frame_counts.get(session_id, 0)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _flush(self, session_id: str) -> np.ndarray:
+        buf = self._buffers.pop(session_id, [])
+        self._has_seen_speech[session_id] = False
+        self._frame_counts[session_id] = 0
+
+        if not buf:
+            return np.zeros((0, 1), dtype=np.float32)
+
+        # Client sends (T, N); stack along the time axis (dim 0).
+        return np.concatenate(buf, axis=0)

--- a/sozia/server/fusion/mel_accumulator.py
+++ b/sozia/server/fusion/mel_accumulator.py
@@ -16,8 +16,9 @@ from __future__ import annotations
 import numpy as np
 
 # log10-mel floor for speech detection. Client sends Math.log10(energy + 1e-10);
-# speech peaks above −3, background noise stays below −5.
-_SPEECH_ENERGY_THRESHOLD: float = -4.0
+# speech peaks above −1, background noise stays below −3. -2.0 sits in the gap
+# and prevents weak-signal flushes that cause Whisper hallucinations.
+_SPEECH_ENERGY_THRESHOLD: float = -2.0
 
 # Ignore silence flushes shorter than this — avoids firing on a single quiet
 # frame in the middle of continuous speech.

--- a/sozia/server/fusion/orchestrator.py
+++ b/sozia/server/fusion/orchestrator.py
@@ -34,6 +34,8 @@ from sozia.common.models import (
 )
 from sozia.server.fusion.degraded_mode_handler import DegradedModeHandler
 from sozia.server.fusion.frame_accumulator import FrameAccumulator
+from sozia.server.fusion.mel_accumulator import MelAccumulator
+from sozia.server.fusion.speech_fusion_policy import SpeechFusionPolicy
 
 if TYPE_CHECKING:
     from sozia.common.interfaces import FusionStrategy, InferenceEngine
@@ -70,6 +72,7 @@ class FusionOrchestrator:
         self,
         degraded_handler: DegradedModeHandler | None = None,
         window_size: int = 30,
+        mel_max_frames: int = 1500,
     ) -> None:
         self._policies: dict[ModalityPath, FusionStrategy] = {}
         # Keyed by (path, modality_type) → (engine, config).
@@ -78,6 +81,7 @@ class FusionOrchestrator:
         ] = {}
         self._degraded: DegradedModeHandler = degraded_handler or DegradedModeHandler()
         self._accumulator = FrameAccumulator(window_size=window_size)
+        self._mel_accumulator = MelAccumulator(max_frames=mel_max_frames)
         # Per-session face landmark cache (SPEECH path — fed to LipReadingEngine).
         self._face_cache: dict[str, np.ndarray] = {}
 
@@ -134,6 +138,7 @@ class FusionOrchestrator:
         """
         self._face_cache.pop(session_id, None)
         self._accumulator.reset(session_id)
+        self._mel_accumulator.reset(session_id)
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -232,7 +237,9 @@ class FusionOrchestrator:
                 )
             return
 
-        # AudioFeatureChunk — run ASR (+ LipReading in parallel if face cached).
+        # AudioFeatureChunk — two independent paths:
+        #   Lip-reading: fires on every chunk → PARTIAL (fast word hints).
+        #   ASR: fires when MelAccumulator flushes (silence or 15 s) → FINAL.
         audio_np = np.asarray(features.features, dtype=np.float32)
         face_np = self._face_cache.get(session_id)
 
@@ -240,56 +247,48 @@ class FusionOrchestrator:
         asr_entry = path_engines.get(ModalityType.ASR)
         lip_entry = path_engines.get(ModalityType.LIP_READING)
 
-        async def _run_asr() -> ModalityResult | None:
-            if asr_entry is None:
-                return None
-            asr_engine, _ = asr_entry
-            try:
-                return await asr_engine.predict(audio_np)
-            except InferenceTimeoutError:
-                return None
-
-        async def _run_lip() -> ModalityResult | None:
-            if lip_entry is None or face_np is None:
-                return None
+        # --- Lip-reading (every chunk) → PARTIAL ----------------------------
+        if lip_entry is not None and face_np is not None:
             lip_engine, _ = lip_entry
             try:
-                return await lip_engine.predict(face_np)
+                lip_result = await lip_engine.predict(face_np)
+                lip_result = dataclasses.replace(
+                    lip_result,
+                    timestamp_ms=features.timestamp_ms,
+                    duration_ms=features.chunk_duration_ms,
+                )
+                lip_segments = await self.process_features(
+                    session_id, [lip_result], health, ModalityPath.SPEECH
+                )
+                for seg in lip_segments:
+                    await _maybe_await(send_fn(seg))
             except InferenceTimeoutError:
-                return None
+                pass
 
-        asr_result, lip_result = await asyncio.gather(_run_asr(), _run_lip())
-
-        if asr_result is None:
-            return  # ASR timed out or missing — nothing to emit.
-
-        # Stamp the session-timeline position from the AudioFeatureChunk.
-        # Engines return timestamp_ms=0 / duration_ms=0 (they have no timeline context);
-        # the orchestrator is the correct layer to fill this in.
-        asr_result = dataclasses.replace(
-            asr_result,
-            timestamp_ms=features.timestamp_ms,
-            duration_ms=features.chunk_duration_ms,
-        )
-        if lip_result is not None:
-            lip_result = dataclasses.replace(
-                lip_result,
-                timestamp_ms=features.timestamp_ms,
-                duration_ms=features.chunk_duration_ms,
-            )
-
-        results = [asr_result]
-        if lip_result is not None:
-            results.append(lip_result)
-
-        segments = await self.process_features(
-            session_id,
-            results,
-            health,
-            ModalityPath.SPEECH,
-        )
-        for seg in segments:
-            await _maybe_await(send_fn(seg))
+        # --- ASR (accumulated, utterance-boundary) → FINAL ------------------
+        asr_batch = self._mel_accumulator.push(session_id, audio_np)
+        if asr_batch is not None and asr_entry is not None:
+            asr_engine, _ = asr_entry
+            try:
+                # Use a longer timeout — the batch covers up to 15 s of audio.
+                asr_result = await asr_engine.predict(asr_batch, timeout_ms=3000)
+                asr_result = dataclasses.replace(
+                    asr_result,
+                    timestamp_ms=features.timestamp_ms,
+                    duration_ms=features.chunk_duration_ms,
+                )
+                policy = self._policies.get(ModalityPath.SPEECH)
+                if isinstance(policy, SpeechFusionPolicy):
+                    asr_segments = policy.emit_asr_final(asr_result, session_id)
+                else:
+                    # Fallback for non-standard policies.
+                    asr_segments = await self.process_features(
+                        session_id, [asr_result], health, ModalityPath.SPEECH
+                    )
+                for seg in asr_segments:
+                    await _maybe_await(send_fn(seg))
+            except InferenceTimeoutError:
+                pass
 
     async def _process_sign(
         self,

--- a/sozia/server/fusion/orchestrator.py
+++ b/sozia/server/fusion/orchestrator.py
@@ -14,9 +14,12 @@ from __future__ import annotations
 
 import asyncio
 import dataclasses
+import logging
 import time
 import uuid
 from typing import TYPE_CHECKING, Awaitable, Callable
+
+logger = logging.getLogger(__name__)
 
 import numpy as np
 
@@ -267,11 +270,20 @@ class FusionOrchestrator:
 
         # --- ASR (accumulated, utterance-boundary) → FINAL ------------------
         asr_batch = self._mel_accumulator.push(session_id, audio_np)
+        logger.info(
+            "mel_accumulator: pending=%d frames, flushed=%s",
+            self._mel_accumulator.pending_frames(session_id),
+            asr_batch is not None,
+        )
         if asr_batch is not None and asr_entry is not None:
             asr_engine, _ = asr_entry
             try:
                 # Use a longer timeout — the batch covers up to 15 s of audio.
                 asr_result = await asr_engine.predict(asr_batch, timeout_ms=3000)
+                logger.info(
+                    "ASR result: text=%r confidence=%.4f latency=%dms",
+                    asr_result.text, asr_result.confidence, asr_result.inference_latency_ms,
+                )
                 asr_result = dataclasses.replace(
                     asr_result,
                     timestamp_ms=features.timestamp_ms,

--- a/sozia/server/fusion/orchestrator.py
+++ b/sozia/server/fusion/orchestrator.py
@@ -282,7 +282,9 @@ class FusionOrchestrator:
                 asr_result = await asr_engine.predict(asr_batch, timeout_ms=3000)
                 logger.info(
                     "ASR result: text=%r confidence=%.4f latency=%dms",
-                    asr_result.text, asr_result.confidence, asr_result.inference_latency_ms,
+                    asr_result.text,
+                    asr_result.confidence,
+                    asr_result.inference_latency_ms,
                 )
                 asr_result = dataclasses.replace(
                     asr_result,

--- a/sozia/server/fusion/speech_fusion_policy.py
+++ b/sozia/server/fusion/speech_fusion_policy.py
@@ -102,8 +102,10 @@ class SpeechFusionPolicy(FusionStrategy):
                 replaces_segment_id=replaces,
             )]
 
-        # Single modality → PARTIAL.
+        # Single modality → PARTIAL, replacing the previous PARTIAL so the
+        # client always shows the latest lip-reading word rather than stacking.
         single = asr or lip
+        previous_id = self._partial_ids.get(session_id)
         seg_id = str(uuid.uuid4())
         self._partial_ids[session_id] = seg_id
 
@@ -115,8 +117,33 @@ class SpeechFusionPolicy(FusionStrategy):
             confidence=single.confidence,
             timestamp_ms=single.timestamp_ms,
             duration_ms=single.duration_ms,
-            replaces_segment_id=None,
+            replaces_segment_id=previous_id,
             segment_id=seg_id,
+        )]
+
+    def emit_asr_final(
+        self,
+        result: ModalityResult,
+        session_id: str,
+    ) -> list[TranscriptSegment]:
+        """Emit a FINAL segment from an accumulated ASR result.
+
+        Called when the MelAccumulator flushes after an utterance boundary.
+        The result covers a full sentence so it goes straight to FINAL,
+        replacing the last lip-reading PARTIAL stored for this session.
+        """
+        if self.should_suppress(result):
+            return []
+        replaces = self._partial_ids.pop(session_id, None)
+        return [self._make_segment(
+            session_id=session_id,
+            status=SegmentStatus.FINAL,
+            text=result.text,
+            source=ModalityType.ASR,
+            confidence=result.confidence,
+            timestamp_ms=result.timestamp_ms,
+            duration_ms=result.duration_ms,
+            replaces_segment_id=replaces,
         )]
 
     def should_suppress(self, result: ModalityResult) -> bool:

--- a/sozia/server/fusion/speech_fusion_policy.py
+++ b/sozia/server/fusion/speech_fusion_policy.py
@@ -25,6 +25,13 @@ from sozia.common.models import (
 
 _DEFAULT_CONFIDENCE_THRESHOLD = 0.30
 
+# Lip-reading PARTIAL segments are suppressed unless confidence exceeds this
+# higher bar. The mouth-only classifier (7 % val accuracy, 226 classes) is
+# unreliable as a standalone predictor; a high threshold prevents noise words
+# from appearing on screen while still allowing high-confidence detections
+# through once the model improves.
+_DEFAULT_LIP_PARTIAL_THRESHOLD = 0.70
+
 # Default weights for the weighted-average confidence merge.
 _DEFAULT_ASR_WEIGHT = 0.65
 _DEFAULT_LIP_WEIGHT = 0.35
@@ -46,10 +53,12 @@ class SpeechFusionPolicy(FusionStrategy):
         asr_weight: float = _DEFAULT_ASR_WEIGHT,
         lip_weight: float = _DEFAULT_LIP_WEIGHT,
         confidence_threshold: float = _DEFAULT_CONFIDENCE_THRESHOLD,
+        lip_partial_threshold: float = _DEFAULT_LIP_PARTIAL_THRESHOLD,
     ) -> None:
         self._asr_weight = asr_weight
         self._lip_weight = lip_weight
         self._confidence_threshold = confidence_threshold
+        self._lip_partial_threshold = lip_partial_threshold
         self._partial_ids: dict[str, str] = {}
 
     # ------------------------------------------------------------------
@@ -153,6 +162,8 @@ class SpeechFusionPolicy(FusionStrategy):
         ]
 
     def should_suppress(self, result: ModalityResult) -> bool:
+        if result.modality_type == ModalityType.LIP_READING:
+            return result.confidence < self._lip_partial_threshold
         return result.confidence < self._confidence_threshold
 
     def get_confidence_threshold(self) -> float:

--- a/sozia/server/fusion/speech_fusion_policy.py
+++ b/sozia/server/fusion/speech_fusion_policy.py
@@ -70,7 +70,8 @@ class SpeechFusionPolicy(FusionStrategy):
 
         asr = next((r for r in valid if r.modality_type == ModalityType.ASR), None)
         lip = next(
-            (r for r in valid if r.modality_type == ModalityType.LIP_READING), None,
+            (r for r in valid if r.modality_type == ModalityType.LIP_READING),
+            None,
         )
 
         session_id = health[0].session_id if health else ""
@@ -86,21 +87,22 @@ class SpeechFusionPolicy(FusionStrategy):
                 merged_text = asr.text
                 merged_source = ModalityType.ASR
             merged_confidence = (
-                self._asr_weight * asr.confidence
-                + self._lip_weight * lip.confidence
+                self._asr_weight * asr.confidence + self._lip_weight * lip.confidence
             )
             replaces = self._partial_ids.pop(session_id, None)
 
-            return [self._make_segment(
-                session_id=session_id,
-                status=SegmentStatus.FINAL,
-                text=merged_text,
-                source=merged_source,
-                confidence=min(1.0, merged_confidence),
-                timestamp_ms=asr.timestamp_ms,
-                duration_ms=max(asr.duration_ms, lip.duration_ms),
-                replaces_segment_id=replaces,
-            )]
+            return [
+                self._make_segment(
+                    session_id=session_id,
+                    status=SegmentStatus.FINAL,
+                    text=merged_text,
+                    source=merged_source,
+                    confidence=min(1.0, merged_confidence),
+                    timestamp_ms=asr.timestamp_ms,
+                    duration_ms=max(asr.duration_ms, lip.duration_ms),
+                    replaces_segment_id=replaces,
+                )
+            ]
 
         # Single modality → PARTIAL, replacing the previous PARTIAL so the
         # client always shows the latest lip-reading word rather than stacking.
@@ -109,17 +111,19 @@ class SpeechFusionPolicy(FusionStrategy):
         seg_id = str(uuid.uuid4())
         self._partial_ids[session_id] = seg_id
 
-        return [self._make_segment(
-            session_id=session_id,
-            status=SegmentStatus.PARTIAL,
-            text=single.text,
-            source=single.modality_type,
-            confidence=single.confidence,
-            timestamp_ms=single.timestamp_ms,
-            duration_ms=single.duration_ms,
-            replaces_segment_id=previous_id,
-            segment_id=seg_id,
-        )]
+        return [
+            self._make_segment(
+                session_id=session_id,
+                status=SegmentStatus.PARTIAL,
+                text=single.text,
+                source=single.modality_type,
+                confidence=single.confidence,
+                timestamp_ms=single.timestamp_ms,
+                duration_ms=single.duration_ms,
+                replaces_segment_id=previous_id,
+                segment_id=seg_id,
+            )
+        ]
 
     def emit_asr_final(
         self,
@@ -135,16 +139,18 @@ class SpeechFusionPolicy(FusionStrategy):
         if self.should_suppress(result):
             return []
         replaces = self._partial_ids.pop(session_id, None)
-        return [self._make_segment(
-            session_id=session_id,
-            status=SegmentStatus.FINAL,
-            text=result.text,
-            source=ModalityType.ASR,
-            confidence=result.confidence,
-            timestamp_ms=result.timestamp_ms,
-            duration_ms=result.duration_ms,
-            replaces_segment_id=replaces,
-        )]
+        return [
+            self._make_segment(
+                session_id=session_id,
+                status=SegmentStatus.FINAL,
+                text=result.text,
+                source=ModalityType.ASR,
+                confidence=result.confidence,
+                timestamp_ms=result.timestamp_ms,
+                duration_ms=result.duration_ms,
+                replaces_segment_id=replaces,
+            )
+        ]
 
     def should_suppress(self, result: ModalityResult) -> bool:
         return result.confidence < self._confidence_threshold

--- a/sozia/server/inference/speech/lip_reading_engine.py
+++ b/sozia/server/inference/speech/lip_reading_engine.py
@@ -167,6 +167,10 @@ class LipReadingEngine(InferenceEngine):
         )
         model.load_state_dict(state_dict)
         model.to(device)
+        # Normalize to fp32: state dicts saved with AMP have fp16 GRU/Linear weights
+        # but fp32 BatchNorm running_mean/running_var (PyTorch never saves BN stats as
+        # fp16). The dtype mismatch causes a RuntimeError in BatchNorm at inference.
+        model.float()
         model.eval()
 
         self._model = model

--- a/sozia/server/inference/speech/whisper_asr_engine.py
+++ b/sozia/server/inference/speech/whisper_asr_engine.py
@@ -35,8 +35,9 @@ _CACHE_CLEAR_INTERVAL = 10
 # log10-mel threshold for server-side VAD: chunks whose loudest bin stays below
 # this are treated as silence and returned as empty without running Whisper.
 # Client sends raw log10-mel (Math.log10(energy + 1e-10)); typical speech peaks
-# above −3, background noise stays below −5.
-_SPEECH_ENERGY_THRESHOLD = -4.0
+# above −1, background noise stays below −3. Raised to -2.0 to block weak-signal
+# batches that cause Whisper to hallucinate ("Altyazı M.K." etc.).
+_SPEECH_ENERGY_THRESHOLD = -2.0
 
 
 class WhisperAsrEngine(InferenceEngine):
@@ -102,7 +103,11 @@ class WhisperAsrEngine(InferenceEngine):
 
         energy_max = float(np.max(features))
         if not self._has_speech_content(features):
-            _log.info("ASR energy gate: BLOCKED (max=%.3f < threshold=%.1f)", energy_max, _SPEECH_ENERGY_THRESHOLD)
+            _log.info(
+                "ASR energy gate: BLOCKED (max=%.3f < threshold=%.1f)",
+                energy_max,
+                _SPEECH_ENERGY_THRESHOLD,
+            )
             return ModalityResult(
                 modality_type=ModalityType.ASR,
                 text="",
@@ -179,9 +184,9 @@ class WhisperAsrEngine(InferenceEngine):
 
         Operates on raw client log10-mel values (before server normalisation).
         Client computes log10(energy + 1e-10), so:
-          silence / background noise → peaks below −5
-          actual speech              → peaks above −3
-        _SPEECH_ENERGY_THRESHOLD (-4.0) sits in the gap.
+          silence / background noise → peaks below −3
+          actual speech              → peaks above −1
+        _SPEECH_ENERGY_THRESHOLD (-2.0) sits in the gap.
         """
         return float(np.max(features)) > _SPEECH_ENERGY_THRESHOLD
 

--- a/sozia/server/inference/speech/whisper_asr_engine.py
+++ b/sozia/server/inference/speech/whisper_asr_engine.py
@@ -34,10 +34,10 @@ _CACHE_CLEAR_INTERVAL = 10
 
 # log10-mel threshold for server-side VAD: chunks whose loudest bin stays below
 # this are treated as silence and returned as empty without running Whisper.
-# Client sends raw log10-mel (Math.log10(energy + 1e-10)); typical speech peaks
-# above −1, background noise stays below −3. Raised to -2.0 to block weak-signal
-# batches that cause Whisper to hallucinate ("Altyazı M.K." etc.).
-_SPEECH_ENERGY_THRESHOLD = -2.0
+# Client sends raw log10-mel (Math.log10(energy + 1e-10)); real speech peaks at
+# +1 to +3, background noise at −1 to −3. -1.0 blocks transient noise bursts
+# that cause Whisper to hallucinate ("İzlediğiniz için teşekkür ederim." etc.).
+_SPEECH_ENERGY_THRESHOLD = -1.0
 
 
 class WhisperAsrEngine(InferenceEngine):
@@ -184,9 +184,9 @@ class WhisperAsrEngine(InferenceEngine):
 
         Operates on raw client log10-mel values (before server normalisation).
         Client computes log10(energy + 1e-10), so:
-          silence / background noise → peaks below −3
-          actual speech              → peaks above −1
-        _SPEECH_ENERGY_THRESHOLD (-2.0) sits in the gap.
+          silence / background noise → peaks below −1
+          actual speech              → peaks at +1 to +3
+        _SPEECH_ENERGY_THRESHOLD (-1.0) sits in the gap.
         """
         return float(np.max(features)) > _SPEECH_ENERGY_THRESHOLD
 

--- a/sozia/server/inference/speech/whisper_asr_engine.py
+++ b/sozia/server/inference/speech/whisper_asr_engine.py
@@ -254,6 +254,7 @@ class WhisperAsrEngine(InferenceEngine):
                 num_beams=self._num_beams,
                 no_repeat_ngram_size=3,
                 return_dict_in_generate=True,
+                output_scores=True,
             )
             text = self._processor.tokenizer.batch_decode(
                 output.sequences, skip_special_tokens=True

--- a/sozia/server/inference/speech/whisper_asr_engine.py
+++ b/sozia/server/inference/speech/whisper_asr_engine.py
@@ -154,7 +154,7 @@ class WhisperAsrEngine(InferenceEngine):
     def _prepare_mel(self, features: np.ndarray) -> torch.Tensor:
         """Convert incoming feature array to a Whisper-compatible mel tensor.
 
-        Returns a float32 tensor of shape ``(1, 80, 3000)`` (batch=1).
+        Returns a tensor of shape ``(1, 80, 3000)`` cast to the model's dtype.
         """
         arr = np.asarray(features, dtype=np.float32)
 
@@ -192,20 +192,22 @@ class WhisperAsrEngine(InferenceEngine):
         arr = np.clip(arr, max_val - 8.0, max_val)
         arr = (arr + 4.0) / 4.0
 
-        return torch.from_numpy(arr).unsqueeze(0).to(self._device)
+        model_dtype = next(self._model.parameters()).dtype
+        return (
+            torch.from_numpy(arr)
+            .unsqueeze(0)
+            .to(device=self._device, dtype=model_dtype)
+        )
 
     def _run_inference(self, mel: torch.Tensor) -> tuple[str, float]:
         """Synchronous HF Whisper decode — called inside ``to_thread``."""
-        forced_ids = self._processor.get_decoder_prompt_ids(
-            language=self._language, task=self._task
-        )
         with torch.inference_mode():
             output = self._model.generate(
                 mel,
-                forced_decoder_ids=forced_ids,
+                language=self._language,
+                task=self._task,
                 num_beams=self._num_beams,
                 return_dict_in_generate=True,
-                output_scores=True,
             )
             text = self._processor.tokenizer.batch_decode(
                 output.sequences, skip_special_tokens=True

--- a/sozia/server/inference/speech/whisper_asr_engine.py
+++ b/sozia/server/inference/speech/whisper_asr_engine.py
@@ -179,9 +179,7 @@ class WhisperAsrEngine(InferenceEngine):
         """
         return float(np.max(features)) > _SPEECH_ENERGY_THRESHOLD
 
-    def _prepare_mel(
-        self, features: np.ndarray
-    ) -> tuple[torch.Tensor, torch.Tensor]:
+    def _prepare_mel(self, features: np.ndarray) -> tuple[torch.Tensor, torch.Tensor]:
         """Convert incoming feature array to a Whisper-compatible mel tensor.
 
         Returns:

--- a/sozia/server/inference/speech/whisper_asr_engine.py
+++ b/sozia/server/inference/speech/whisper_asr_engine.py
@@ -163,13 +163,18 @@ class WhisperAsrEngine(InferenceEngine):
                 f"WhisperAsrEngine: expected 2-D features, got shape {arr.shape}"
             )
 
-        # Transpose (T, 80) → (80, T)
-        if arr.ndim == 2 and arr.shape[1] <= 80 and arr.shape[0] > 80:
-            arr = arr.T
+        # Client sends (T, 80); Whisper needs (80, T). Detect orientation by
+        # which dimension equals 80 (mel bins). Handles any chunk length T.
+        if arr.ndim == 2:
+            if arr.shape[0] == 80:
+                pass  # already (80, T)
+            elif arr.shape[1] == 80:
+                arr = arr.T  # (T, 80) → (80, T)
+            # else: neither dim is 80 — fall through to zero-pad path below
 
         n_mels, t_len = arr.shape[0], arr.shape[1]
 
-        # Zero-pad to 80 mel bins if fewer (e.g. 13-dim MFCC input)
+        # Zero-pad to 80 mel bins if fewer
         if n_mels < 80:
             arr = np.vstack([arr, np.zeros((80 - n_mels, t_len), dtype=np.float32)])
 

--- a/sozia/server/inference/speech/whisper_asr_engine.py
+++ b/sozia/server/inference/speech/whisper_asr_engine.py
@@ -10,8 +10,11 @@ Latency budget: ≤ 800 ms.
 from __future__ import annotations
 
 import asyncio
+import logging
 import time
 from typing import TYPE_CHECKING
+
+_log = logging.getLogger(__name__)
 
 import numpy as np
 import torch
@@ -97,7 +100,9 @@ class WhisperAsrEngine(InferenceEngine):
         if self._model is None or self._processor is None:
             raise ModelNotLoadedError("WhisperAsrEngine: no model loaded.")
 
+        energy_max = float(np.max(features))
         if not self._has_speech_content(features):
+            _log.info("ASR energy gate: BLOCKED (max=%.3f < threshold=%.1f)", energy_max, _SPEECH_ENERGY_THRESHOLD)
             return ModalityResult(
                 modality_type=ModalityType.ASR,
                 text="",
@@ -107,6 +112,7 @@ class WhisperAsrEngine(InferenceEngine):
                 inference_latency_ms=0,
             )
 
+        _log.info("ASR energy gate: PASSED (max=%.3f)", energy_max)
         mel, attention_mask = self._prepare_mel(features)
         start = time.perf_counter()
 

--- a/sozia/server/inference/speech/whisper_asr_engine.py
+++ b/sozia/server/inference/speech/whisper_asr_engine.py
@@ -50,6 +50,7 @@ class WhisperAsrEngine(InferenceEngine):
         self._language: str = "tr"
         self._task: str = "transcribe"
         self._num_beams: int = 1
+        self._n_mels: int = 80
         self._inference_count: int = 0
 
     # ------------------------------------------------------------------
@@ -69,6 +70,8 @@ class WhisperAsrEngine(InferenceEngine):
         self._processor = processor
         self._model = model
         self._model_id = config.model_id
+        feature_size = getattr(processor.feature_extractor, "feature_size", 80)
+        self._n_mels = feature_size if isinstance(feature_size, int) else 80
 
     async def predict(
         self,
@@ -163,20 +166,21 @@ class WhisperAsrEngine(InferenceEngine):
                 f"WhisperAsrEngine: expected 2-D features, got shape {arr.shape}"
             )
 
-        # Client sends (T, 80); Whisper needs (80, T). Detect orientation by
-        # which dimension equals 80 (mel bins). Handles any chunk length T.
+        # Client sends (T, N); Whisper needs (N, T) where N = self._n_mels.
+        # Detect orientation by which dimension equals N.
+        n = self._n_mels
         if arr.ndim == 2:
-            if arr.shape[0] == 80:
-                pass  # already (80, T)
-            elif arr.shape[1] == 80:
-                arr = arr.T  # (T, 80) → (80, T)
-            # else: neither dim is 80 — fall through to zero-pad path below
+            if arr.shape[0] == n:
+                pass  # already (N, T)
+            elif arr.shape[1] == n:
+                arr = arr.T  # (T, N) → (N, T)
+            # else: neither dim matches — fall through to zero-pad below
 
         n_mels, t_len = arr.shape[0], arr.shape[1]
 
-        # Zero-pad to 80 mel bins if fewer
-        if n_mels < 80:
-            arr = np.vstack([arr, np.zeros((80 - n_mels, t_len), dtype=np.float32)])
+        # Zero-pad to n mel bins if fewer
+        if n_mels < n:
+            arr = np.vstack([arr, np.zeros((n - n_mels, t_len), dtype=np.float32)])
 
         # Whisper expects exactly 3000 time frames (30 s × 100 Hz)
         target_t = 3000

--- a/sozia/server/inference/speech/whisper_asr_engine.py
+++ b/sozia/server/inference/speech/whisper_asr_engine.py
@@ -29,6 +29,12 @@ if TYPE_CHECKING:
 _DEFAULT_TIMEOUT_MS = 800
 _CACHE_CLEAR_INTERVAL = 10
 
+# log10-mel threshold for server-side VAD: chunks whose loudest bin stays below
+# this are treated as silence and returned as empty without running Whisper.
+# Client sends raw log10-mel (Math.log10(energy + 1e-10)); typical speech peaks
+# above −3, background noise stays below −5.
+_SPEECH_ENERGY_THRESHOLD = -4.0
+
 
 class WhisperAsrEngine(InferenceEngine):
     """InferenceEngine backed by a HuggingFace WhisperForConditionalGeneration.
@@ -91,12 +97,22 @@ class WhisperAsrEngine(InferenceEngine):
         if self._model is None or self._processor is None:
             raise ModelNotLoadedError("WhisperAsrEngine: no model loaded.")
 
-        mel = self._prepare_mel(features)
+        if not self._has_speech_content(features):
+            return ModalityResult(
+                modality_type=ModalityType.ASR,
+                text="",
+                confidence=0.0,
+                timestamp_ms=0,
+                duration_ms=0,
+                inference_latency_ms=0,
+            )
+
+        mel, attention_mask = self._prepare_mel(features)
         start = time.perf_counter()
 
         try:
             text, confidence = await asyncio.wait_for(
-                asyncio.to_thread(self._run_inference, mel),
+                asyncio.to_thread(self._run_inference, mel, attention_mask),
                 timeout=timeout_ms / 1000.0,
             )
         except asyncio.TimeoutError:
@@ -104,10 +120,7 @@ class WhisperAsrEngine(InferenceEngine):
                 f"WhisperAsrEngine exceeded {timeout_ms}ms budget."
             )
         finally:
-            # On timeout the thread is still running and holds its own reference
-            # to `mel` via the call frame; this del only drops the event-loop
-            # copy. GPU memory is released when the thread returns naturally.
-            del mel
+            del mel, attention_mask
 
         latency_ms = int((time.perf_counter() - start) * 1000)
 
@@ -154,10 +167,28 @@ class WhisperAsrEngine(InferenceEngine):
         model.eval()
         return processor, model
 
-    def _prepare_mel(self, features: np.ndarray) -> torch.Tensor:
+    @staticmethod
+    def _has_speech_content(features: np.ndarray) -> bool:
+        """Return False if the mel chunk is silence/noise.
+
+        Operates on raw client log10-mel values (before server normalisation).
+        Client computes log10(energy + 1e-10), so:
+          silence / background noise → peaks below −5
+          actual speech              → peaks above −3
+        _SPEECH_ENERGY_THRESHOLD (-4.0) sits in the gap.
+        """
+        return float(np.max(features)) > _SPEECH_ENERGY_THRESHOLD
+
+    def _prepare_mel(
+        self, features: np.ndarray
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         """Convert incoming feature array to a Whisper-compatible mel tensor.
 
-        Returns a tensor of shape ``(1, 80, 3000)`` cast to the model's dtype.
+        Returns:
+            mel: ``(1, N, 3000)`` cast to the model's dtype.
+            attention_mask: ``(1, 3000)`` long tensor — 1 for real frames,
+                0 for zero-padded frames. Passing this to ``generate()``
+                prevents Whisper from treating silence-padding as real audio.
         """
         arr = np.asarray(features, dtype=np.float32)
 
@@ -182,8 +213,12 @@ class WhisperAsrEngine(InferenceEngine):
         if n_mels < n:
             arr = np.vstack([arr, np.zeros((n - n_mels, t_len), dtype=np.float32)])
 
-        # Whisper expects exactly 3000 time frames (30 s × 100 Hz)
+        # Whisper expects exactly 3000 time frames (30 s × 100 Hz).
+        # Record the real frame count before padding so we can build a precise
+        # attention mask — an all-ones mask would cause the model to treat the
+        # zero-padded tail as real audio and hallucinate.
         target_t = 3000
+        real_frames = min(arr.shape[1], target_t)
         if arr.shape[1] < target_t:
             arr = np.pad(arr, ((0, 0), (0, target_t - arr.shape[1])))
         elif arr.shape[1] > target_t:
@@ -197,20 +232,29 @@ class WhisperAsrEngine(InferenceEngine):
         arr = (arr + 4.0) / 4.0
 
         model_dtype = next(self._model.parameters()).dtype
-        return (
+        mel = (
             torch.from_numpy(arr)
             .unsqueeze(0)
             .to(device=self._device, dtype=model_dtype)
         )
 
-    def _run_inference(self, mel: torch.Tensor) -> tuple[str, float]:
+        attention_mask = torch.zeros(1, target_t, dtype=torch.long, device=self._device)
+        attention_mask[0, :real_frames] = 1
+
+        return mel, attention_mask
+
+    def _run_inference(
+        self, mel: torch.Tensor, attention_mask: torch.Tensor
+    ) -> tuple[str, float]:
         """Synchronous HF Whisper decode — called inside ``to_thread``."""
         with torch.inference_mode():
             output = self._model.generate(
                 mel,
+                attention_mask=attention_mask,
                 language=self._language,
                 task=self._task,
                 num_beams=self._num_beams,
+                no_repeat_ngram_size=3,
                 return_dict_in_generate=True,
             )
             text = self._processor.tokenizer.batch_decode(

--- a/tests/fusion/test_mel_accumulator.py
+++ b/tests/fusion/test_mel_accumulator.py
@@ -1,0 +1,142 @@
+"""Tests for MelAccumulator — utterance-boundary mel buffering."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from sozia.server.fusion.mel_accumulator import MelAccumulator
+
+SESSION = "test-session"
+
+# Helpers: speech chunks peak above -4; silence peaks below -4.
+def _speech(t: int = 50, n: int = 128) -> np.ndarray:
+    arr = np.full((t, n), -10.0, dtype=np.float32)
+    arr[0, 0] = -2.0  # one bin well above threshold
+    return arr
+
+
+def _silence(t: int = 50, n: int = 128) -> np.ndarray:
+    return np.full((t, n), -10.0, dtype=np.float32)
+
+
+# ---------------------------------------------------------------------------
+# Basic accumulation
+# ---------------------------------------------------------------------------
+
+
+class TestMelAccumulatorBasic:
+    def test_returns_none_while_buffering(self):
+        acc = MelAccumulator(min_flush_frames=200)
+        assert acc.push(SESSION, _speech()) is None
+        assert acc.push(SESSION, _speech()) is None
+
+    def test_flush_on_silence_after_speech(self):
+        acc = MelAccumulator(min_flush_frames=50)
+        acc.push(SESSION, _speech(t=50))
+        result = acc.push(SESSION, _silence())
+        assert result is not None
+        assert result.shape[0] == 50  # only the speech chunk
+
+    def test_silence_before_speech_is_ignored(self):
+        acc = MelAccumulator()
+        assert acc.push(SESSION, _silence()) is None
+        assert acc.push(SESSION, _silence()) is None
+
+    def test_flush_on_max_frames(self):
+        acc = MelAccumulator(max_frames=100)
+        # Two 60-frame speech chunks → should flush when total ≥ 100
+        acc.push(SESSION, _speech(t=60))
+        result = acc.push(SESSION, _speech(t=60))
+        assert result is not None
+        assert result.shape[0] == 120
+
+    def test_buffer_resets_after_flush(self):
+        acc = MelAccumulator(min_flush_frames=50)
+        acc.push(SESSION, _speech(t=50))
+        acc.push(SESSION, _silence())  # flush
+        # New speech after flush should not carry over frames
+        assert acc.pending_frames(SESSION) == 0
+
+    def test_pending_frames_tracks_count(self):
+        acc = MelAccumulator(min_flush_frames=200)
+        acc.push(SESSION, _speech(t=50))
+        assert acc.pending_frames(SESSION) == 50
+        acc.push(SESSION, _speech(t=30))
+        assert acc.pending_frames(SESSION) == 80
+
+    def test_short_pause_does_not_flush(self):
+        # min_flush_frames=200; only 50 frames buffered → silence should not flush
+        acc = MelAccumulator(min_flush_frames=200)
+        acc.push(SESSION, _speech(t=50))
+        result = acc.push(SESSION, _silence())
+        assert result is None
+        assert acc.pending_frames(SESSION) == 50
+
+
+# ---------------------------------------------------------------------------
+# Multi-session isolation
+# ---------------------------------------------------------------------------
+
+
+class TestMelAccumulatorMultiSession:
+    def test_sessions_are_isolated(self):
+        acc = MelAccumulator(min_flush_frames=50)
+        acc.push("s1", _speech(t=50))
+        result_s2 = acc.push("s2", _silence())
+        assert result_s2 is None  # s2 never saw speech
+
+    def test_flush_in_one_session_does_not_affect_other(self):
+        acc = MelAccumulator(min_flush_frames=50)
+        acc.push("s1", _speech(t=50))
+        acc.push("s1", _silence())  # flush s1
+        acc.push("s2", _speech(t=50))
+        assert acc.pending_frames("s2") == 50
+
+
+# ---------------------------------------------------------------------------
+# Output shape and content
+# ---------------------------------------------------------------------------
+
+
+class TestMelAccumulatorOutput:
+    def test_output_concatenates_time_axis(self):
+        acc = MelAccumulator(min_flush_frames=50)
+        acc.push(SESSION, _speech(t=30))
+        acc.push(SESSION, _speech(t=40))
+        result = acc.push(SESSION, _silence())
+        assert result is not None
+        assert result.shape == (70, 128)
+
+    def test_speech_content_preserved(self):
+        acc = MelAccumulator(min_flush_frames=50)
+        chunk = _speech(t=50)
+        chunk[5, 10] = 999.0  # sentinel
+        acc.push(SESSION, chunk)
+        result = acc.push(SESSION, _silence())
+        assert result is not None
+        assert result[5, 10] == pytest.approx(999.0)
+
+
+# ---------------------------------------------------------------------------
+# Reset
+# ---------------------------------------------------------------------------
+
+
+class TestMelAccumulatorReset:
+    def test_reset_clears_buffer(self):
+        acc = MelAccumulator(min_flush_frames=200)
+        acc.push(SESSION, _speech(t=50))
+        acc.reset(SESSION)
+        assert acc.pending_frames(SESSION) == 0
+
+    def test_reset_prevents_stale_flush(self):
+        acc = MelAccumulator(min_flush_frames=50)
+        acc.push(SESSION, _speech(t=50))
+        acc.reset(SESSION)
+        result = acc.push(SESSION, _silence())
+        assert result is None  # speech flag was cleared
+
+    def test_reset_on_unknown_session_is_safe(self):
+        acc = MelAccumulator()
+        acc.reset("nonexistent")  # must not raise

--- a/tests/fusion/test_mel_accumulator.py
+++ b/tests/fusion/test_mel_accumulator.py
@@ -13,7 +13,7 @@ SESSION = "test-session"
 # Helpers: speech chunks peak above -4; silence peaks below -4.
 def _speech(t: int = 50, n: int = 128) -> np.ndarray:
     arr = np.full((t, n), -10.0, dtype=np.float32)
-    arr[0, 0] = -2.0  # one bin well above threshold
+    arr[0, 0] = 0.0  # one bin well above -1.0 threshold
     return arr
 
 

--- a/tests/fusion/test_mel_accumulator.py
+++ b/tests/fusion/test_mel_accumulator.py
@@ -9,6 +9,7 @@ from sozia.server.fusion.mel_accumulator import MelAccumulator
 
 SESSION = "test-session"
 
+
 # Helpers: speech chunks peak above -4; silence peaks below -4.
 def _speech(t: int = 50, n: int = 128) -> np.ndarray:
     arr = np.full((t, n), -10.0, dtype=np.float32)

--- a/tests/fusion/test_orchestrator_process.py
+++ b/tests/fusion/test_orchestrator_process.py
@@ -139,6 +139,7 @@ class _StubEngine(InferenceEngine):
 
 def _make_orchestrator(
     window_size: int = 1,
+    mel_max_frames: int = 1500,
     with_speech: bool = False,
     with_sign: bool = False,
     asr_engine: _StubEngine | None = None,
@@ -146,7 +147,7 @@ def _make_orchestrator(
     tsl_engine: _StubEngine | None = None,
     gloss_engine: _StubEngine | None = None,
 ) -> FusionOrchestrator:
-    orch = FusionOrchestrator(window_size=window_size)
+    orch = FusionOrchestrator(window_size=window_size, mel_max_frames=mel_max_frames)
     orch.register_policy(ModalityPath.SPEECH, SpeechFusionPolicy())
     orch.register_policy(ModalityPath.SIGN, SignFusionPolicy())
 
@@ -285,21 +286,23 @@ class TestWarmUpCoolDownUpdated:
 
 class TestProcessSpeech:
     async def test_audio_chunk_emits_partial_via_send_fn(self):
+        # Lip-reading fires on every chunk when face is cached → PARTIAL.
         orch = _make_orchestrator(with_speech=True)
-        sent: list[TranscriptSegment] = []
-
         await orch.process(
-            _SESSION,
-            _audio_chunk(),
-            [_audio_health()],
-            ModalityPath.SPEECH,
-            sent.append,
+            _SESSION, _landmark_frame(), [_video_health()], ModalityPath.SPEECH, lambda _: None
+        )
+
+        sent: list[TranscriptSegment] = []
+        await orch.process(
+            _SESSION, _audio_chunk(), [_audio_health()], ModalityPath.SPEECH, sent.append
         )
 
         assert len(sent) >= 1
         assert any(s.status == SegmentStatus.PARTIAL for s in sent)
 
     async def test_audio_chunk_with_cached_face_emits_final(self):
+        # mel_max_frames=1 forces accumulator to flush on the first speech chunk.
+        # Lip-reading emits PARTIAL; ASR emits FINAL after flush.
         asr = _StubEngine(_result(ModalityType.ASR, "merhaba", 0.75), model_id="w")
         lip = _StubEngine(
             _result(ModalityType.LIP_READING, "merhaba dünya", 0.85), model_id="l"
@@ -307,41 +310,33 @@ class TestProcessSpeech:
         asr._loaded = True
         lip._loaded = True
 
-        orch = FusionOrchestrator()
+        orch = FusionOrchestrator(mel_max_frames=1)
         orch.register_policy(ModalityPath.SPEECH, SpeechFusionPolicy())
         orch.register_engine(ModalityPath.SPEECH, ModalityType.ASR, asr, _cfg("w"))
         orch.register_engine(
             ModalityPath.SPEECH, ModalityType.LIP_READING, lip, _cfg("l")
         )
 
-        # First send a landmark frame to populate the face cache.
         sent: list[TranscriptSegment] = []
         await orch.process(
-            _SESSION,
-            _landmark_frame(),
-            [_video_health()],
-            ModalityPath.SPEECH,
-            sent.append,
+            _SESSION, _landmark_frame(), [_video_health()], ModalityPath.SPEECH, sent.append
         )
-        assert sent == []  # face caching only, no inference yet
+        assert sent == []  # face caching only
 
-        # Now send audio chunk — both engines run.
         await orch.process(
-            _SESSION,
-            _audio_chunk(),
-            [_audio_health()],
-            ModalityPath.SPEECH,
-            sent.append,
+            _SESSION, _audio_chunk(), [_audio_health()], ModalityPath.SPEECH, sent.append
         )
         assert any(s.status == SegmentStatus.FINAL for s in sent)
 
-    async def test_audio_chunk_without_face_cache_emits_asr_only_partial(self):
+    async def test_asr_final_emits_after_accumulator_flush(self):
+        # Without a cached face, lip-reading is skipped. ASR fires as FINAL
+        # when the accumulator flushes (mel_max_frames=1 forces it on first chunk).
         asr = _StubEngine(_result(ModalityType.ASR, "merhaba", 0.85), model_id="w")
         lip = _StubEngine(_result(ModalityType.LIP_READING, "x", 0.75), model_id="l")
         asr._loaded = True
         lip._loaded = True
 
-        orch = FusionOrchestrator()
+        orch = FusionOrchestrator(mel_max_frames=1)
         orch.register_policy(ModalityPath.SPEECH, SpeechFusionPolicy())
         orch.register_engine(ModalityPath.SPEECH, ModalityType.ASR, asr, _cfg("w"))
         orch.register_engine(
@@ -350,15 +345,11 @@ class TestProcessSpeech:
 
         sent: list[TranscriptSegment] = []
         await orch.process(
-            _SESSION,
-            _audio_chunk(),
-            [_audio_health()],
-            ModalityPath.SPEECH,
-            sent.append,
+            _SESSION, _audio_chunk(), [_audio_health()], ModalityPath.SPEECH, sent.append
         )
-        # Only ASR runs (no cached face) → PARTIAL.
+        # Lip-reading skipped (no face cache). ASR fires as FINAL from accumulator.
         assert len(sent) == 1
-        assert sent[0].status == SegmentStatus.PARTIAL
+        assert sent[0].status == SegmentStatus.FINAL
         assert sent[0].source == ModalityType.ASR
 
     async def test_asr_timeout_produces_no_segments(self):
@@ -379,38 +370,30 @@ class TestProcessSpeech:
         )
         assert sent == []
 
-    async def test_lip_timeout_emits_asr_partial_only(self):
+    async def test_lip_timeout_asr_still_emits_final(self):
+        # Lip-reading times out → no PARTIAL. ASR fires FINAL from accumulator.
         asr = _StubEngine(_result(ModalityType.ASR, "merhaba", 0.80), model_id="w")
         lip = _StubEngine(None, raise_timeout=True, model_id="l")
         asr._loaded = True
         lip._loaded = True
 
-        orch = FusionOrchestrator()
+        orch = FusionOrchestrator(mel_max_frames=1)
         orch.register_policy(ModalityPath.SPEECH, SpeechFusionPolicy())
         orch.register_engine(ModalityPath.SPEECH, ModalityType.ASR, asr, _cfg("w"))
         orch.register_engine(
             ModalityPath.SPEECH, ModalityType.LIP_READING, lip, _cfg("l")
         )
 
-        # Prime face cache first.
         await orch.process(
-            _SESSION,
-            _landmark_frame(),
-            [_video_health()],
-            ModalityPath.SPEECH,
-            lambda s: None,
+            _SESSION, _landmark_frame(), [_video_health()], ModalityPath.SPEECH, lambda s: None
         )
 
         sent: list[TranscriptSegment] = []
         await orch.process(
-            _SESSION,
-            _audio_chunk(),
-            [_audio_health()],
-            ModalityPath.SPEECH,
-            sent.append,
+            _SESSION, _audio_chunk(), [_audio_health()], ModalityPath.SPEECH, sent.append
         )
         assert len(sent) == 1
-        assert sent[0].status == SegmentStatus.PARTIAL
+        assert sent[0].status == SegmentStatus.FINAL
         assert sent[0].source == ModalityType.ASR
 
     async def test_suppressed_asr_emits_nothing(self):
@@ -457,26 +440,21 @@ class TestProcessSpeech:
         asr = _StubEngine(_result(ModalityType.ASR, "test", 0.85), model_id="w")
         asr._loaded = True
 
-        orch = FusionOrchestrator()
+        # mel_max_frames=1 forces accumulator flush so ASR fires on first chunk.
+        orch = FusionOrchestrator(mel_max_frames=1)
         orch.register_policy(ModalityPath.SPEECH, SpeechFusionPolicy())
         orch.register_engine(ModalityPath.SPEECH, ModalityType.ASR, asr, _cfg("w"))
 
         sent: list[TranscriptSegment] = []
-        await orch.process(
-            _SESSION,
-            chunk,
-            [_audio_health()],
-            ModalityPath.SPEECH,
-            sent.append,
-        )
+        await orch.process(_SESSION, chunk, [_audio_health()], ModalityPath.SPEECH, sent.append)
 
         assert len(sent) >= 1
         for seg in sent:
             assert seg.timestamp_ms == 5000
             assert seg.duration_ms == 750
 
-    async def test_lip_result_also_carries_audio_chunk_timing(self):
-        """Both ASR and LipReading results get stamped with the same AudioFeatureChunk timing."""
+    async def test_lip_partial_carries_audio_chunk_timing(self):
+        """Lip-reading PARTIAL is stamped with AudioFeatureChunk timing."""
         chunk = AudioFeatureChunk(
             session_id=_SESSION,
             timestamp_ms=3000,
@@ -485,42 +463,23 @@ class TestProcessSpeech:
             sample_rate_hz=16000,
             chunk_duration_ms=500,
         )
-        asr = _StubEngine(_result(ModalityType.ASR, "hello", 0.75), model_id="w")
-        lip = _StubEngine(
-            _result(ModalityType.LIP_READING, "hello", 0.80), model_id="l"
-        )
-        asr._loaded = True
+        lip = _StubEngine(_result(ModalityType.LIP_READING, "hello", 0.80), model_id="l")
         lip._loaded = True
 
         orch = FusionOrchestrator()
         orch.register_policy(ModalityPath.SPEECH, SpeechFusionPolicy())
-        orch.register_engine(ModalityPath.SPEECH, ModalityType.ASR, asr, _cfg("w"))
-        orch.register_engine(
-            ModalityPath.SPEECH, ModalityType.LIP_READING, lip, _cfg("l")
-        )
+        orch.register_engine(ModalityPath.SPEECH, ModalityType.LIP_READING, lip, _cfg("l"))
 
-        # Prime face cache.
         await orch.process(
-            _SESSION,
-            _landmark_frame(),
-            [_video_health()],
-            ModalityPath.SPEECH,
-            lambda _: None,
+            _SESSION, _landmark_frame(), [_video_health()], ModalityPath.SPEECH, lambda _: None
         )
 
         sent: list[TranscriptSegment] = []
-        await orch.process(
-            _SESSION,
-            chunk,
-            [_audio_health()],
-            ModalityPath.SPEECH,
-            sent.append,
-        )
+        await orch.process(_SESSION, chunk, [_audio_health()], ModalityPath.SPEECH, sent.append)
 
-        assert any(s.status == SegmentStatus.FINAL for s in sent)
-        for seg in sent:
-            assert seg.timestamp_ms == 3000
-            assert seg.duration_ms == 500
+        assert len(sent) == 1
+        assert sent[0].timestamp_ms == 3000
+        assert sent[0].duration_ms == 500
 
 
 # ---------------------------------------------------------------------------

--- a/tests/fusion/test_orchestrator_process.py
+++ b/tests/fusion/test_orchestrator_process.py
@@ -289,12 +289,20 @@ class TestProcessSpeech:
         # Lip-reading fires on every chunk when face is cached → PARTIAL.
         orch = _make_orchestrator(with_speech=True)
         await orch.process(
-            _SESSION, _landmark_frame(), [_video_health()], ModalityPath.SPEECH, lambda _: None
+            _SESSION,
+            _landmark_frame(),
+            [_video_health()],
+            ModalityPath.SPEECH,
+            lambda _: None,
         )
 
         sent: list[TranscriptSegment] = []
         await orch.process(
-            _SESSION, _audio_chunk(), [_audio_health()], ModalityPath.SPEECH, sent.append
+            _SESSION,
+            _audio_chunk(),
+            [_audio_health()],
+            ModalityPath.SPEECH,
+            sent.append,
         )
 
         assert len(sent) >= 1
@@ -319,12 +327,20 @@ class TestProcessSpeech:
 
         sent: list[TranscriptSegment] = []
         await orch.process(
-            _SESSION, _landmark_frame(), [_video_health()], ModalityPath.SPEECH, sent.append
+            _SESSION,
+            _landmark_frame(),
+            [_video_health()],
+            ModalityPath.SPEECH,
+            sent.append,
         )
         assert sent == []  # face caching only
 
         await orch.process(
-            _SESSION, _audio_chunk(), [_audio_health()], ModalityPath.SPEECH, sent.append
+            _SESSION,
+            _audio_chunk(),
+            [_audio_health()],
+            ModalityPath.SPEECH,
+            sent.append,
         )
         assert any(s.status == SegmentStatus.FINAL for s in sent)
 
@@ -345,7 +361,11 @@ class TestProcessSpeech:
 
         sent: list[TranscriptSegment] = []
         await orch.process(
-            _SESSION, _audio_chunk(), [_audio_health()], ModalityPath.SPEECH, sent.append
+            _SESSION,
+            _audio_chunk(),
+            [_audio_health()],
+            ModalityPath.SPEECH,
+            sent.append,
         )
         # Lip-reading skipped (no face cache). ASR fires as FINAL from accumulator.
         assert len(sent) == 1
@@ -385,12 +405,20 @@ class TestProcessSpeech:
         )
 
         await orch.process(
-            _SESSION, _landmark_frame(), [_video_health()], ModalityPath.SPEECH, lambda s: None
+            _SESSION,
+            _landmark_frame(),
+            [_video_health()],
+            ModalityPath.SPEECH,
+            lambda s: None,
         )
 
         sent: list[TranscriptSegment] = []
         await orch.process(
-            _SESSION, _audio_chunk(), [_audio_health()], ModalityPath.SPEECH, sent.append
+            _SESSION,
+            _audio_chunk(),
+            [_audio_health()],
+            ModalityPath.SPEECH,
+            sent.append,
         )
         assert len(sent) == 1
         assert sent[0].status == SegmentStatus.FINAL
@@ -446,7 +474,9 @@ class TestProcessSpeech:
         orch.register_engine(ModalityPath.SPEECH, ModalityType.ASR, asr, _cfg("w"))
 
         sent: list[TranscriptSegment] = []
-        await orch.process(_SESSION, chunk, [_audio_health()], ModalityPath.SPEECH, sent.append)
+        await orch.process(
+            _SESSION, chunk, [_audio_health()], ModalityPath.SPEECH, sent.append
+        )
 
         assert len(sent) >= 1
         for seg in sent:
@@ -463,19 +493,29 @@ class TestProcessSpeech:
             sample_rate_hz=16000,
             chunk_duration_ms=500,
         )
-        lip = _StubEngine(_result(ModalityType.LIP_READING, "hello", 0.80), model_id="l")
+        lip = _StubEngine(
+            _result(ModalityType.LIP_READING, "hello", 0.80), model_id="l"
+        )
         lip._loaded = True
 
         orch = FusionOrchestrator()
         orch.register_policy(ModalityPath.SPEECH, SpeechFusionPolicy())
-        orch.register_engine(ModalityPath.SPEECH, ModalityType.LIP_READING, lip, _cfg("l"))
+        orch.register_engine(
+            ModalityPath.SPEECH, ModalityType.LIP_READING, lip, _cfg("l")
+        )
 
         await orch.process(
-            _SESSION, _landmark_frame(), [_video_health()], ModalityPath.SPEECH, lambda _: None
+            _SESSION,
+            _landmark_frame(),
+            [_video_health()],
+            ModalityPath.SPEECH,
+            lambda _: None,
         )
 
         sent: list[TranscriptSegment] = []
-        await orch.process(_SESSION, chunk, [_audio_health()], ModalityPath.SPEECH, sent.append)
+        await orch.process(
+            _SESSION, chunk, [_audio_health()], ModalityPath.SPEECH, sent.append
+        )
 
         assert len(sent) == 1
         assert sent[0].timestamp_ms == 3000

--- a/tests/inference/speech/test_whisper_asr_engine.py
+++ b/tests/inference/speech/test_whisper_asr_engine.py
@@ -284,7 +284,9 @@ class TestWhisperAsrEngineVad:
             engine = WhisperAsrEngine()
             import asyncio
 
-            asyncio.get_event_loop().run_until_complete(engine.load_model(_make_config()))
+            asyncio.get_event_loop().run_until_complete(
+                engine.load_model(_make_config())
+            )
 
         # All-−10 array is pure silence (log10-mel floor)
         silent = np.full((80, 200), -10.0, dtype=np.float32)
@@ -308,7 +310,9 @@ class TestWhisperAsrEngineVad:
             engine = WhisperAsrEngine()
             import asyncio
 
-            asyncio.get_event_loop().run_until_complete(engine.load_model(_make_config()))
+            asyncio.get_event_loop().run_until_complete(
+                engine.load_model(_make_config())
+            )
 
         # Array with a peak above the threshold → should run inference
         speech = np.full((80, 200), -10.0, dtype=np.float32)

--- a/tests/inference/speech/test_whisper_asr_engine.py
+++ b/tests/inference/speech/test_whisper_asr_engine.py
@@ -30,6 +30,20 @@ def _make_mel_features(n_mels: int = 80, t_frames: int = 100) -> np.ndarray:
     return np.random.randn(n_mels, t_frames).astype(np.float32)
 
 
+def _make_mock_model(dtype: torch.dtype = torch.float32) -> MagicMock:
+    """Return a MagicMock model with parameters() and generate() wired up."""
+    mock_model = MagicMock()
+    mock_model.parameters.return_value = iter(
+        [torch.nn.Parameter(torch.zeros(1, dtype=dtype))]
+    )
+    mock_output = MagicMock()
+    mock_output.sequences = torch.zeros(1, 10, dtype=torch.long)
+    mock_output.sequences_scores = torch.tensor([-0.3])
+    mock_output.scores = None
+    mock_model.generate.return_value = mock_output
+    return mock_model
+
+
 def _make_mock_engine() -> tuple:
     """Return (engine, mock_model, mock_processor) with load_model already called."""
     from sozia.server.inference.speech.whisper_asr_engine import WhisperAsrEngine
@@ -38,12 +52,7 @@ def _make_mock_engine() -> tuple:
     mock_processor.get_decoder_prompt_ids.return_value = [[1, 2]]
     mock_processor.tokenizer.batch_decode.return_value = ["merhaba dünya"]
 
-    mock_model = MagicMock()
-    mock_output = MagicMock()
-    mock_output.sequences = torch.zeros(1, 10, dtype=torch.long)
-    mock_output.sequences_scores = torch.tensor([-0.3])
-    mock_output.scores = None
-    mock_model.generate.return_value = mock_output
+    mock_model = _make_mock_model()
 
     with patch.object(
         WhisperAsrEngine,
@@ -116,15 +125,8 @@ class TestWhisperAsrEnginePredict:
         from sozia.server.inference.speech.whisper_asr_engine import WhisperAsrEngine
 
         mock_processor = MagicMock()
-        mock_processor.get_decoder_prompt_ids.return_value = [[1, 2]]
         mock_processor.tokenizer.batch_decode.return_value = ["merhaba dünya"]
-
-        mock_output = MagicMock()
-        mock_output.sequences = torch.zeros(1, 10, dtype=torch.long)
-        mock_output.sequences_scores = torch.tensor([-0.3])
-        mock_output.scores = None
-        mock_model = MagicMock()
-        mock_model.generate.return_value = mock_output
+        mock_model = _make_mock_model()
 
         with patch.object(
             WhisperAsrEngine,
@@ -145,19 +147,16 @@ class TestWhisperAsrEnginePredict:
 
         from sozia.server.inference.speech.whisper_asr_engine import WhisperAsrEngine
 
-        mock_processor = MagicMock()
-        mock_processor.get_decoder_prompt_ids.return_value = []
-
         def _slow(*_a, **_kw):
             _time.sleep(10)
 
-        mock_model = MagicMock()
+        mock_model = _make_mock_model()
         mock_model.generate.side_effect = _slow
 
         with patch.object(
             WhisperAsrEngine,
             "_load_from_directory",
-            return_value=(mock_processor, mock_model),
+            return_value=(MagicMock(), mock_model),
         ):
             engine = WhisperAsrEngine()
             await engine.load_model(_make_config())
@@ -172,11 +171,11 @@ class TestWhisperAsrEnginePredict:
 
 
 class TestWhisperAsrEngineMelPrep:
-    def _make_engine(self):
+    def _make_engine(self, dtype: torch.dtype = torch.float32):
         from sozia.server.inference.speech.whisper_asr_engine import WhisperAsrEngine
 
         engine = WhisperAsrEngine()
-        engine._model = MagicMock()
+        engine._model = _make_mock_model(dtype)
         engine._processor = MagicMock()
         engine._device = torch.device("cpu")
         return engine
@@ -185,6 +184,11 @@ class TestWhisperAsrEngineMelPrep:
         engine = self._make_engine()
         mel = engine._prepare_mel(np.random.randn(80, 200).astype(np.float32))
         assert mel.shape == (1, 80, 3000)
+
+    def test_output_dtype_matches_model(self):
+        engine = self._make_engine(dtype=torch.float16)
+        mel = engine._prepare_mel(np.random.randn(50, 80).astype(np.float32))
+        assert mel.dtype == torch.float16
 
     def test_transpose_short_chunk_client_format(self):
         # Real client format: 500ms chunk → 50 frames × 80 mel bins → (50, 80).

--- a/tests/inference/speech/test_whisper_asr_engine.py
+++ b/tests/inference/speech/test_whisper_asr_engine.py
@@ -186,7 +186,14 @@ class TestWhisperAsrEngineMelPrep:
         mel = engine._prepare_mel(np.random.randn(80, 200).astype(np.float32))
         assert mel.shape == (1, 80, 3000)
 
-    def test_transpose_t_by_80_input(self):
+    def test_transpose_short_chunk_client_format(self):
+        # Real client format: 500ms chunk → 50 frames × 80 mel bins → (50, 80).
+        # The previous condition (shape[0] > 80) failed here — regression guard.
+        engine = self._make_engine()
+        mel = engine._prepare_mel(np.random.randn(50, 80).astype(np.float32))
+        assert mel.shape == (1, 80, 3000)
+
+    def test_transpose_long_chunk_t_by_80_input(self):
         engine = self._make_engine()
         mel = engine._prepare_mel(np.random.randn(200, 80).astype(np.float32))
         assert mel.shape == (1, 80, 3000)

--- a/tests/inference/speech/test_whisper_asr_engine.py
+++ b/tests/inference/speech/test_whisper_asr_engine.py
@@ -183,39 +183,39 @@ class TestWhisperAsrEngineMelPrep:
 
     def test_output_shape_is_batched(self):
         engine = self._make_engine()
-        mel = engine._prepare_mel(np.random.randn(80, 200).astype(np.float32))
+        mel, mask = engine._prepare_mel(np.random.randn(80, 200).astype(np.float32))
         assert mel.shape == (1, 80, 3000)
 
     def test_output_dtype_matches_model(self):
         engine = self._make_engine(dtype=torch.float16)
-        mel = engine._prepare_mel(np.random.randn(50, 80).astype(np.float32))
+        mel, _ = engine._prepare_mel(np.random.randn(50, 80).astype(np.float32))
         assert mel.dtype == torch.float16
 
     def test_128_bin_model_large_v3(self):
         engine = self._make_engine(n_mels=128)
-        mel = engine._prepare_mel(np.random.randn(50, 128).astype(np.float32))
+        mel, _ = engine._prepare_mel(np.random.randn(50, 128).astype(np.float32))
         assert mel.shape == (1, 128, 3000)
 
     def test_transpose_short_chunk_client_format(self):
         # Real client format: 500ms chunk → 50 frames × 80 mel bins → (50, 80).
         # The previous condition (shape[0] > 80) failed here — regression guard.
         engine = self._make_engine()
-        mel = engine._prepare_mel(np.random.randn(50, 80).astype(np.float32))
+        mel, _ = engine._prepare_mel(np.random.randn(50, 80).astype(np.float32))
         assert mel.shape == (1, 80, 3000)
 
     def test_transpose_long_chunk_t_by_80_input(self):
         engine = self._make_engine()
-        mel = engine._prepare_mel(np.random.randn(200, 80).astype(np.float32))
+        mel, _ = engine._prepare_mel(np.random.randn(200, 80).astype(np.float32))
         assert mel.shape == (1, 80, 3000)
 
     def test_pads_short_mel_bins(self):
         engine = self._make_engine()
-        mel = engine._prepare_mel(np.random.randn(13, 100).astype(np.float32))
+        mel, _ = engine._prepare_mel(np.random.randn(13, 100).astype(np.float32))
         assert mel.shape == (1, 80, 3000)
 
     def test_trims_long_time_axis(self):
         engine = self._make_engine()
-        mel = engine._prepare_mel(np.random.randn(80, 5000).astype(np.float32))
+        mel, _ = engine._prepare_mel(np.random.randn(80, 5000).astype(np.float32))
         assert mel.shape == (1, 80, 3000)
 
     def test_rejects_1d_input(self):
@@ -223,13 +223,32 @@ class TestWhisperAsrEngineMelPrep:
         with pytest.raises(ValueError, match="2-D"):
             engine._prepare_mel(np.zeros(100, dtype=np.float32))
 
+    def test_attention_mask_shape(self):
+        engine = self._make_engine()
+        _, mask = engine._prepare_mel(np.random.randn(80, 200).astype(np.float32))
+        assert mask.shape == (1, 3000)
+        assert mask.dtype == torch.long
+
+    def test_attention_mask_marks_real_frames(self):
+        engine = self._make_engine()
+        # (N, T) orientation: 80 bins × 200 real frames, padded to 3000
+        _, mask = engine._prepare_mel(np.random.randn(80, 200).astype(np.float32))
+        assert mask[0, :200].sum().item() == 200
+        assert mask[0, 200:].sum().item() == 0
+
+    def test_attention_mask_full_chunk(self):
+        # 3000-frame chunk should produce all-ones mask — no padding needed
+        engine = self._make_engine()
+        _, mask = engine._prepare_mel(np.random.randn(80, 3000).astype(np.float32))
+        assert mask.sum().item() == 3000
+
     def test_normalisation_applied_globally(self):
         engine = self._make_engine()
         # Known array: all values 0.0 except one cell = 8.0 → max_val = 8.0
         # clip(x, 0, 8) → (x+4)/4 → range [1.0, 3.0]
         arr = np.zeros((80, 100), dtype=np.float32)
         arr[0, 0] = 8.0
-        mel = engine._prepare_mel(arr)
+        mel, _ = engine._prepare_mel(arr)
         tensor_vals = mel[0].numpy()
         assert float(tensor_vals.max()) == pytest.approx(3.0, abs=1e-5)
         assert float(tensor_vals.min()) == pytest.approx(1.0, abs=1e-5)
@@ -239,9 +258,70 @@ class TestWhisperAsrEngineMelPrep:
         engine = self._make_engine()
         rng = np.random.default_rng(42)
         arr = rng.uniform(-10, 10, (80, 3000)).astype(np.float32)
-        mel = engine._prepare_mel(arr)
+        mel, _ = engine._prepare_mel(arr)
         span = mel.max().item() - mel.min().item()
         assert span == pytest.approx(2.0, abs=1e-4)
+
+
+# ---------------------------------------------------------------------------
+# VAD gate
+# ---------------------------------------------------------------------------
+
+
+class TestWhisperAsrEngineVad:
+    def test_silence_skips_inference(self):
+        from sozia.server.inference.speech.whisper_asr_engine import WhisperAsrEngine
+
+        mock_model = _make_mock_model()
+        mock_processor = MagicMock()
+        mock_processor.tokenizer.batch_decode.return_value = ["hallucination"]
+
+        with patch.object(
+            WhisperAsrEngine,
+            "_load_from_directory",
+            return_value=(mock_processor, mock_model),
+        ):
+            engine = WhisperAsrEngine()
+            import asyncio
+
+            asyncio.get_event_loop().run_until_complete(engine.load_model(_make_config()))
+
+        # All-−10 array is pure silence (log10-mel floor)
+        silent = np.full((80, 200), -10.0, dtype=np.float32)
+        result = asyncio.get_event_loop().run_until_complete(engine.predict(silent))
+        assert result.text == ""
+        assert result.confidence == 0.0
+        mock_model.generate.assert_not_called()
+
+    def test_speech_runs_inference(self):
+        from sozia.server.inference.speech.whisper_asr_engine import WhisperAsrEngine
+
+        mock_processor = MagicMock()
+        mock_processor.tokenizer.batch_decode.return_value = ["merhaba"]
+        mock_model = _make_mock_model()
+
+        with patch.object(
+            WhisperAsrEngine,
+            "_load_from_directory",
+            return_value=(mock_processor, mock_model),
+        ):
+            engine = WhisperAsrEngine()
+            import asyncio
+
+            asyncio.get_event_loop().run_until_complete(engine.load_model(_make_config()))
+
+        # Array with a peak above the threshold → should run inference
+        speech = np.full((80, 200), -10.0, dtype=np.float32)
+        speech[0, 0] = -2.0
+        result = asyncio.get_event_loop().run_until_complete(engine.predict(speech))
+        assert result.text == "merhaba"
+        mock_model.generate.assert_called_once()
+
+    def test_has_speech_content_threshold(self):
+        from sozia.server.inference.speech.whisper_asr_engine import WhisperAsrEngine
+
+        assert WhisperAsrEngine._has_speech_content(np.array([[-10.0, -8.0]])) is False
+        assert WhisperAsrEngine._has_speech_content(np.array([[-3.0, -10.0]])) is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/inference/speech/test_whisper_asr_engine.py
+++ b/tests/inference/speech/test_whisper_asr_engine.py
@@ -316,7 +316,7 @@ class TestWhisperAsrEngineVad:
 
         # Array with a peak above the threshold → should run inference
         speech = np.full((80, 200), -10.0, dtype=np.float32)
-        speech[0, 0] = -2.0
+        speech[0, 0] = 0.0
         result = asyncio.get_event_loop().run_until_complete(engine.predict(speech))
         assert result.text == "merhaba"
         mock_model.generate.assert_called_once()
@@ -325,7 +325,7 @@ class TestWhisperAsrEngineVad:
         from sozia.server.inference.speech.whisper_asr_engine import WhisperAsrEngine
 
         assert WhisperAsrEngine._has_speech_content(np.array([[-10.0, -8.0]])) is False
-        assert WhisperAsrEngine._has_speech_content(np.array([[-3.0, -10.0]])) is True
+        assert WhisperAsrEngine._has_speech_content(np.array([[0.0, -10.0]])) is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/inference/speech/test_whisper_asr_engine.py
+++ b/tests/inference/speech/test_whisper_asr_engine.py
@@ -171,13 +171,14 @@ class TestWhisperAsrEnginePredict:
 
 
 class TestWhisperAsrEngineMelPrep:
-    def _make_engine(self, dtype: torch.dtype = torch.float32):
+    def _make_engine(self, dtype: torch.dtype = torch.float32, n_mels: int = 80):
         from sozia.server.inference.speech.whisper_asr_engine import WhisperAsrEngine
 
         engine = WhisperAsrEngine()
         engine._model = _make_mock_model(dtype)
         engine._processor = MagicMock()
         engine._device = torch.device("cpu")
+        engine._n_mels = n_mels
         return engine
 
     def test_output_shape_is_batched(self):
@@ -189,6 +190,11 @@ class TestWhisperAsrEngineMelPrep:
         engine = self._make_engine(dtype=torch.float16)
         mel = engine._prepare_mel(np.random.randn(50, 80).astype(np.float32))
         assert mel.dtype == torch.float16
+
+    def test_128_bin_model_large_v3(self):
+        engine = self._make_engine(n_mels=128)
+        mel = engine._prepare_mel(np.random.randn(50, 128).astype(np.float32))
+        assert mel.shape == (1, 128, 3000)
 
     def test_transpose_short_chunk_client_format(self):
         # Real client format: 500ms chunk → 50 frames × 80 mel bins → (50, 80).


### PR DESCRIPTION
## What does this PR do?

Started as a mel transpose fix, ended up being a lot more than that.

The original bug: `_prepare_mel` only transposed when `shape[0] > 80`. A 500ms chunk is 50 frames, so the condition never fired and Whisper read the axes backwards. Fixed with a dimension-identity check; added a regression test for the real client shape `(50, 80)`. (Closes #35)

While testing, Whisper was hallucinating `(Müzik)` and similar tokens on near-silence. Added an energy gate that skips inference entirely, `attention_mask` to stop padding from contaminating the output, and `no_repeat_ngram_size`. Energy threshold tightened to -1.0, minimum 150-frame buffer before any flush. (Closes #38)

Running ASR on every 500ms chunk was producing unusable fragmented output. Added `MelAccumulator` in the fusion layer to buffer frames and flush on silence or overflow. Also raised the lip PARTIAL gate to 0.70 -- the mouth-only model at 7% val is noisy enough that anything below that isn't worth sending. (Closes #39)

`model.float()` after loading to fix a `BatchNorm1d` dtype mismatch on float16 weights. (Closes #37)

`scripts/smoke_asr.py` for quick manual checks without starting the full server. (Closes #40)

## Which package(s) does it touch?

- `sozia.server.inference.speech` -- WhisperAsrEngine, LipReadingEngine
- `sozia.server.fusion` -- MelAccumulator (new), orchestrator, SpeechFusionPolicy
- `sozia.server.api` -- session_handler (logging)
- `scripts/` -- smoke_asr.py

## How to test

```
pytest tests/inference/speech/ tests/fusion/
python scripts/smoke_asr.py --weights-path /path/to/weights
```

Tested live: "Benim adim Mehmet." (0.92), "Calismak istiyorum." (0.84).

## Checklist
- [x] Follows commit convention (`<type>(<scope>): <description>`)
- [x] Added/updated tests (if applicable)
- [x] No sozia.common schema changes (or: both repos updated)
- [x] Tested locally