### PR TITLE
feat(fusion): accumulate face frames during speech; run lip on 30-frame windows

### DIFF
--- a/sozia/server/fusion/orchestrator.py
+++ b/sozia/server/fusion/orchestrator.py
@@ -49,6 +49,12 @@ if TYPE_CHECKING:
 # like DegradedModeHandler's degraded_penalty_factor.
 _GLOSS_TIMEOUT_CONFIDENCE_DEDUCTION = 0.15
 
+# Mirrors MelAccumulator threshold; gates face-frame collection for lip-reading.
+_SPEECH_ENERGY_THRESHOLD = 0.3
+
+# Number of face frames to accumulate before running lip inference.
+_LIP_WINDOW_FRAMES = 30
+
 
 class FusionOrchestrator:
     """Routes inference results to the appropriate fusion policy.
@@ -85,8 +91,12 @@ class FusionOrchestrator:
         self._degraded: DegradedModeHandler = degraded_handler or DegradedModeHandler()
         self._accumulator = FrameAccumulator(window_size=window_size)
         self._mel_accumulator = MelAccumulator(max_frames=mel_max_frames)
-        # Per-session face landmark cache (SPEECH path — fed to LipReadingEngine).
+        # Per-session face landmark cache (SPEECH path — latest frame from client).
         self._face_cache: dict[str, np.ndarray] = {}
+        # Face frames accumulated during speech periods for lip-reading batches.
+        self._face_frame_buffer: dict[str, list[np.ndarray]] = {}
+        # Whether the last audio chunk detected speech energy.
+        self._is_speaking: dict[str, bool] = {}
         # Most recent lip-reading result per session; fused with the next ASR flush.
         self._last_lip_result: dict[str, ModalityResult] = {}
 
@@ -142,6 +152,8 @@ class FusionOrchestrator:
             session_id: The session whose cached state should be discarded.
         """
         self._face_cache.pop(session_id, None)
+        self._face_frame_buffer.pop(session_id, None)
+        self._is_speaking.pop(session_id, None)
         self._last_lip_result.pop(session_id, None)
         self._accumulator.reset(session_id)
         self._mel_accumulator.reset(session_id)
@@ -273,52 +285,29 @@ class FusionOrchestrator:
         send_fn: Callable[[TranscriptSegment], Awaitable[None] | None],
     ) -> None:
         if isinstance(features, LandmarkFrame):
-            # Cache the face landmarks for the next audio chunk.
             if features.face_landmarks is not None:
-                self._face_cache[session_id] = np.asarray(
-                    features.face_landmarks, dtype=np.float32
-                )
+                face = np.asarray(features.face_landmarks, dtype=np.float32)
+                self._face_cache[session_id] = face
+                # Accumulate face frames only during speech periods.
+                if self._is_speaking.get(session_id, False):
+                    self._face_frame_buffer.setdefault(session_id, []).append(face)
+                    if len(self._face_frame_buffer[session_id]) >= _LIP_WINDOW_FRAMES:
+                        await self._run_lip(session_id, health, send_fn)
             return
 
         # AudioFeatureChunk — two independent paths:
-        #   Lip-reading: fires on every chunk → PARTIAL (fast word hints).
+        #   Lip-reading: fires every _LIP_WINDOW_FRAMES face frames during speech.
         #   ASR: fires when MelAccumulator flushes (silence or 15 s) → FINAL.
         audio_np = np.asarray(features.features, dtype=np.float32)
-        face_np = self._face_cache.get(session_id)
+        is_speech = float(np.max(audio_np)) > _SPEECH_ENERGY_THRESHOLD
+        self._is_speaking[session_id] = is_speech
+
+        if not is_speech:
+            # Drop accumulated face frames so stale frames don't cross utterances.
+            self._face_frame_buffer.pop(session_id, None)
 
         path_engines = self._engines.get(ModalityPath.SPEECH, {})
         asr_entry = path_engines.get(ModalityType.ASR)
