### PR TITLE
test(fusion): add silence gating tests for face frame accumulator

### DIFF
--- a/tests/fusion/test_orchestrator_process.py
+++ b/tests/fusion/test_orchestrator_process.py
@@ -552,6 +552,64 @@ class TestProcessSpeech:
         assert sent[0].status == SegmentStatus.PARTIAL
         assert sent[0].timestamp_ms > 0
 
+    async def test_landmark_frames_during_silence_do_not_trigger_lip(self):
+        # Silence audio chunk → is_speaking=False. Landmark frames must not accumulate.
+        lip = _StubEngine(_result(ModalityType.LIP_READING, "hello", 0.80), model_id="l")
+        lip._loaded = True
+
+        orch = FusionOrchestrator()
+        orch.register_policy(ModalityPath.SPEECH, SpeechFusionPolicy())
+        orch.register_engine(ModalityPath.SPEECH, ModalityType.LIP_READING, lip, _cfg("l"))
+
+        silence_chunk = AudioFeatureChunk(
+            session_id=_SESSION,
+            timestamp_ms=0,
+            features=[[-1.0, -1.0]] * 100,
+            feature_type="mfcc",
+            sample_rate_hz=16000,
+            chunk_duration_ms=500,
+        )
+
+        sent: list[TranscriptSegment] = []
+        await orch.process(_SESSION, silence_chunk, [_audio_health()], ModalityPath.SPEECH, sent.append)
+        for _ in range(30):
+            await orch.process(_SESSION, _landmark_frame(), [_video_health()], ModalityPath.SPEECH, sent.append)
+
+        assert sent == []
+
+    async def test_silence_after_speech_clears_face_buffer(self):
+        # Partial face buffer accumulated during speech is discarded on silence.
+        lip = _StubEngine(_result(ModalityType.LIP_READING, "hello", 0.80), model_id="l")
+        lip._loaded = True
+
+        orch = FusionOrchestrator()
+        orch.register_policy(ModalityPath.SPEECH, SpeechFusionPolicy())
+        orch.register_engine(ModalityPath.SPEECH, ModalityType.LIP_READING, lip, _cfg("l"))
+
+        silence_chunk = AudioFeatureChunk(
+            session_id=_SESSION,
+            timestamp_ms=0,
+            features=[[-1.0, -1.0]] * 100,
+            feature_type="mfcc",
+            sample_rate_hz=16000,
+            chunk_duration_ms=500,
+        )
+
+        sent: list[TranscriptSegment] = []
+        # Accumulate 20 face frames during speech.
+        await orch.process(_SESSION, _audio_chunk(), [_audio_health()], ModalityPath.SPEECH, sent.append)
+        for _ in range(20):
+            await orch.process(_SESSION, _landmark_frame(), [_video_health()], ModalityPath.SPEECH, sent.append)
+
+        # Silence clears the buffer.
+        await orch.process(_SESSION, silence_chunk, [_audio_health()], ModalityPath.SPEECH, sent.append)
+
+        # 30 more landmark frames during silence — must not trigger lip.
+        for _ in range(30):
+            await orch.process(_SESSION, _landmark_frame(), [_video_health()], ModalityPath.SPEECH, sent.append)
+
+        assert sent == []
+
 
 # ---------------------------------------------------------------------------
 # process() — Path B (SIGN)


### PR DESCRIPTION
Closes #55

## What does this PR do?

Adds two tests verifying that the face frame accumulator correctly gates on speech energy: landmark frames during silence are not accumulated, and a partial buffer is cleared when silence is detected after speech.

## Which package(s) does it touch?

`sozia.server.fusion`

## How to test

```
python -m pytest tests/fusion/test_orchestrator_process.py -q
```

## Checklist

- [x] Follows commit convention (`<type>(<scope>): <description>`)
- [x] Added/updated tests (if applicable)
- [x] No sozia.common schema changes (or: both repos updated)
- [x] Tested locally