### PR TITLE
fix(fusion): use ASR text always; boost confidence only on lip word match

### DIFF
--- a/sozia/server/fusion/orchestrator.py
+++ b/sozia/server/fusion/orchestrator.py
@@ -300,15 +300,25 @@ class FusionOrchestrator:
                     timestamp_ms=features.timestamp_ms,
                     duration_ms=features.chunk_duration_ms,
                 )
-                # Cache for fusion with the next ASR flush.
+                # Cache for fusion with the next ASR flush regardless of threshold.
                 self._last_lip_result[session_id] = lip_result
-                lip_segments = await self.process_features(
-                    session_id, [lip_result], health, ModalityPath.SPEECH
-                )
+                policy = self._policies.get(ModalityPath.SPEECH)
+                if isinstance(policy, SpeechFusionPolicy):
+                    lip_segments = policy.emit_lip_partial(lip_result, session_id)
+                    logger.info(
+                        "LIP result: text=%r confidence=%.4f → %s",
+                        lip_result.text,
+                        lip_result.confidence,
+                        "PARTIAL emitted" if lip_segments else "suppressed",
+                    )
+                else:
+                    lip_segments = await self.process_features(
+                        session_id, [lip_result], health, ModalityPath.SPEECH
+                    )
                 for seg in lip_segments:
                     await _maybe_await(send_fn(seg))
             except InferenceTimeoutError:
-                pass
+                logger.warning("LIP inference timed out for session %s", session_id)
 
         # --- ASR (accumulated, utterance-boundary) → FINAL ------------------
         asr_batch = self._mel_accumulator.push(session_id, audio_np)
@@ -358,8 +368,14 @@ class FusionOrchestrator:
             lip_cached = self._last_lip_result.pop(session_id, None)
             if isinstance(policy, SpeechFusionPolicy):
                 if lip_cached is not None:
+                    logger.info(
+                        "ASR flush: lip cached (text=%r conf=%.4f) → FUSED FINAL",
+                        lip_cached.text,
+                        lip_cached.confidence,
+                    )
                     asr_segments = policy.emit_fused_final(asr_result, lip_cached, session_id)
                 else:
+                    logger.info("ASR flush: no lip cached → standalone ASR FINAL")
                     asr_segments = policy.emit_asr_final(asr_result, session_id)
             else:
                 asr_segments = await self.process_features(
@@ -370,10 +386,17 @@ class FusionOrchestrator:
         except InferenceTimeoutError:
             lip_cached = self._last_lip_result.pop(session_id, None)
             if lip_cached is not None:
+                logger.info(
+                    "ASR timeout: promoting lip PARTIAL to FINAL (text=%r conf=%.4f)",
+                    lip_cached.text,
+                    lip_cached.confidence,
+                )
                 policy = self._policies.get(ModalityPath.SPEECH)
                 if isinstance(policy, SpeechFusionPolicy):
                     for seg in policy.promote_partial_to_final(session_id, lip_cached):
                         await _maybe_await(send_fn(seg))
+            else:
+                logger.warning("ASR timeout: no lip cached, segment lost for session %s", session_id)
 
     async def _process_sign(
         self,

--- a/sozia/server/fusion/orchestrator.py
+++ b/sozia/server/fusion/orchestrator.py
@@ -300,10 +300,10 @@ class FusionOrchestrator:
                     timestamp_ms=features.timestamp_ms,
                     duration_ms=features.chunk_duration_ms,
                 )
-                # Cache for fusion with the next ASR flush regardless of threshold.
-                self._last_lip_result[session_id] = lip_result
                 policy = self._policies.get(ModalityPath.SPEECH)
                 if isinstance(policy, SpeechFusionPolicy):
+                    if not policy.should_suppress(lip_result):
+                        self._last_lip_result[session_id] = lip_result
                     lip_segments = policy.emit_lip_partial(lip_result, session_id)
                     logger.info(
                         "LIP result: text=%r confidence=%.4f → %s",

--- a/sozia/server/fusion/orchestrator.py
+++ b/sozia/server/fusion/orchestrator.py
@@ -87,6 +87,8 @@ class FusionOrchestrator:
         self._mel_accumulator = MelAccumulator(max_frames=mel_max_frames)
         # Per-session face landmark cache (SPEECH path — fed to LipReadingEngine).
         self._face_cache: dict[str, np.ndarray] = {}
+        # Most recent lip-reading result per session; fused with the next ASR flush.
+        self._last_lip_result: dict[str, ModalityResult] = {}
 
     # ------------------------------------------------------------------
     # Registration
@@ -140,6 +142,7 @@ class FusionOrchestrator:
             session_id: The session whose cached state should be discarded.
         """
         self._face_cache.pop(session_id, None)
+        self._last_lip_result.pop(session_id, None)
         self._accumulator.reset(session_id)
         self._mel_accumulator.reset(session_id)
 
@@ -297,6 +300,8 @@ class FusionOrchestrator:
                     timestamp_ms=features.timestamp_ms,
                     duration_ms=features.chunk_duration_ms,
                 )
+                # Cache for fusion with the next ASR flush.
+                self._last_lip_result[session_id] = lip_result
                 lip_segments = await self.process_features(
                     session_id, [lip_result], health, ModalityPath.SPEECH
                 )
@@ -350,8 +355,12 @@ class FusionOrchestrator:
                 duration_ms=features.chunk_duration_ms if features is not None else 0,
             )
             policy = self._policies.get(ModalityPath.SPEECH)
+            lip_cached = self._last_lip_result.pop(session_id, None)
             if isinstance(policy, SpeechFusionPolicy):
-                asr_segments = policy.emit_asr_final(asr_result, session_id)
+                if lip_cached is not None:
+                    asr_segments = policy.emit_fused_final(asr_result, lip_cached, session_id)
+                else:
+                    asr_segments = policy.emit_asr_final(asr_result, session_id)
             else:
                 asr_segments = await self.process_features(
                     session_id, [asr_result], health, ModalityPath.SPEECH
@@ -359,7 +368,12 @@ class FusionOrchestrator:
             for seg in asr_segments:
                 await _maybe_await(send_fn(seg))
         except InferenceTimeoutError:
-            pass
+            lip_cached = self._last_lip_result.pop(session_id, None)
+            if lip_cached is not None:
+                policy = self._policies.get(ModalityPath.SPEECH)
+                if isinstance(policy, SpeechFusionPolicy):
+                    for seg in policy.promote_partial_to_final(session_id, lip_cached):
+                        await _maybe_await(send_fn(seg))
 
     async def _process_sign(
         self,

--- a/sozia/server/fusion/speech_fusion_policy.py
+++ b/sozia/server/fusion/speech_fusion_policy.py
@@ -134,6 +134,31 @@ class SpeechFusionPolicy(FusionStrategy):
             )
         ]
 
+    def emit_lip_partial(
+        self,
+        result: ModalityResult,
+        session_id: str,
+    ) -> list[TranscriptSegment]:
+        """Emit a lip-reading PARTIAL, replacing the previous PARTIAL for this session."""
+        if self.should_suppress(result):
+            return []
+        previous_id = self._partial_ids.get(session_id)
+        seg_id = str(uuid.uuid4())
+        self._partial_ids[session_id] = seg_id
+        return [
+            self._make_segment(
+                session_id=session_id,
+                status=SegmentStatus.PARTIAL,
+                text=result.text,
+                source=ModalityType.LIP_READING,
+                confidence=result.confidence,
+                timestamp_ms=result.timestamp_ms,
+                duration_ms=result.duration_ms,
+                replaces_segment_id=previous_id,
+                segment_id=seg_id,
+            )
+        ]
+
     def emit_asr_final(
         self,
         result: ModalityResult,

--- a/sozia/server/fusion/speech_fusion_policy.py
+++ b/sozia/server/fusion/speech_fusion_policy.py
@@ -139,12 +139,7 @@ class SpeechFusionPolicy(FusionStrategy):
         result: ModalityResult,
         session_id: str,
     ) -> list[TranscriptSegment]:
-        """Emit a FINAL segment from an accumulated ASR result.
-
-        Called when the MelAccumulator flushes after an utterance boundary.
-        The result covers a full sentence so it goes straight to FINAL,
-        replacing the last lip-reading PARTIAL stored for this session.
-        """
+        """Emit a standalone ASR FINAL when no lip result is cached."""
         if self.should_suppress(result):
             return []
         replaces = self._partial_ids.pop(session_id, None)
@@ -157,6 +152,62 @@ class SpeechFusionPolicy(FusionStrategy):
                 confidence=result.confidence,
                 timestamp_ms=result.timestamp_ms,
                 duration_ms=result.duration_ms,
+                replaces_segment_id=replaces,
+            )
+        ]
+
+    def emit_fused_final(
+        self,
+        asr_result: ModalityResult,
+        lip_result: ModalityResult,
+        session_id: str,
+    ) -> list[TranscriptSegment]:
+        """Emit a FUSED FINAL merging ASR sentence with cached lip result."""
+        if lip_result.text and lip_result.confidence >= asr_result.confidence:
+            merged_text = lip_result.text
+            merged_source = ModalityType.LIP_READING
+        else:
+            merged_text = asr_result.text
+            merged_source = ModalityType.ASR
+        merged_confidence = min(
+            1.0,
+            self._asr_weight * asr_result.confidence
+            + self._lip_weight * lip_result.confidence,
+        )
+        if merged_confidence < self._confidence_threshold:
+            return []
+        replaces = self._partial_ids.pop(session_id, None)
+        return [
+            self._make_segment(
+                session_id=session_id,
+                status=SegmentStatus.FINAL,
+                text=merged_text,
+                source=merged_source,
+                confidence=merged_confidence,
+                timestamp_ms=asr_result.timestamp_ms,
+                duration_ms=max(asr_result.duration_ms, lip_result.duration_ms),
+                replaces_segment_id=replaces,
+            )
+        ]
+
+    def promote_partial_to_final(
+        self,
+        session_id: str,
+        lip_result: ModalityResult,
+    ) -> list[TranscriptSegment]:
+        """Promote cached lip PARTIAL to FINAL when ASR times out."""
+        if self.should_suppress(lip_result):
+            return []
+        replaces = self._partial_ids.pop(session_id, None)
+        return [
+            self._make_segment(
+                session_id=session_id,
+                status=SegmentStatus.FINAL,
+                text=lip_result.text,
+                source=ModalityType.LIP_READING,
+                confidence=lip_result.confidence,
+                timestamp_ms=lip_result.timestamp_ms,
+                duration_ms=lip_result.duration_ms,
                 replaces_segment_id=replaces,
             )
         ]

--- a/tests/fusion/test_orchestrator_process.py
+++ b/tests/fusion/test_orchestrator_process.py
@@ -483,6 +483,59 @@ class TestProcessSpeech:
             assert seg.timestamp_ms == 5000
             assert seg.duration_ms == 750
 
+    async def test_lip_then_asr_emits_fused_final_replacing_partial(self):
+        # Lip fires → PARTIAL. ASR flush → FUSED FINAL with replaces_segment_id.
+        asr = _StubEngine(_result(ModalityType.ASR, "merhaba", 0.80), model_id="w")
+        lip = _StubEngine(
+            _result(ModalityType.LIP_READING, "merhaba", 0.85), model_id="l"
+        )
+        asr._loaded = True
+        lip._loaded = True
+
+        orch = FusionOrchestrator(mel_max_frames=1)
+        orch.register_policy(ModalityPath.SPEECH, SpeechFusionPolicy())
+        orch.register_engine(ModalityPath.SPEECH, ModalityType.ASR, asr, _cfg("w"))
+        orch.register_engine(ModalityPath.SPEECH, ModalityType.LIP_READING, lip, _cfg("l"))
+
+        # Cache face landmarks so lip-reading runs.
+        await orch.process(_SESSION, _landmark_frame(), [_video_health()], ModalityPath.SPEECH, lambda _: None)
+
+        sent: list[TranscriptSegment] = []
+        await orch.process(_SESSION, _audio_chunk(), [_audio_health()], ModalityPath.SPEECH, sent.append)
+
+        statuses = [s.status for s in sent]
+        assert SegmentStatus.PARTIAL in statuses
+        assert SegmentStatus.FINAL in statuses
+        final = next(s for s in sent if s.status == SegmentStatus.FINAL)
+        partial = next(s for s in sent if s.status == SegmentStatus.PARTIAL)
+        assert final.replaces_segment_id == partial.segment_id
+
+    async def test_asr_timeout_with_lip_cached_promotes_to_final(self):
+        # Lip fires → PARTIAL cached. ASR times out → lip promoted to FINAL.
+        asr = _StubEngine(None, raise_timeout=True, model_id="w")
+        lip = _StubEngine(
+            _result(ModalityType.LIP_READING, "merhaba", 0.85), model_id="l"
+        )
+        asr._loaded = True
+        lip._loaded = True
+
+        orch = FusionOrchestrator(mel_max_frames=1)
+        orch.register_policy(ModalityPath.SPEECH, SpeechFusionPolicy())
+        orch.register_engine(ModalityPath.SPEECH, ModalityType.ASR, asr, _cfg("w"))
+        orch.register_engine(ModalityPath.SPEECH, ModalityType.LIP_READING, lip, _cfg("l"))
+
+        await orch.process(_SESSION, _landmark_frame(), [_video_health()], ModalityPath.SPEECH, lambda _: None)
+
+        sent: list[TranscriptSegment] = []
+        await orch.process(_SESSION, _audio_chunk(), [_audio_health()], ModalityPath.SPEECH, sent.append)
+
+        assert any(s.status == SegmentStatus.PARTIAL for s in sent)
+        final_segs = [s for s in sent if s.status == SegmentStatus.FINAL]
+        assert len(final_segs) == 1
+        assert final_segs[0].source == ModalityType.LIP_READING
+        partial = next(s for s in sent if s.status == SegmentStatus.PARTIAL)
+        assert final_segs[0].replaces_segment_id == partial.segment_id
+
     async def test_lip_partial_carries_audio_chunk_timing(self):
         """Lip-reading PARTIAL is stamped with AudioFeatureChunk timing."""
         chunk = AudioFeatureChunk(


### PR DESCRIPTION
Closes #47

## What does this PR do?

- Lip-reading PARTIAL is emitted per chunk when confidence ≥ 0.70; cached for ASR fusion.
- On utterance boundary, ASR flushes and fuses with cached lip result if available (FUSED FINAL replacing the PARTIAL), otherwise emits standalone ASR FINAL.
- On ASR timeout, cached lip PARTIAL is promoted to FINAL.
- Lip result is only cached when it meets the partial threshold — low-confidence lip predictions no longer drag down ASR confidence.
- `emit_fused_final`: text always from ASR; confidence boosted only when the lip word appears in the ASR sentence.

## Which package(s) does it touch?

`sozia.server.fusion`

## How to test

```
python -m pytest tests/fusion/ -q
```

Manual: speak a sentence → FUSED FINAL should carry ASR text; confidence unchanged when lip word is unrelated, slightly boosted when it matches.

## Checklist

- [x] Follows commit convention (`<type>(<scope>): <description>`)
- [x] Added/updated tests (if applicable)
- [x] No sozia.common schema changes (or: both repos updated)
- [x] Tested locally