-        lip_entry = path_engines.get(ModalityType.LIP_READING)
-
-        # --- Lip-reading (every chunk) → PARTIAL ----------------------------
-        if lip_entry is not None and face_np is not None:
-            lip_engine, _ = lip_entry
-            try:
-                lip_result = await lip_engine.predict(face_np)
-                lip_result = dataclasses.replace(
-                    lip_result,
-                    timestamp_ms=features.timestamp_ms,
-                    duration_ms=features.chunk_duration_ms,
-                )
-                policy = self._policies.get(ModalityPath.SPEECH)
-                if isinstance(policy, SpeechFusionPolicy):
-                    if not policy.should_suppress(lip_result):
-                        self._last_lip_result[session_id] = lip_result
-                    lip_segments = policy.emit_lip_partial(lip_result, session_id)
-                    logger.info(
-                        "LIP result: text=%r confidence=%.4f → %s",
-                        lip_result.text,
-                        lip_result.confidence,
-                        "PARTIAL emitted" if lip_segments else "suppressed",
-                    )
-                else:
-                    lip_segments = await self.process_features(
-                        session_id, [lip_result], health, ModalityPath.SPEECH
-                    )
-                for seg in lip_segments:
-                    await _maybe_await(send_fn(seg))
-            except InferenceTimeoutError:
-                logger.warning("LIP inference timed out for session %s", session_id)
 
         # --- ASR (accumulated, utterance-boundary) → FINAL ------------------
         asr_batch = self._mel_accumulator.push(session_id, audio_np)
@@ -329,6 +318,50 @@ class FusionOrchestrator:
         )
         if asr_batch is not None and asr_entry is not None:
             await self._run_asr(session_id, asr_batch, health, send_fn, features)
