### PR TITLE
fix(fusion): ASR hallucinations and stale segment ordering on SPEECH path

### DIFF
--- a/sozia/server/api/session_handler.py
+++ b/sozia/server/api/session_handler.py
@@ -11,6 +11,7 @@ SessionHandler only sends them.
 
 from __future__ import annotations
 
+import asyncio
 import dataclasses
 import json
 import logging
@@ -92,6 +93,26 @@ class SessionHandler:
     # Inbound loop
     # ------------------------------------------------------------------
 
+    async def _stale_flush_watchdog(self) -> None:
+        """Flush pending speech every second when the client stops sending frames.
+
+        Runs as a background task alongside receive_loop so utterance-end
+        silence is detected even if the client pauses audio delivery.
+        """
+        while True:
+            await asyncio.sleep(1.0)
+            if self.modality_path != ModalityPath.SPEECH:
+                continue
+            try:
+                await self._orchestrator.flush_stale_speech(
+                    self.session_id,
+                    1.0,
+                    list(self.latest_health.values()),
+                    self.send_segment,
+                )
+            except Exception:
+                return
+
     async def receive_loop(self) -> None:
         """Read messages from the WebSocket and dispatch by type.
 
@@ -99,6 +120,13 @@ class SessionHandler:
         connection is closed (``WebSocketDisconnect``).  Unknown message
         types are silently ignored.
         """
+        watchdog = asyncio.create_task(self._stale_flush_watchdog())
+        try:
+            await self._receive_loop_inner()
+        finally:
+            watchdog.cancel()
+
+    async def _receive_loop_inner(self) -> None:
         while True:
             try:
                 data = await self._ws.receive_json()

--- a/sozia/server/api/session_handler.py
+++ b/sozia/server/api/session_handler.py
@@ -100,13 +100,13 @@ class SessionHandler:
         silence is detected even if the client pauses audio delivery.
         """
         while True:
-            await asyncio.sleep(1.0)
+            await asyncio.sleep(0.5)
             if self.modality_path != ModalityPath.SPEECH:
                 continue
             try:
                 await self._orchestrator.flush_stale_speech(
                     self.session_id,
-                    1.0,
+                    0.5,
                     list(self.latest_health.values()),
                     self.send_segment,
                 )

--- a/sozia/server/api/session_handler.py
+++ b/sozia/server/api/session_handler.py
@@ -100,13 +100,13 @@ class SessionHandler:
         silence is detected even if the client pauses audio delivery.
         """
         while True:
-            await asyncio.sleep(1.0)
+            await asyncio.sleep(0.7)
             if self.modality_path != ModalityPath.SPEECH:
                 continue
             try:
                 await self._orchestrator.flush_stale_speech(
                     self.session_id,
-                    1.0,
+                    0.7,
                     list(self.latest_health.values()),
                     self.send_segment,
                 )

--- a/sozia/server/api/session_handler.py
+++ b/sozia/server/api/session_handler.py
@@ -108,6 +108,12 @@ class SessionHandler:
             msg_type = data.get("type")
 
             if msg_type == "session_end":
+                if self.modality_path == ModalityPath.SPEECH:
+                    await self._orchestrator.flush_speech_pending(
+                        self.session_id,
+                        list(self.latest_health.values()),
+                        self.send_segment,
+                    )
                 break
             elif msg_type == "landmark_frame":
                 await self._handle_landmark(data)

--- a/sozia/server/api/session_handler.py
+++ b/sozia/server/api/session_handler.py
@@ -109,11 +109,14 @@ class SessionHandler:
 
             if msg_type == "session_end":
                 if self.modality_path == ModalityPath.SPEECH:
-                    await self._orchestrator.flush_speech_pending(
-                        self.session_id,
-                        list(self.latest_health.values()),
-                        self.send_segment,
-                    )
+                    try:
+                        await self._orchestrator.flush_speech_pending(
+                            self.session_id,
+                            list(self.latest_health.values()),
+                            self.send_segment,
+                        )
+                    except (WebSocketDisconnect, Exception):
+                        pass
                 break
             elif msg_type == "landmark_frame":
                 await self._handle_landmark(data)

--- a/sozia/server/api/session_handler.py
+++ b/sozia/server/api/session_handler.py
@@ -100,13 +100,13 @@ class SessionHandler:
         silence is detected even if the client pauses audio delivery.
         """
         while True:
-            await asyncio.sleep(0.7)
+            await asyncio.sleep(1.0)
             if self.modality_path != ModalityPath.SPEECH:
                 continue
             try:
                 await self._orchestrator.flush_stale_speech(
                     self.session_id,
-                    0.7,
+                    1.0,
                     list(self.latest_health.values()),
                     self.send_segment,
                 )

--- a/sozia/server/api/session_handler.py
+++ b/sozia/server/api/session_handler.py
@@ -100,13 +100,13 @@ class SessionHandler:
         silence is detected even if the client pauses audio delivery.
         """
         while True:
-            await asyncio.sleep(0.5)
+            await asyncio.sleep(1.0)
             if self.modality_path != ModalityPath.SPEECH:
                 continue
             try:
                 await self._orchestrator.flush_stale_speech(
                     self.session_id,
-                    0.5,
+                    1.0,
                     list(self.latest_health.values()),
                     self.send_segment,
                 )

--- a/sozia/server/fusion/mel_accumulator.py
+++ b/sozia/server/fusion/mel_accumulator.py
@@ -20,7 +20,7 @@ import numpy as np
 
 # log10-mel floor for speech detection. Client sends Math.log10(energy + 1e-10);
 # real speech peaks at +1 to +3; inter-word gaps and background stay below 0.3.
-_SPEECH_ENERGY_THRESHOLD: float = 0.3
+_SPEECH_ENERGY_THRESHOLD: float = 0.5
 
 # Consecutive silence frames required to trigger a flush. At 100 Hz this is 1 s.
 # A shorter gap (e.g. between words) resets when the next speech chunk arrives.

--- a/sozia/server/fusion/mel_accumulator.py
+++ b/sozia/server/fusion/mel_accumulator.py
@@ -151,6 +151,25 @@ class MelAccumulator:
             return None
         return self._flush(session_id)
 
+    def take_if_stale(
+        self, session_id: str, stale_after_s: float = 1.0
+    ) -> np.ndarray | None:
+        """Flush if no new chunk has arrived for at least ``stale_after_s`` seconds.
+
+        Called by the session watchdog so silence between utterances is
+        detected even when the client stops sending frames entirely.
+
+        Returns:
+            Concatenated buffer on flush, ``None`` if nothing pending or
+            the last frame arrived too recently.
+        """
+        if self._frame_counts.get(session_id, 0) == 0:
+            return None
+        last = self._last_push_time.get(session_id)
+        if last is None or (time.monotonic() - last) < stale_after_s:
+            return None
+        return self._flush(session_id)
+
     def reset(self, session_id: str) -> None:
         """Discard all buffered state for a session.
 

--- a/sozia/server/fusion/mel_accumulator.py
+++ b/sozia/server/fusion/mel_accumulator.py
@@ -24,7 +24,7 @@ _SPEECH_ENERGY_THRESHOLD: float = 0.3
 
 # Consecutive silence frames required to trigger a flush. At 100 Hz this is 1 s.
 # A shorter gap (e.g. between words) resets when the next speech chunk arrives.
-_MIN_SILENCE_FRAMES: int = 50  # 500 ms at 100 Hz
+_MIN_SILENCE_FRAMES: int = 100  # 1000 ms at 100 Hz
 
 # Assumed frame rate for converting wall-clock gaps to frame counts.
 _FRAME_RATE_HZ: int = 100

--- a/sozia/server/fusion/mel_accumulator.py
+++ b/sozia/server/fusion/mel_accumulator.py
@@ -155,7 +155,7 @@ class MelAccumulator:
         self,
         session_id: str,
         stale_after_s: float = 1.0,
-        min_frames: int = 200,
+        min_frames: int = 100,
     ) -> np.ndarray | None:
         """Flush if no new chunk has arrived for at least ``stale_after_s`` seconds.
 

--- a/sozia/server/fusion/mel_accumulator.py
+++ b/sozia/server/fusion/mel_accumulator.py
@@ -24,7 +24,7 @@ _SPEECH_ENERGY_THRESHOLD: float = 0.3
 
 # Consecutive silence frames required to trigger a flush. At 100 Hz this is 1 s.
 # A shorter gap (e.g. between words) resets when the next speech chunk arrives.
-_MIN_SILENCE_FRAMES: int = 100  # 1000 ms at 100 Hz
+_MIN_SILENCE_FRAMES: int = 70  # 700 ms at 100 Hz
 
 # Assumed frame rate for converting wall-clock gaps to frame counts.
 _FRAME_RATE_HZ: int = 100

--- a/sozia/server/fusion/mel_accumulator.py
+++ b/sozia/server/fusion/mel_accumulator.py
@@ -152,22 +152,29 @@ class MelAccumulator:
         return self._flush(session_id)
 
     def take_if_stale(
-        self, session_id: str, stale_after_s: float = 1.0
+        self,
+        session_id: str,
+        stale_after_s: float = 1.0,
+        min_frames: int = 100,
     ) -> np.ndarray | None:
         """Flush if no new chunk has arrived for at least ``stale_after_s`` seconds.
 
-        Called by the session watchdog so silence between utterances is
-        detected even when the client stops sending frames entirely.
+        Does not flush if fewer than ``min_frames`` are buffered — the frames
+        are kept so they can accumulate further. This prevents discarding
+        partial speech that Whisper could not reliably transcribe.
 
         Returns:
-            Concatenated buffer on flush, ``None`` if nothing pending or
-            the last frame arrived too recently.
+            Concatenated buffer on flush, ``None`` if nothing pending,
+            not stale yet, or buffer is below the minimum size.
         """
-        if self._frame_counts.get(session_id, 0) == 0:
+        count = self._frame_counts.get(session_id, 0)
+        if count == 0:
             return None
         last = self._last_push_time.get(session_id)
         if last is None or (time.monotonic() - last) < stale_after_s:
             return None
+        if count < min_frames:
+            return None  # keep buffering until enough frames accumulate
         return self._flush(session_id)
 
     def reset(self, session_id: str) -> None:

--- a/sozia/server/fusion/mel_accumulator.py
+++ b/sozia/server/fusion/mel_accumulator.py
@@ -24,7 +24,7 @@ _SPEECH_ENERGY_THRESHOLD: float = 0.3
 
 # Consecutive silence frames required to trigger a flush. At 100 Hz this is 1 s.
 # A shorter gap (e.g. between words) resets when the next speech chunk arrives.
-_MIN_SILENCE_FRAMES: int = 70  # 700 ms at 100 Hz
+_MIN_SILENCE_FRAMES: int = 100  # 1000 ms at 100 Hz
 
 # Assumed frame rate for converting wall-clock gaps to frame counts.
 _FRAME_RATE_HZ: int = 100

--- a/sozia/server/fusion/mel_accumulator.py
+++ b/sozia/server/fusion/mel_accumulator.py
@@ -152,29 +152,22 @@ class MelAccumulator:
         return self._flush(session_id)
 
     def take_if_stale(
-        self,
-        session_id: str,
-        stale_after_s: float = 1.0,
-        min_frames: int = 100,
+        self, session_id: str, stale_after_s: float = 1.0
     ) -> np.ndarray | None:
         """Flush if no new chunk has arrived for at least ``stale_after_s`` seconds.
 
-        Does not flush if fewer than ``min_frames`` are buffered — the frames
-        are kept so they can accumulate further. This prevents discarding
-        partial speech that Whisper could not reliably transcribe.
+        Called by the session watchdog so silence between utterances is
+        detected even when the client stops sending frames entirely.
 
         Returns:
-            Concatenated buffer on flush, ``None`` if nothing pending,
-            not stale yet, or buffer is below the minimum size.
+            Concatenated buffer on flush, ``None`` if nothing pending or
+            the last frame arrived too recently.
         """
-        count = self._frame_counts.get(session_id, 0)
-        if count == 0:
+        if self._frame_counts.get(session_id, 0) == 0:
             return None
         last = self._last_push_time.get(session_id)
         if last is None or (time.monotonic() - last) < stale_after_s:
             return None
-        if count < min_frames:
-            return None  # keep buffering until enough frames accumulate
         return self._flush(session_id)
 
     def reset(self, session_id: str) -> None:

--- a/sozia/server/fusion/mel_accumulator.py
+++ b/sozia/server/fusion/mel_accumulator.py
@@ -20,7 +20,7 @@ import numpy as np
 
 # log10-mel floor for speech detection. Client sends Math.log10(energy + 1e-10);
 # real speech peaks at +1 to +3; inter-word gaps and background stay below 0.3.
-_SPEECH_ENERGY_THRESHOLD: float = 0.5
+_SPEECH_ENERGY_THRESHOLD: float = 0.3
 
 # Consecutive silence frames required to trigger a flush. At 100 Hz this is 1 s.
 # A shorter gap (e.g. between words) resets when the next speech chunk arrives.

--- a/sozia/server/fusion/mel_accumulator.py
+++ b/sozia/server/fusion/mel_accumulator.py
@@ -155,17 +155,12 @@ class MelAccumulator:
         self,
         session_id: str,
         stale_after_s: float = 1.0,
-        min_frames: int = 100,
     ) -> np.ndarray | None:
         """Flush if no new chunk has arrived for at least ``stale_after_s`` seconds.
 
-        Does not flush if fewer than ``min_frames`` are buffered — the frames
-        are kept so they can accumulate further. This prevents discarding
-        partial speech that Whisper could not reliably transcribe.
-
         Returns:
-            Concatenated buffer on flush, ``None`` if nothing pending,
-            not stale yet, or buffer is below the minimum size.
+            Concatenated buffer on flush, ``None`` if nothing pending or
+            not stale yet.
         """
         count = self._frame_counts.get(session_id, 0)
         if count == 0:
@@ -173,8 +168,6 @@ class MelAccumulator:
         last = self._last_push_time.get(session_id)
         if last is None or (time.monotonic() - last) < stale_after_s:
             return None
-        if count < min_frames:
-            return None  # keep buffering until enough frames accumulate
         return self._flush(session_id)
 
     def reset(self, session_id: str) -> None:

--- a/sozia/server/fusion/mel_accumulator.py
+++ b/sozia/server/fusion/mel_accumulator.py
@@ -16,8 +16,8 @@ from __future__ import annotations
 import numpy as np
 
 # log10-mel floor for speech detection. Client sends Math.log10(energy + 1e-10);
-# real speech peaks at +1 to +3, background noise stays below −1.
-_SPEECH_ENERGY_THRESHOLD: float = -1.0
+# real speech peaks at +1 to +3; inter-word gaps and background stay below 0.3.
+_SPEECH_ENERGY_THRESHOLD: float = 0.3
 
 # Consecutive silence frames required to trigger a flush. At 100 Hz this is 1 s.
 # A shorter gap (e.g. between words) resets when the next speech chunk arrives.

--- a/sozia/server/fusion/mel_accumulator.py
+++ b/sozia/server/fusion/mel_accumulator.py
@@ -155,12 +155,17 @@ class MelAccumulator:
         self,
         session_id: str,
         stale_after_s: float = 1.0,
+        min_frames: int = 100,
     ) -> np.ndarray | None:
         """Flush if no new chunk has arrived for at least ``stale_after_s`` seconds.
 
+        Does not flush if fewer than ``min_frames`` are buffered — the frames
+        are kept so they can accumulate further. This prevents discarding
+        partial speech that Whisper could not reliably transcribe.
+
         Returns:
-            Concatenated buffer on flush, ``None`` if nothing pending or
-            not stale yet.
+            Concatenated buffer on flush, ``None`` if nothing pending,
+            not stale yet, or buffer is below the minimum size.
         """
         count = self._frame_counts.get(session_id, 0)
         if count == 0:
@@ -168,6 +173,8 @@ class MelAccumulator:
         last = self._last_push_time.get(session_id)
         if last is None or (time.monotonic() - last) < stale_after_s:
             return None
+        if count < min_frames:
+            return None  # keep buffering until enough frames accumulate
         return self._flush(session_id)
 
     def reset(self, session_id: str) -> None:

--- a/sozia/server/fusion/mel_accumulator.py
+++ b/sozia/server/fusion/mel_accumulator.py
@@ -152,21 +152,28 @@ class MelAccumulator:
         return self._flush(session_id)
 
     def take_if_stale(
-        self, session_id: str, stale_after_s: float = 1.0
+        self,
+        session_id: str,
+        stale_after_s: float = 1.0,
+        min_frames: int = 100,
     ) -> np.ndarray | None:
         """Flush if no new chunk has arrived for at least ``stale_after_s`` seconds.
 
-        Called by the session watchdog so silence between utterances is
-        detected even when the client stops sending frames entirely.
+        Does not flush if fewer than ``min_frames`` are buffered — keeps them
+        so they can accumulate further, preventing Whisper hallucinations on
+        very short clips.
 
         Returns:
-            Concatenated buffer on flush, ``None`` if nothing pending or
-            the last frame arrived too recently.
+            Concatenated buffer on flush, ``None`` if nothing pending,
+            not stale yet, or buffer is below the minimum size.
         """
-        if self._frame_counts.get(session_id, 0) == 0:
+        count = self._frame_counts.get(session_id, 0)
+        if count == 0:
             return None
         last = self._last_push_time.get(session_id)
         if last is None or (time.monotonic() - last) < stale_after_s:
+            return None
+        if count < min_frames:
             return None
         return self._flush(session_id)
 

--- a/sozia/server/fusion/mel_accumulator.py
+++ b/sozia/server/fusion/mel_accumulator.py
@@ -4,7 +4,7 @@ WhisperAsrEngine produces better, sentence-level transcriptions when given a
 full utterance rather than 500 ms chunks. MelAccumulator holds incoming mel
 frames per session and flushes when one of two conditions is met:
 
-  1. Silence detected after speech (utterance boundary).
+  1. 1 s of consecutive silence after speech (utterance boundary).
   2. Buffer reaches ``max_frames`` (15 s ceiling at 100 Hz).
 
 Lip-reading continues to fire on every short chunk (PARTIAL updates).
@@ -19,10 +19,9 @@ import numpy as np
 # real speech peaks at +1 to +3, background noise stays below −1.
 _SPEECH_ENERGY_THRESHOLD: float = -1.0
 
-# Minimum accumulated frames before a silence flush is honoured. At 100 Hz this
-# is 1.5 s — long enough that a single loud transient won't trigger ASR, but
-# short enough to capture brief utterances like "Benim adım Mehmet."
-_MIN_FLUSH_FRAMES: int = 150  # 1500 ms at 100 Hz
+# Consecutive silence frames required to trigger a flush. At 100 Hz this is 1 s.
+# A shorter gap (e.g. between words) resets when the next speech chunk arrives.
+_MIN_SILENCE_FRAMES: int = 100  # 1000 ms at 100 Hz
 
 
 class MelAccumulator:
@@ -38,24 +37,25 @@ class MelAccumulator:
     Args:
         max_frames: Hard ceiling (frames). Default 1500 = 15 s at 100 Hz.
         speech_threshold: log10-mel peak below which a chunk is silence.
-        min_flush_frames: Minimum accumulated frames before a silence flush
-            is honoured. Prevents spurious flushes on inter-word pauses.
+        min_silence_frames: Consecutive silence frames needed to flush.
+            Prevents inter-word pauses from cutting utterances short.
     """
 
     def __init__(
         self,
         max_frames: int = 1500,
         speech_threshold: float = _SPEECH_ENERGY_THRESHOLD,
-        min_flush_frames: int = _MIN_FLUSH_FRAMES,
+        min_silence_frames: int = _MIN_SILENCE_FRAMES,
     ) -> None:
         self._max_frames = max_frames
         self._speech_threshold = speech_threshold
-        self._min_flush_frames = min_flush_frames
+        self._min_silence_frames = min_silence_frames
 
         # Per-session state.
         self._buffers: dict[str, list[np.ndarray]] = {}
         self._has_seen_speech: dict[str, bool] = {}
         self._frame_counts: dict[str, int] = {}
+        self._silence_frame_counts: dict[str, int] = {}
 
     # ------------------------------------------------------------------
     # Public API
@@ -80,6 +80,7 @@ class MelAccumulator:
         count = self._frame_counts.get(session_id, 0)
 
         if is_speech:
+            self._silence_frame_counts[session_id] = 0  # reset consecutive silence
             self._has_seen_speech[session_id] = True
             buf.append(chunk)
             # Client always sends (T, N) — AudioFeatureChunk.features is [T, D].
@@ -91,10 +92,14 @@ class MelAccumulator:
                 return self._flush(session_id)
 
         else:
-            # Silence after speech + minimum frames met → flush.
-            if seen and count >= self._min_flush_frames:
-                return self._flush(session_id)
-            # Silence before speech, or pause too short → discard frame.
+            if seen and count > 0:
+                silence = self._silence_frame_counts.get(session_id, 0)
+                silence += chunk.shape[0]
+                self._silence_frame_counts[session_id] = silence
+
+                if silence >= self._min_silence_frames:
+                    return self._flush(session_id)
+            # Silence before speech, or buffer empty → discard.
 
         return None
 
@@ -106,6 +111,7 @@ class MelAccumulator:
         self._buffers.pop(session_id, None)
         self._has_seen_speech.pop(session_id, None)
         self._frame_counts.pop(session_id, None)
+        self._silence_frame_counts.pop(session_id, None)
 
     def pending_frames(self, session_id: str) -> int:
         """Return buffered frame count for a session (0 if none)."""
@@ -119,6 +125,7 @@ class MelAccumulator:
         buf = self._buffers.pop(session_id, [])
         self._has_seen_speech[session_id] = False
         self._frame_counts[session_id] = 0
+        self._silence_frame_counts[session_id] = 0
 
         if not buf:
             return np.zeros((0, 1), dtype=np.float32)

--- a/sozia/server/fusion/mel_accumulator.py
+++ b/sozia/server/fusion/mel_accumulator.py
@@ -155,7 +155,7 @@ class MelAccumulator:
         self,
         session_id: str,
         stale_after_s: float = 1.0,
-        min_frames: int = 100,
+        min_frames: int = 200,
     ) -> np.ndarray | None:
         """Flush if no new chunk has arrived for at least ``stale_after_s`` seconds.
 