+
+    async def _run_lip(
+        self,
+        session_id: str,
+        health: list[PipelineHealth],
+        send_fn: Callable[[TranscriptSegment], Awaitable[None] | None],
+    ) -> None:
+        buf = self._face_frame_buffer.get(session_id, [])
+        if len(buf) < _LIP_WINDOW_FRAMES:
+            return
+        batch = np.stack(buf[:_LIP_WINDOW_FRAMES])  # (30, 83, 3)
+        self._face_frame_buffer[session_id] = buf[_LIP_WINDOW_FRAMES:]
+
+        path_engines = self._engines.get(ModalityPath.SPEECH, {})
+        lip_entry = path_engines.get(ModalityType.LIP_READING)
+        if lip_entry is None:
+            return
+        lip_engine, _ = lip_entry
+        try:
+            lip_result = await lip_engine.predict(batch)
+            lip_result = dataclasses.replace(
+                lip_result,
+                timestamp_ms=int(time.time() * 1000),
+                duration_ms=0,
+            )
+            policy = self._policies.get(ModalityPath.SPEECH)
+            if isinstance(policy, SpeechFusionPolicy):
+                if not policy.should_suppress(lip_result):
+                    self._last_lip_result[session_id] = lip_result
+                lip_segments = policy.emit_lip_partial(lip_result, session_id)
+                logger.info(
+                    "LIP result: text=%r confidence=%.4f → %s",
+                    lip_result.text,
+                    lip_result.confidence,
+                    "PARTIAL emitted" if lip_segments else "suppressed",
+                )
+            else:
+                lip_segments = await self.process_features(
+                    session_id, [lip_result], health, ModalityPath.SPEECH
+                )
+            for seg in lip_segments:
+                await _maybe_await(send_fn(seg))
+        except InferenceTimeoutError:
+            logger.warning("LIP inference timed out for session %s", session_id)
 
     async def _run_asr(
         self,

--- a/tests/fusion/test_orchestrator_process.py
+++ b/tests/fusion/test_orchestrator_process.py
@@ -286,26 +286,18 @@ class TestWarmUpCoolDownUpdated:
 
 class TestProcessSpeech:
     async def test_audio_chunk_emits_partial_via_send_fn(self):
-        # Lip-reading fires on every chunk when face is cached → PARTIAL.
+        # Speech audio sets is_speaking=True. 30 landmark frames trigger lip → PARTIAL.
         orch = _make_orchestrator(with_speech=True)
-        await orch.process(
-            _SESSION,
-            _landmark_frame(),
-            [_video_health()],
-            ModalityPath.SPEECH,
-            lambda _: None,
-        )
 
         sent: list[TranscriptSegment] = []
         await orch.process(
-            _SESSION,
-            _audio_chunk(),
-            [_audio_health()],
-            ModalityPath.SPEECH,
-            sent.append,
+            _SESSION, _audio_chunk(), [_audio_health()], ModalityPath.SPEECH, sent.append
         )
+        for _ in range(30):
+            await orch.process(
+                _SESSION, _landmark_frame(), [_video_health()], ModalityPath.SPEECH, sent.append
+            )
 
-        assert len(sent) >= 1
         assert any(s.status == SegmentStatus.PARTIAL for s in sent)
 
     async def test_audio_chunk_with_cached_face_emits_final(self):
@@ -484,24 +476,22 @@ class TestProcessSpeech:
             assert seg.duration_ms == 750
 
     async def test_lip_then_asr_emits_fused_final_replacing_partial(self):
-        # Lip fires → PARTIAL. ASR flush → FUSED FINAL with replaces_segment_id.
+        # Speech audio → is_speaking. 30 landmarks → lip PARTIAL. ASR flush → FUSED FINAL.
         asr = _StubEngine(_result(ModalityType.ASR, "merhaba", 0.80), model_id="w")
-        lip = _StubEngine(
-            _result(ModalityType.LIP_READING, "merhaba", 0.85), model_id="l"
-        )
+        lip = _StubEngine(_result(ModalityType.LIP_READING, "merhaba", 0.85), model_id="l")
         asr._loaded = True
         lip._loaded = True
 
-        orch = FusionOrchestrator(mel_max_frames=1)
+        orch = FusionOrchestrator()  # large mel_max_frames — no auto flush
         orch.register_policy(ModalityPath.SPEECH, SpeechFusionPolicy())
         orch.register_engine(ModalityPath.SPEECH, ModalityType.ASR, asr, _cfg("w"))
         orch.register_engine(ModalityPath.SPEECH, ModalityType.LIP_READING, lip, _cfg("l"))
 
-        # Cache face landmarks so lip-reading runs.
-        await orch.process(_SESSION, _landmark_frame(), [_video_health()], ModalityPath.SPEECH, lambda _: None)
-
         sent: list[TranscriptSegment] = []
         await orch.process(_SESSION, _audio_chunk(), [_audio_health()], ModalityPath.SPEECH, sent.append)
+        for _ in range(30):
+            await orch.process(_SESSION, _landmark_frame(), [_video_health()], ModalityPath.SPEECH, sent.append)
+        await orch.flush_speech_pending(_SESSION, [_audio_health()], sent.append)
 
         statuses = [s.status for s in sent]
         assert SegmentStatus.PARTIAL in statuses
@@ -511,23 +501,22 @@ class TestProcessSpeech:
         assert final.replaces_segment_id == partial.segment_id
 
     async def test_asr_timeout_with_lip_cached_promotes_to_final(self):
-        # Lip fires → PARTIAL cached. ASR times out → lip promoted to FINAL.
+        # Speech audio → is_speaking. 30 landmarks → lip PARTIAL cached. ASR times out → LIP FINAL.
         asr = _StubEngine(None, raise_timeout=True, model_id="w")
-        lip = _StubEngine(
-            _result(ModalityType.LIP_READING, "merhaba", 0.85), model_id="l"
-        )
+        lip = _StubEngine(_result(ModalityType.LIP_READING, "merhaba", 0.85), model_id="l")
         asr._loaded = True
         lip._loaded = True
 
-        orch = FusionOrchestrator(mel_max_frames=1)
+        orch = FusionOrchestrator()
         orch.register_policy(ModalityPath.SPEECH, SpeechFusionPolicy())
         orch.register_engine(ModalityPath.SPEECH, ModalityType.ASR, asr, _cfg("w"))
         orch.register_engine(ModalityPath.SPEECH, ModalityType.LIP_READING, lip, _cfg("l"))
 
-        await orch.process(_SESSION, _landmark_frame(), [_video_health()], ModalityPath.SPEECH, lambda _: None)
-
         sent: list[TranscriptSegment] = []
         await orch.process(_SESSION, _audio_chunk(), [_audio_health()], ModalityPath.SPEECH, sent.append)
+        for _ in range(30):
+            await orch.process(_SESSION, _landmark_frame(), [_video_health()], ModalityPath.SPEECH, sent.append)
+        await orch.flush_speech_pending(_SESSION, [_audio_health()], sent.append)
 
         assert any(s.status == SegmentStatus.PARTIAL for s in sent)
         final_segs = [s for s in sent if s.status == SegmentStatus.FINAL]
@@ -536,16 +525,8 @@ class TestProcessSpeech:
         partial = next(s for s in sent if s.status == SegmentStatus.PARTIAL)
         assert final_segs[0].replaces_segment_id == partial.segment_id
 
-    async def test_lip_partial_carries_audio_chunk_timing(self):
-        """Lip-reading PARTIAL is stamped with AudioFeatureChunk timing."""
-        chunk = AudioFeatureChunk(
-            session_id=_SESSION,
-            timestamp_ms=3000,
-            features=[[0.1]] * 5,
-            feature_type="mfcc",
-            sample_rate_hz=16000,
-            chunk_duration_ms=500,
-        )
+    async def test_lip_partial_fires_after_30_face_frames_during_speech(self):
+        """Lip PARTIAL fires once 30 face frames accumulate during a speech period."""
         lip = _StubEngine(
             _result(ModalityType.LIP_READING, "hello", 0.80), model_id="l"
         )
@@ -553,26 +534,23 @@ class TestProcessSpeech:
 
         orch = FusionOrchestrator()
         orch.register_policy(ModalityPath.SPEECH, SpeechFusionPolicy())
-        orch.register_engine(
-            ModalityPath.SPEECH, ModalityType.LIP_READING, lip, _cfg("l")
-        )
-
-        await orch.process(
-            _SESSION,
-            _landmark_frame(),
-            [_video_health()],
-            ModalityPath.SPEECH,
-            lambda _: None,
-        )
+        orch.register_engine(ModalityPath.SPEECH, ModalityType.LIP_READING, lip, _cfg("l"))
 
         sent: list[TranscriptSegment] = []
-        await orch.process(
-            _SESSION, chunk, [_audio_health()], ModalityPath.SPEECH, sent.append
-        )
+        # Speech audio marks is_speaking=True.
+        await orch.process(_SESSION, _audio_chunk(), [_audio_health()], ModalityPath.SPEECH, sent.append)
+        assert sent == []  # no lip yet
 
+        # 29 frames — not enough to fire.
+        for _ in range(29):
+            await orch.process(_SESSION, _landmark_frame(), [_video_health()], ModalityPath.SPEECH, sent.append)
+        assert sent == []
+
+        # 30th frame triggers lip inference → PARTIAL.
+        await orch.process(_SESSION, _landmark_frame(), [_video_health()], ModalityPath.SPEECH, sent.append)
         assert len(sent) == 1
-        assert sent[0].timestamp_ms == 3000
-        assert sent[0].duration_ms == 500
+        assert sent[0].status == SegmentStatus.PARTIAL
+        assert sent[0].timestamp_ms > 0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #53

## What does this PR do?

Replaces per-chunk single-frame lip inference with a 30-frame windowed accumulator gated on speech energy. Face frames are collected only while audio energy exceeds the speech threshold (`max > 0.3`); the face buffer is cleared on silence so frames are never sent to the model between utterances. Lip inference fires once per 30-frame window, producing a PARTIAL that is fused with the next ASR FINAL.

## Which package(s) does it touch?

`sozia.server.fusion`

## How to test

```
python -m pytest tests/fusion/ -q
```

Manual: speak a sentence and check server logs — `LIP result` lines should appear roughly every 1 s during speech only, not on every audio chunk and not during silence.

## Checklist

- [x] Follows commit convention (`<type>(<scope>): <description>`)
- [x] Added/updated tests (if applicable)
- [x] No sozia.common schema changes (or: both repos updated)
- [x] Tested locally