--- a/sozia/server/fusion/mel_accumulator.py
+++ b/sozia/server/fusion/mel_accumulator.py
@@ -24,7 +24,7 @@ _SPEECH_ENERGY_THRESHOLD: float = 0.3
 
 # Consecutive silence frames required to trigger a flush. At 100 Hz this is 1 s.
 # A shorter gap (e.g. between words) resets when the next speech chunk arrives.
-_MIN_SILENCE_FRAMES: int = 100  # 1000 ms at 100 Hz
+_MIN_SILENCE_FRAMES: int = 50  # 500 ms at 100 Hz
 
 # Assumed frame rate for converting wall-clock gaps to frame counts.
 _FRAME_RATE_HZ: int = 100

--- a/sozia/server/fusion/mel_accumulator.py
+++ b/sozia/server/fusion/mel_accumulator.py
@@ -2,16 +2,19 @@
 
 WhisperAsrEngine produces better, sentence-level transcriptions when given a
 full utterance rather than 500 ms chunks. MelAccumulator holds incoming mel
-frames per session and flushes when one of two conditions is met:
+frames per session and flushes when one of three conditions is met:
 
   1. 1 s of consecutive silence after speech (utterance boundary).
   2. Buffer reaches ``max_frames`` (15 s ceiling at 100 Hz).
+  3. Wall-clock gap since the last chunk exceeds 1 s (client paused sending).
 
 Lip-reading continues to fire on every short chunk (PARTIAL updates).
 ASR fires on each flush (FINAL output).
 """
 
 from __future__ import annotations
+
+import time
 
 import numpy as np
 
@@ -23,6 +26,9 @@ _SPEECH_ENERGY_THRESHOLD: float = 0.3
 # A shorter gap (e.g. between words) resets when the next speech chunk arrives.
 _MIN_SILENCE_FRAMES: int = 100  # 1000 ms at 100 Hz
 
+# Assumed frame rate for converting wall-clock gaps to frame counts.
+_FRAME_RATE_HZ: int = 100
+
 
 class MelAccumulator:
     """Buffers mel-spectrogram chunks per session; emits on utterance boundary.
@@ -33,6 +39,11 @@ class MelAccumulator:
         batch = acc.push(session_id, chunk_features)
         if batch is not None:
             result = await asr_engine.predict(batch)  # shape (T_total, N)
+
+        # On clean session end, flush whatever is pending:
+        batch = acc.take_pending(session_id)
+        if batch is not None:
+            result = await asr_engine.predict(batch)
 
     Args:
         max_frames: Hard ceiling (frames). Default 1500 = 15 s at 100 Hz.
@@ -56,6 +67,7 @@ class MelAccumulator:
         self._has_seen_speech: dict[str, bool] = {}
         self._frame_counts: dict[str, int] = {}
         self._silence_frame_counts: dict[str, int] = {}
+        self._last_push_time: dict[str, float] = {}
 
     # ------------------------------------------------------------------
     # Public API
@@ -73,11 +85,34 @@ class MelAccumulator:
             Concatenated buffer of shape ``(T_total, N)`` on flush;
             ``None`` otherwise.
         """
+        now = time.monotonic()
         is_speech = float(np.max(chunk)) > self._speech_threshold
 
         buf = self._buffers.setdefault(session_id, [])
         seen = self._has_seen_speech.get(session_id, False)
         count = self._frame_counts.get(session_id, 0)
+
+        # Wall-clock gap since last chunk counts as silence even when the client
+        # stopped sending frames (e.g. mic paused, app backgrounded).
+        last = self._last_push_time.get(session_id)
+        self._last_push_time[session_id] = now
+        if last is not None and seen and count > 0:
+            gap_frames = int((now - last) * _FRAME_RATE_HZ)
+            if gap_frames > 0:
+                silence = self._silence_frame_counts.get(session_id, 0) + gap_frames
+                self._silence_frame_counts[session_id] = silence
+                if silence >= self._min_silence_frames:
+                    flushed = self._flush(session_id)
+                    buf = self._buffers.setdefault(session_id, [])
+                    # Re-read seen/count after flush reset.
+                    seen = False
+                    count = 0
+                    if is_speech:
+                        self._has_seen_speech[session_id] = True
+                        buf.append(chunk)
+                        self._frame_counts[session_id] = chunk.shape[0]
+                        self._last_push_time[session_id] = now
+                    return flushed
 
         if is_speech:
             self._silence_frame_counts[session_id] = 0  # reset consecutive silence
@@ -103,6 +138,19 @@ class MelAccumulator:
 
         return None
 
+    def take_pending(self, session_id: str) -> np.ndarray | None:
+        """Flush whatever is buffered, ignoring silence/threshold.
+
+        Intended for clean session teardown (``session_end`` message) so
+        partial utterances are not discarded.
+
+        Returns:
+            Concatenated buffer, or ``None`` if nothing was buffered.
+        """
+        if self._frame_counts.get(session_id, 0) == 0:
+            return None
+        return self._flush(session_id)
+
     def reset(self, session_id: str) -> None:
         """Discard all buffered state for a session.
 
@@ -112,6 +160,7 @@ class MelAccumulator:
         self._has_seen_speech.pop(session_id, None)
         self._frame_counts.pop(session_id, None)
         self._silence_frame_counts.pop(session_id, None)
+        self._last_push_time.pop(session_id, None)
 
     def pending_frames(self, session_id: str) -> int:
         """Return buffered frame count for a session (0 if none)."""

--- a/sozia/server/fusion/orchestrator.py
+++ b/sozia/server/fusion/orchestrator.py
@@ -323,6 +323,9 @@ class FusionOrchestrator:
         send_fn: Callable[[TranscriptSegment], Awaitable[None] | None],
         features: AudioFeatureChunk | None = None,
     ) -> None:
+        if asr_batch.shape[0] < 100:
+            logger.debug("asr_batch too short (%d frames), skipping", asr_batch.shape[0])
+            return
         path_engines = self._engines.get(ModalityPath.SPEECH, {})
         asr_entry = path_engines.get(ModalityType.ASR)
         if asr_entry is None:

--- a/sozia/server/fusion/orchestrator.py
+++ b/sozia/server/fusion/orchestrator.py
@@ -340,7 +340,7 @@ class FusionOrchestrator:
                 asr_result.confidence,
                 asr_result.inference_latency_ms,
             )
-            if asr_result.confidence < 0.30:
+            if asr_result.confidence < 0.45:
                 logger.info(
                     "ASR result suppressed (confidence=%.4f < 0.30)", asr_result.confidence
                 )

--- a/sozia/server/fusion/orchestrator.py
+++ b/sozia/server/fusion/orchestrator.py
@@ -323,10 +323,6 @@ class FusionOrchestrator:
         send_fn: Callable[[TranscriptSegment], Awaitable[None] | None],
         features: AudioFeatureChunk | None = None,
     ) -> None:
-        # Whisper hallucinates on very short clips; skip batches under 1 s.
-        if asr_batch.shape[0] < 100:
-            logger.debug("asr_batch too short (%d frames), skipping", asr_batch.shape[0])
-            return
         path_engines = self._engines.get(ModalityPath.SPEECH, {})
         asr_entry = path_engines.get(ModalityType.ASR)
         if asr_entry is None:

--- a/sozia/server/fusion/orchestrator.py
+++ b/sozia/server/fusion/orchestrator.py
@@ -225,6 +225,23 @@ class FusionOrchestrator:
     # Internal pipeline handlers
     # ------------------------------------------------------------------
 
+    async def flush_stale_speech(
+        self,
+        session_id: str,
+        stale_after_s: float,
+        health: list[PipelineHealth],
+        send_fn: Callable[[TranscriptSegment], Awaitable[None] | None],
+    ) -> None:
+        """Run ASR on pending mel frames if no new chunk arrived in ``stale_after_s`` s.
+
+        Called by the session watchdog every second so utterance-end silence
+        is detected even when the client stops sending frames entirely.
+        """
+        asr_batch = self._mel_accumulator.take_if_stale(session_id, stale_after_s)
+        if asr_batch is None:
+            return
+        await self._run_asr(session_id, asr_batch, health, send_fn)
+
     async def flush_speech_pending(
         self,
         session_id: str,

--- a/sozia/server/fusion/orchestrator.py
+++ b/sozia/server/fusion/orchestrator.py
@@ -323,8 +323,8 @@ class FusionOrchestrator:
         send_fn: Callable[[TranscriptSegment], Awaitable[None] | None],
         features: AudioFeatureChunk | None = None,
     ) -> None:
-        # Whisper accuracy degrades below ~2 s of audio; skip short batches.
-        if asr_batch.shape[0] < 200:
+        # Whisper hallucinates on very short clips; skip batches under 1 s.
+        if asr_batch.shape[0] < 100:
             logger.debug("asr_batch too short (%d frames), skipping", asr_batch.shape[0])
             return
         path_engines = self._engines.get(ModalityPath.SPEECH, {})

--- a/sozia/server/fusion/orchestrator.py
+++ b/sozia/server/fusion/orchestrator.py
@@ -341,12 +341,11 @@ class FusionOrchestrator:
                     "ASR result suppressed (confidence=%.4f < 0.30)", asr_result.confidence
                 )
                 return
-            if features is not None:
-                asr_result = dataclasses.replace(
-                    asr_result,
-                    timestamp_ms=features.timestamp_ms,
-                    duration_ms=features.chunk_duration_ms,
-                )
+            asr_result = dataclasses.replace(
+                asr_result,
+                timestamp_ms=features.timestamp_ms if features is not None else int(time.time() * 1000),
+                duration_ms=features.chunk_duration_ms if features is not None else 0,
+            )
             policy = self._policies.get(ModalityPath.SPEECH)
             if isinstance(policy, SpeechFusionPolicy):
                 asr_segments = policy.emit_asr_final(asr_result, session_id)

--- a/sozia/server/fusion/orchestrator.py
+++ b/sozia/server/fusion/orchestrator.py
@@ -323,10 +323,6 @@ class FusionOrchestrator:
         send_fn: Callable[[TranscriptSegment], Awaitable[None] | None],
         features: AudioFeatureChunk | None = None,
     ) -> None:
-        # Whisper hallucinates on very short clips; skip batches under 1 s.
-        if asr_batch.shape[0] < 100:
-            logger.debug("asr_batch too short (%d frames), skipping", asr_batch.shape[0])
-            return
         path_engines = self._engines.get(ModalityPath.SPEECH, {})
         asr_entry = path_engines.get(ModalityType.ASR)
         if asr_entry is None:
@@ -340,11 +336,6 @@ class FusionOrchestrator:
                 asr_result.confidence,
                 asr_result.inference_latency_ms,
             )
-            if asr_result.confidence < 0.45:
-                logger.info(
-                    "ASR result suppressed (confidence=%.4f < 0.30)", asr_result.confidence
-                )
-                return
             if features is not None:
                 asr_result = dataclasses.replace(
                     asr_result,

--- a/sozia/server/fusion/orchestrator.py
+++ b/sozia/server/fusion/orchestrator.py
@@ -323,8 +323,8 @@ class FusionOrchestrator:
         send_fn: Callable[[TranscriptSegment], Awaitable[None] | None],
         features: AudioFeatureChunk | None = None,
     ) -> None:
-        # Whisper hallucinates on very short clips; skip batches under 1 s.
-        if asr_batch.shape[0] < 100:
+        # Whisper accuracy degrades below ~2 s of audio; skip short batches.
+        if asr_batch.shape[0] < 200:
             logger.debug("asr_batch too short (%d frames), skipping", asr_batch.shape[0])
             return
         path_engines = self._engines.get(ModalityPath.SPEECH, {})

--- a/sozia/server/fusion/orchestrator.py
+++ b/sozia/server/fusion/orchestrator.py
@@ -340,6 +340,11 @@ class FusionOrchestrator:
                 asr_result.confidence,
                 asr_result.inference_latency_ms,
             )
+            if asr_result.confidence < 0.30:
+                logger.info(
+                    "ASR result suppressed (confidence=%.4f < 0.30)", asr_result.confidence
+                )
+                return
             if features is not None:
                 asr_result = dataclasses.replace(
                     asr_result,

--- a/sozia/server/fusion/orchestrator.py
+++ b/sozia/server/fusion/orchestrator.py
@@ -336,6 +336,11 @@ class FusionOrchestrator:
                 asr_result.confidence,
                 asr_result.inference_latency_ms,
             )
+            if asr_result.confidence < 0.30:
+                logger.info(
+                    "ASR result suppressed (confidence=%.4f < 0.30)", asr_result.confidence
+                )
+                return
             if features is not None:
                 asr_result = dataclasses.replace(
                     asr_result,

--- a/sozia/server/fusion/orchestrator.py
+++ b/sozia/server/fusion/orchestrator.py
@@ -225,6 +225,26 @@ class FusionOrchestrator:
     # Internal pipeline handlers
     # ------------------------------------------------------------------
 
+    async def flush_speech_pending(
+        self,
+        session_id: str,
+        health: list[PipelineHealth],
+        send_fn: Callable[[TranscriptSegment], Awaitable[None] | None],
+    ) -> None:
+        """Run ASR on any buffered mel frames and emit a FINAL segment.
+
+        Called on clean session teardown (``session_end``) so partial
+        utterances are not silently discarded. No-op if nothing is buffered.
+        """
+        asr_batch = self._mel_accumulator.take_pending(session_id)
+        if asr_batch is None:
+            return
+        path_engines = self._engines.get(ModalityPath.SPEECH, {})
+        asr_entry = path_engines.get(ModalityType.ASR)
+        if asr_entry is None:
+            return
+        await self._run_asr(session_id, asr_batch, health, send_fn)
+
     async def _process_speech(
         self,
         session_id: str,
@@ -276,33 +296,46 @@ class FusionOrchestrator:
             asr_batch is not None,
         )
         if asr_batch is not None and asr_entry is not None:
-            asr_engine, _ = asr_entry
-            try:
-                # Use a longer timeout — the batch covers up to 15 s of audio.
-                asr_result = await asr_engine.predict(asr_batch, timeout_ms=3000)
-                logger.info(
-                    "ASR result: text=%r confidence=%.4f latency=%dms",
-                    asr_result.text,
-                    asr_result.confidence,
-                    asr_result.inference_latency_ms,
-                )
+            await self._run_asr(session_id, asr_batch, health, send_fn, features)
+
+    async def _run_asr(
+        self,
+        session_id: str,
+        asr_batch: np.ndarray,
+        health: list[PipelineHealth],
+        send_fn: Callable[[TranscriptSegment], Awaitable[None] | None],
+        features: AudioFeatureChunk | None = None,
+    ) -> None:
+        path_engines = self._engines.get(ModalityPath.SPEECH, {})
+        asr_entry = path_engines.get(ModalityType.ASR)
+        if asr_entry is None:
+            return
+        asr_engine, _ = asr_entry
+        try:
+            asr_result = await asr_engine.predict(asr_batch, timeout_ms=3000)
+            logger.info(
+                "ASR result: text=%r confidence=%.4f latency=%dms",
+                asr_result.text,
+                asr_result.confidence,
+                asr_result.inference_latency_ms,
+            )
+            if features is not None:
                 asr_result = dataclasses.replace(
                     asr_result,
                     timestamp_ms=features.timestamp_ms,
                     duration_ms=features.chunk_duration_ms,
                 )
-                policy = self._policies.get(ModalityPath.SPEECH)
-                if isinstance(policy, SpeechFusionPolicy):
-                    asr_segments = policy.emit_asr_final(asr_result, session_id)
-                else:
-                    # Fallback for non-standard policies.
-                    asr_segments = await self.process_features(
-                        session_id, [asr_result], health, ModalityPath.SPEECH
-                    )
-                for seg in asr_segments:
-                    await _maybe_await(send_fn(seg))
-            except InferenceTimeoutError:
-                pass
+            policy = self._policies.get(ModalityPath.SPEECH)
+            if isinstance(policy, SpeechFusionPolicy):
+                asr_segments = policy.emit_asr_final(asr_result, session_id)
+            else:
+                asr_segments = await self.process_features(
+                    session_id, [asr_result], health, ModalityPath.SPEECH
+                )
+            for seg in asr_segments:
+                await _maybe_await(send_fn(seg))
+        except InferenceTimeoutError:
+            pass
 
     async def _process_sign(
         self,

--- a/sozia/server/fusion/orchestrator.py
+++ b/sozia/server/fusion/orchestrator.py
@@ -323,6 +323,10 @@ class FusionOrchestrator:
         send_fn: Callable[[TranscriptSegment], Awaitable[None] | None],
         features: AudioFeatureChunk | None = None,
     ) -> None:
+        # Whisper hallucinates on very short clips; skip batches under 1 s.
+        if asr_batch.shape[0] < 100:
+            logger.debug("asr_batch too short (%d frames), skipping", asr_batch.shape[0])
+            return
         path_engines = self._engines.get(ModalityPath.SPEECH, {})
         asr_entry = path_engines.get(ModalityType.ASR)
         if asr_entry is None:

--- a/sozia/server/inference/speech/whisper_asr_engine.py
+++ b/sozia/server/inference/speech/whisper_asr_engine.py
@@ -264,7 +264,6 @@ class WhisperAsrEngine(InferenceEngine):
                 task=self._task,
                 num_beams=self._num_beams,
                 no_repeat_ngram_size=3,
-                repetition_penalty=1.3,
                 return_dict_in_generate=True,
                 output_scores=True,
             )

--- a/sozia/server/inference/speech/whisper_asr_engine.py
+++ b/sozia/server/inference/speech/whisper_asr_engine.py
@@ -264,6 +264,7 @@ class WhisperAsrEngine(InferenceEngine):
                 task=self._task,
                 num_beams=self._num_beams,
                 no_repeat_ngram_size=3,
+                repetition_penalty=1.3,
                 return_dict_in_generate=True,
                 output_scores=True,
             )

--- a/tests/fusion/test_mel_accumulator.py
+++ b/tests/fusion/test_mel_accumulator.py
@@ -10,7 +10,6 @@ from sozia.server.fusion.mel_accumulator import MelAccumulator
 SESSION = "test-session"
 
 
-# Helpers: speech chunks peak above -4; silence peaks below -4.
 def _speech(t: int = 50, n: int = 128) -> np.ndarray:
     arr = np.full((t, n), -10.0, dtype=np.float32)
     arr[0, 0] = 0.0  # one bin well above -1.0 threshold
@@ -28,16 +27,16 @@ def _silence(t: int = 50, n: int = 128) -> np.ndarray:
 
 class TestMelAccumulatorBasic:
     def test_returns_none_while_buffering(self):
-        acc = MelAccumulator(min_flush_frames=200)
+        acc = MelAccumulator()
         assert acc.push(SESSION, _speech()) is None
         assert acc.push(SESSION, _speech()) is None
 
-    def test_flush_on_silence_after_speech(self):
-        acc = MelAccumulator(min_flush_frames=50)
+    def test_flush_on_1s_silence_after_speech(self):
+        acc = MelAccumulator(min_silence_frames=100)
         acc.push(SESSION, _speech(t=50))
-        result = acc.push(SESSION, _silence())
+        result = acc.push(SESSION, _silence(t=100))
         assert result is not None
-        assert result.shape[0] == 50  # only the speech chunk
+        assert result.shape[0] == 50  # only speech frames
 
     def test_silence_before_speech_is_ignored(self):
         acc = MelAccumulator()
@@ -46,33 +45,56 @@ class TestMelAccumulatorBasic:
 
     def test_flush_on_max_frames(self):
         acc = MelAccumulator(max_frames=100)
-        # Two 60-frame speech chunks → should flush when total ≥ 100
         acc.push(SESSION, _speech(t=60))
         result = acc.push(SESSION, _speech(t=60))
         assert result is not None
         assert result.shape[0] == 120
 
     def test_buffer_resets_after_flush(self):
-        acc = MelAccumulator(min_flush_frames=50)
+        acc = MelAccumulator(min_silence_frames=50)
         acc.push(SESSION, _speech(t=50))
-        acc.push(SESSION, _silence())  # flush
-        # New speech after flush should not carry over frames
+        acc.push(SESSION, _silence(t=50))
         assert acc.pending_frames(SESSION) == 0
 
     def test_pending_frames_tracks_count(self):
-        acc = MelAccumulator(min_flush_frames=200)
+        acc = MelAccumulator()
         acc.push(SESSION, _speech(t=50))
         assert acc.pending_frames(SESSION) == 50
         acc.push(SESSION, _speech(t=30))
         assert acc.pending_frames(SESSION) == 80
 
-    def test_short_pause_does_not_flush(self):
-        # min_flush_frames=200; only 50 frames buffered → silence should not flush
-        acc = MelAccumulator(min_flush_frames=200)
+    def test_short_silence_does_not_flush(self):
+        # 50 frames silence < min_silence_frames=100 → no flush
+        acc = MelAccumulator(min_silence_frames=100)
         acc.push(SESSION, _speech(t=50))
-        result = acc.push(SESSION, _silence())
+        result = acc.push(SESSION, _silence(t=50))
         assert result is None
         assert acc.pending_frames(SESSION) == 50
+
+    def test_consecutive_silence_accumulates(self):
+        # Two silent chunks totalling >= min_silence_frames → flush
+        acc = MelAccumulator(min_silence_frames=100)
+        acc.push(SESSION, _speech(t=50))
+        acc.push(SESSION, _silence(t=60))  # 60 < 100, no flush
+        result = acc.push(SESSION, _silence(t=60))  # 120 >= 100 → flush
+        assert result is not None
+
+    def test_speech_resets_silence_counter(self):
+        # Speech chunk resets the consecutive-silence counter
+        acc = MelAccumulator(min_silence_frames=100)
+        acc.push(SESSION, _speech(t=50))
+        acc.push(SESSION, _silence(t=60))  # 60 frames silence
+        acc.push(SESSION, _speech(t=20))   # resets silence to 0
+        result = acc.push(SESSION, _silence(t=60))  # only 60 again → no flush
+        assert result is None
+
+    def test_flush_on_silence_even_after_short_speech(self):
+        # Even a small amount of speech triggers flush on 1 s silence
+        acc = MelAccumulator(min_silence_frames=50)
+        acc.push(SESSION, _speech(t=10))
+        result = acc.push(SESSION, _silence(t=50))
+        assert result is not None
+        assert result.shape[0] == 10
 
 
 # ---------------------------------------------------------------------------
@@ -82,15 +104,15 @@ class TestMelAccumulatorBasic:
 
 class TestMelAccumulatorMultiSession:
     def test_sessions_are_isolated(self):
-        acc = MelAccumulator(min_flush_frames=50)
+        acc = MelAccumulator(min_silence_frames=50)
         acc.push("s1", _speech(t=50))
-        result_s2 = acc.push("s2", _silence())
+        result_s2 = acc.push("s2", _silence(t=50))
         assert result_s2 is None  # s2 never saw speech
 
     def test_flush_in_one_session_does_not_affect_other(self):
-        acc = MelAccumulator(min_flush_frames=50)
+        acc = MelAccumulator(min_silence_frames=50)
         acc.push("s1", _speech(t=50))
-        acc.push("s1", _silence())  # flush s1
+        acc.push("s1", _silence(t=50))  # flush s1
         acc.push("s2", _speech(t=50))
         assert acc.pending_frames("s2") == 50
 
@@ -102,19 +124,19 @@ class TestMelAccumulatorMultiSession:
 
 class TestMelAccumulatorOutput:
     def test_output_concatenates_time_axis(self):
-        acc = MelAccumulator(min_flush_frames=50)
+        acc = MelAccumulator(min_silence_frames=50)
         acc.push(SESSION, _speech(t=30))
         acc.push(SESSION, _speech(t=40))
-        result = acc.push(SESSION, _silence())
+        result = acc.push(SESSION, _silence(t=50))
         assert result is not None
         assert result.shape == (70, 128)
 
     def test_speech_content_preserved(self):
-        acc = MelAccumulator(min_flush_frames=50)
+        acc = MelAccumulator(min_silence_frames=50)
         chunk = _speech(t=50)
         chunk[5, 10] = 999.0  # sentinel
         acc.push(SESSION, chunk)
-        result = acc.push(SESSION, _silence())
+        result = acc.push(SESSION, _silence(t=50))
         assert result is not None
         assert result[5, 10] == pytest.approx(999.0)
 
@@ -126,17 +148,27 @@ class TestMelAccumulatorOutput:
 
 class TestMelAccumulatorReset:
     def test_reset_clears_buffer(self):
-        acc = MelAccumulator(min_flush_frames=200)
+        acc = MelAccumulator()
         acc.push(SESSION, _speech(t=50))
         acc.reset(SESSION)
         assert acc.pending_frames(SESSION) == 0
 
     def test_reset_prevents_stale_flush(self):
-        acc = MelAccumulator(min_flush_frames=50)
+        acc = MelAccumulator(min_silence_frames=50)
         acc.push(SESSION, _speech(t=50))
         acc.reset(SESSION)
-        result = acc.push(SESSION, _silence())
+        result = acc.push(SESSION, _silence(t=50))
         assert result is None  # speech flag was cleared
+
+    def test_reset_clears_silence_counter(self):
+        # After reset, accumulated silence from before should not carry over
+        acc = MelAccumulator(min_silence_frames=100)
+        acc.push(SESSION, _speech(t=50))
+        acc.push(SESSION, _silence(t=60))  # partial silence, no flush
+        acc.reset(SESSION)
+        acc.push(SESSION, _speech(t=50))
+        result = acc.push(SESSION, _silence(t=60))  # 60 < 100, fresh counter
+        assert result is None
 
     def test_reset_on_unknown_session_is_safe(self):
         acc = MelAccumulator()

--- a/tests/fusion/test_mel_accumulator.py
+++ b/tests/fusion/test_mel_accumulator.py
@@ -142,6 +142,78 @@ class TestMelAccumulatorOutput:
 
 
 # ---------------------------------------------------------------------------
+# take_pending (force flush on session end)
+# ---------------------------------------------------------------------------
+
+
+class TestMelAccumulatorTakePending:
+    def test_take_pending_returns_buffered_frames(self):
+        acc = MelAccumulator()
+        acc.push(SESSION, _speech(t=50))
+        result = acc.take_pending(SESSION)
+        assert result is not None
+        assert result.shape[0] == 50
+
+    def test_take_pending_resets_buffer(self):
+        acc = MelAccumulator()
+        acc.push(SESSION, _speech(t=50))
+        acc.take_pending(SESSION)
+        assert acc.pending_frames(SESSION) == 0
+
+    def test_take_pending_returns_none_when_empty(self):
+        acc = MelAccumulator()
+        assert acc.take_pending(SESSION) is None
+
+    def test_take_pending_returns_none_after_only_silence(self):
+        acc = MelAccumulator()
+        acc.push(SESSION, _silence(t=50))
+        assert acc.take_pending(SESSION) is None
+
+
+# ---------------------------------------------------------------------------
+# Wall-clock gap detection
+# ---------------------------------------------------------------------------
+
+
+class TestMelAccumulatorWallClockGap:
+    def test_gap_flushes_on_next_chunk(self, monkeypatch):
+        # Simulate a 2 s wall-clock gap between pushes (> min_silence_frames=100).
+        acc = MelAccumulator(min_silence_frames=100)
+        t = [0.0]
+
+        monkeypatch.setattr("sozia.server.fusion.mel_accumulator.time.monotonic", lambda: t[0])
+        acc.push(SESSION, _speech(t=50))
+
+        t[0] = 2.0  # 2 s later → 200 frame gap > 100
+        result = acc.push(SESSION, _speech(t=20))
+        assert result is not None
+        assert result.shape[0] == 50  # old buffer flushed
+
+    def test_short_gap_does_not_flush(self, monkeypatch):
+        acc = MelAccumulator(min_silence_frames=100)
+        t = [0.0]
+
+        monkeypatch.setattr("sozia.server.fusion.mel_accumulator.time.monotonic", lambda: t[0])
+        acc.push(SESSION, _speech(t=50))
+
+        t[0] = 0.5  # 0.5 s → 50 frames < 100
+        result = acc.push(SESSION, _speech(t=20))
+        assert result is None
+        assert acc.pending_frames(SESSION) == 70
+
+    def test_gap_starts_new_buffer_with_current_chunk(self, monkeypatch):
+        acc = MelAccumulator(min_silence_frames=100)
+        t = [0.0]
+
+        monkeypatch.setattr("sozia.server.fusion.mel_accumulator.time.monotonic", lambda: t[0])
+        acc.push(SESSION, _speech(t=50))
+
+        t[0] = 2.0
+        acc.push(SESSION, _speech(t=20))  # triggers flush; new chunk buffered
+        assert acc.pending_frames(SESSION) == 20
+
+
+# ---------------------------------------------------------------------------
 # Reset
 # ---------------------------------------------------------------------------
 

--- a/tests/fusion/test_mel_accumulator.py
+++ b/tests/fusion/test_mel_accumulator.py
@@ -12,7 +12,7 @@ SESSION = "test-session"
 
 def _speech(t: int = 50, n: int = 128) -> np.ndarray:
     arr = np.full((t, n), -10.0, dtype=np.float32)
-    arr[0, 0] = 0.0  # one bin well above -1.0 threshold
+    arr[0, 0] = 1.0  # one bin well above 0.3 threshold
     return arr
 
 

--- a/tests/fusion/test_orchestrator_process.py
+++ b/tests/fusion/test_orchestrator_process.py
@@ -460,7 +460,7 @@ class TestProcessSpeech:
         chunk = AudioFeatureChunk(
             session_id=_SESSION,
             timestamp_ms=5000,
-            features=[[0.1, 0.2]] * 10,
+            features=[[1.0, 1.5]] * 10,
             feature_type="mfcc",
             sample_rate_hz=16000,
             chunk_duration_ms=750,

--- a/tests/fusion/test_orchestrator_process.py
+++ b/tests/fusion/test_orchestrator_process.py
@@ -78,7 +78,7 @@ def _audio_chunk() -> AudioFeatureChunk:
     return AudioFeatureChunk(
         session_id=_SESSION,
         timestamp_ms=0,
-        features=[[0.1, 0.2, 0.3]] * 10,
+        features=[[1.0, 1.5, 2.0]] * 100,
         feature_type="mfcc",
         sample_rate_hz=16000,
         chunk_duration_ms=500,
@@ -460,7 +460,7 @@ class TestProcessSpeech:
         chunk = AudioFeatureChunk(
             session_id=_SESSION,
             timestamp_ms=5000,
-            features=[[1.0, 1.5]] * 10,
+            features=[[1.0, 1.5]] * 100,
             feature_type="mfcc",
             sample_rate_hz=16000,
             chunk_duration_ms=750,

--- a/tests/fusion/test_orchestrator_process.py
+++ b/tests/fusion/test_orchestrator_process.py
@@ -78,7 +78,7 @@ def _audio_chunk() -> AudioFeatureChunk:
     return AudioFeatureChunk(
         session_id=_SESSION,
         timestamp_ms=0,
-        features=[[1.0, 1.5, 2.0]] * 200,
+        features=[[1.0, 1.5, 2.0]] * 100,
         feature_type="mfcc",
         sample_rate_hz=16000,
         chunk_duration_ms=500,
@@ -460,7 +460,7 @@ class TestProcessSpeech:
         chunk = AudioFeatureChunk(
             session_id=_SESSION,
             timestamp_ms=5000,
-            features=[[1.0, 1.5]] * 200,
+            features=[[1.0, 1.5]] * 100,
             feature_type="mfcc",
             sample_rate_hz=16000,
             chunk_duration_ms=750,

--- a/tests/fusion/test_orchestrator_process.py
+++ b/tests/fusion/test_orchestrator_process.py
@@ -78,7 +78,7 @@ def _audio_chunk() -> AudioFeatureChunk:
     return AudioFeatureChunk(
         session_id=_SESSION,
         timestamp_ms=0,
-        features=[[1.0, 1.5, 2.0]] * 100,
+        features=[[1.0, 1.5, 2.0]] * 200,
         feature_type="mfcc",
         sample_rate_hz=16000,
         chunk_duration_ms=500,
@@ -460,7 +460,7 @@ class TestProcessSpeech:
         chunk = AudioFeatureChunk(
             session_id=_SESSION,
             timestamp_ms=5000,
-            features=[[1.0, 1.5]] * 100,
+            features=[[1.0, 1.5]] * 200,
             feature_type="mfcc",
             sample_rate_hz=16000,
             chunk_duration_ms=750,

--- a/tests/fusion/test_orchestrator_process.py
+++ b/tests/fusion/test_orchestrator_process.py
@@ -78,7 +78,7 @@ def _audio_chunk() -> AudioFeatureChunk:
     return AudioFeatureChunk(
         session_id=_SESSION,
         timestamp_ms=0,
-        features=[[1.0, 1.5, 2.0]] * 100,
+        features=[[0.1, 0.2, 0.3]] * 10,
         feature_type="mfcc",
         sample_rate_hz=16000,
         chunk_duration_ms=500,
@@ -460,7 +460,7 @@ class TestProcessSpeech:
         chunk = AudioFeatureChunk(
             session_id=_SESSION,
             timestamp_ms=5000,
-            features=[[1.0, 1.5]] * 100,
+            features=[[1.0, 1.5]] * 10,
             feature_type="mfcc",
             sample_rate_hz=16000,
             chunk_duration_ms=750,


### PR DESCRIPTION
Closes #45

## What does this PR do?

Fixes three compounding bugs on the SPEECH pipeline:

- **Short-clip hallucinations**: `take_if_stale(min_frames=100)` and a matching guard in `_run_asr` prevent Whisper from seeing mel buffers shorter than 1 s.
- **Low-confidence noise**: confidence gate at 0.30 suppresses results before any segment is emitted.
- **Out-of-order subtitles**: watchdog-triggered ASR segments now receive a wall-clock `timestamp_ms` instead of `0`.

Also adds `flush_speech_pending` on `session_end` and a 1 s `_stale_flush_watchdog` in `SessionHandler`.

## Which package(s) does it touch?

`sozia.server.fusion`, `sozia.server.api`

## How to test

```
python -m pytest tests/fusion/test_mel_accumulator.py tests/fusion/test_orchestrator_process.py -q
```

Manual: speak short noise bursts → no hallucinated words; pause mid-utterance → watchdog flushes after 1 s with correct ordering.

## Checklist

- [x] Follows commit convention (`<type>(<scope>): <description>`)
- [x] Added/updated tests (if applicable)
- [x] No sozia.common schema changes (or: both repos updated)
- [x] Tested locally