### PR TITLE
fix(fusion): sign path live fixes + multi-word accumulation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,10 @@ torch>=2.0.0
 numpy>=1.24.0
 transformers>=4.40
 huggingface_hub>=0.20
+peft>=0.10.0
+accelerate>=0.30.0
+bitsandbytes>=0.43.0
+scikit-learn>=1.4.0
 
 # dev
 pytest>=8.0.0

--- a/sozia/server/__init__.py
+++ b/sozia/server/__init__.py
@@ -120,7 +120,7 @@ def _sign_configs(device: str) -> tuple[ModelConfig | None, ModelConfig | None]:
             model_id="gemma-9b-gloss-tr",
             weights_path=gloss_path,
             device=device,
-            params={},
+            params={"merged": True},
         )
         if gloss_path
         else None

--- a/sozia/server/fusion/__init__.py
+++ b/sozia/server/fusion/__init__.py
@@ -1,17 +1,23 @@
 """sozia.fusion — fusion layer for the Sozia server."""
 
+from sozia.server.fusion.activity_detector import ADEvent, ActivityDetector
 from sozia.server.fusion.degraded_mode_handler import DegradedModeHandler, DegradedStatus
 from sozia.server.fusion.frame_accumulator import FEATURE_DIM, FrameAccumulator
+from sozia.server.fusion.gloss_accumulator import GlossAccumulator, GlossEntry
 from sozia.server.fusion.orchestrator import FusionOrchestrator
 from sozia.server.fusion.sign_fusion_policy import SignFusionPolicy
 from sozia.server.fusion.speech_fusion_policy import SpeechFusionPolicy
 
 __all__ = [
+    "ADEvent",
+    "ActivityDetector",
     "DegradedModeHandler",
     "DegradedStatus",
     "FEATURE_DIM",
     "FrameAccumulator",
     "FusionOrchestrator",
+    "GlossAccumulator",
+    "GlossEntry",
     "SignFusionPolicy",
     "SpeechFusionPolicy",
 ]

--- a/sozia/server/fusion/__init__.py
+++ b/sozia/server/fusion/__init__.py
@@ -1,7 +1,10 @@
 """sozia.fusion — fusion layer for the Sozia server."""
 
 from sozia.server.fusion.activity_detector import ADEvent, ActivityDetector
-from sozia.server.fusion.degraded_mode_handler import DegradedModeHandler, DegradedStatus
+from sozia.server.fusion.degraded_mode_handler import (
+    DegradedModeHandler,
+    DegradedStatus,
+)
 from sozia.server.fusion.frame_accumulator import FEATURE_DIM, FrameAccumulator
 from sozia.server.fusion.gloss_accumulator import GlossAccumulator, GlossEntry
 from sozia.server.fusion.orchestrator import FusionOrchestrator

--- a/sozia/server/fusion/activity_detector.py
+++ b/sozia/server/fusion/activity_detector.py
@@ -28,10 +28,10 @@ _DEFAULT_DEACTIVATE_FRAMES: int = 5
 
 
 class ADEvent(Enum):
-    IDLE = "IDLE"        # inactive, no state change
+    IDLE = "IDLE"  # inactive, no state change
     STARTED = "STARTED"  # rising edge: inactive → active
-    ACTIVE = "ACTIVE"    # active, no state change
-    ENDED = "ENDED"      # falling edge: active → inactive
+    ACTIVE = "ACTIVE"  # active, no state change
+    ENDED = "ENDED"  # falling edge: active → inactive
 
 
 class ActivityDetector:
@@ -168,10 +168,16 @@ class ActivityDetector:
                 rw = pose[_RIGHT_WRIST_IDX]
                 wrists["right"] = (float(rw[0]), float(rw[1]))
         else:
-            if frame.left_hand_landmarks is not None and len(frame.left_hand_landmarks[0]) >= 2:
+            if (
+                frame.left_hand_landmarks is not None
+                and len(frame.left_hand_landmarks[0]) >= 2
+            ):
                 hw = frame.left_hand_landmarks[0]
                 wrists["left"] = (float(hw[0]), float(hw[1]))
-            if frame.right_hand_landmarks is not None and len(frame.right_hand_landmarks[0]) >= 2:
+            if (
+                frame.right_hand_landmarks is not None
+                and len(frame.right_hand_landmarks[0]) >= 2
+            ):
                 hw = frame.right_hand_landmarks[0]
                 wrists["right"] = (float(hw[0]), float(hw[1]))
 

--- a/sozia/server/fusion/activity_detector.py
+++ b/sozia/server/fusion/activity_detector.py
@@ -1,0 +1,178 @@
+"""ActivityDetector — per-session signing activity state machine.
+
+Determines whether a signer is actively signing by requiring both hand
+presence AND wrist motion above a velocity threshold. Hysteresis prevents
+per-frame flicker: ``activate_frames`` consecutive active frames are needed
+to enter the ACTIVE state, and ``deactivate_frames`` consecutive inactive
+frames to leave it.
+
+Sits upstream of FrameAccumulator in the sign pipeline.
+"""
+
+from __future__ import annotations
+
+import math
+from enum import Enum
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sozia.common.models import LandmarkFrame
+
+# Pose landmark indices for wrists (MediaPipe convention).
+_LEFT_WRIST_IDX = 15
+_RIGHT_WRIST_IDX = 16
+
+_DEFAULT_VELOCITY_THRESHOLD: float = 0.005
+_DEFAULT_ACTIVATE_FRAMES: int = 3
+_DEFAULT_DEACTIVATE_FRAMES: int = 5
+
+
+class ADEvent(Enum):
+    IDLE = "IDLE"        # inactive, no state change
+    STARTED = "STARTED"  # rising edge: inactive → active
+    ACTIVE = "ACTIVE"    # active, no state change
+    ENDED = "ENDED"      # falling edge: active → inactive
+
+
+class ActivityDetector:
+    """Per-session state machine for detecting signing activity.
+
+    Args:
+        velocity_threshold: Minimum wrist displacement (normalised coords) per
+            frame to count as motion. Default 0.005.
+        activate_frames: Consecutive active frames required to enter ACTIVE
+            state. Default 3.
+        deactivate_frames: Consecutive inactive frames required to leave ACTIVE
+            state. Default 5.
+    """
+
+    def __init__(
+        self,
+        velocity_threshold: float = _DEFAULT_VELOCITY_THRESHOLD,
+        activate_frames: int = _DEFAULT_ACTIVATE_FRAMES,
+        deactivate_frames: int = _DEFAULT_DEACTIVATE_FRAMES,
+    ) -> None:
+        if activate_frames < 1:
+            raise ValueError(f"activate_frames must be >= 1, got {activate_frames}")
+        if deactivate_frames < 1:
+            raise ValueError(f"deactivate_frames must be >= 1, got {deactivate_frames}")
+        self._velocity_threshold = velocity_threshold
+        self._activate_frames = activate_frames
+        self._deactivate_frames = deactivate_frames
+
+        # Per-session per-side previous wrist positions: sid → {"left": (x,y), "right": (x,y)}
+        self._prev_wrists: dict[str, dict[str, tuple[float, float]]] = {}
+        self._active_count: dict[str, int] = {}
+        self._inactive_count: dict[str, int] = {}
+        self._is_active: dict[str, bool] = {}
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def update(self, frame: LandmarkFrame) -> ADEvent:
+        """Process one LandmarkFrame and return the current AD event.
+
+        Args:
+            frame: Incoming frame from the WebSocket gateway.
+
+        Returns:
+            ADEvent reflecting the current activity state transition.
+        """
+        sid = frame.session_id
+        has_hands = (
+            frame.left_hand_landmarks is not None
+            or frame.right_hand_landmarks is not None
+        )
+
+        current_wrists = self._get_all_wrists(frame)
+        prev_wrists = self._prev_wrists.get(sid, {})
+
+        # Max velocity across both wrists; each side compared against its own prev.
+        velocity = 0.0
+        for side, pos in current_wrists.items():
+            prev = prev_wrists.get(side)
+            if prev is not None:
+                velocity = max(velocity, math.hypot(pos[0] - prev[0], pos[1] - prev[1]))
+
+        # Update previous wrist positions; clear when nothing visible to avoid stale
+        # velocity spike when the signer re-enters the frame after an absence.
+        if current_wrists:
+            self._prev_wrists[sid] = current_wrists
+        else:
+            self._prev_wrists.pop(sid, None)
+
+        frame_active = has_hands and velocity > self._velocity_threshold
+
+        is_active = self._is_active.get(sid, False)
+        active_count = self._active_count.get(sid, 0)
+        inactive_count = self._inactive_count.get(sid, 0)
+
+        if frame_active:
+            active_count += 1
+            inactive_count = 0
+            self._active_count[sid] = active_count
+            self._inactive_count[sid] = 0
+
+            if not is_active and active_count >= self._activate_frames:
+                self._is_active[sid] = True
+                self._active_count[sid] = 0
+                return ADEvent.STARTED
+
+            return ADEvent.ACTIVE if is_active else ADEvent.IDLE
+
+        else:
+            inactive_count += 1
+            active_count = 0
+            self._active_count[sid] = 0
+            self._inactive_count[sid] = inactive_count
+
+            if is_active and inactive_count >= self._deactivate_frames:
+                self._is_active[sid] = False
+                self._inactive_count[sid] = 0
+                return ADEvent.ENDED
+
+            return ADEvent.ACTIVE if is_active else ADEvent.IDLE
+
+    def is_active(self, session_id: str) -> bool:
+        """Return whether ``session_id`` is currently in the ACTIVE state."""
+        return self._is_active.get(session_id, False)
+
+    def reset(self, session_id: str) -> None:
+        """Clear all state for ``session_id``. Safe to call on unknown sessions."""
+        self._prev_wrists.pop(session_id, None)
+        self._active_count.pop(session_id, None)
+        self._inactive_count.pop(session_id, None)
+        self._is_active.pop(session_id, None)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _get_all_wrists(frame: LandmarkFrame) -> dict[str, tuple[float, float]]:
+        """Extract available wrist positions from a frame.
+
+        Returns a dict with keys ``"left"`` and/or ``"right"``. Prefers pose
+        landmarks (indices 15/16) over hand landmarks (index 0) when pose is
+        present. Returns an empty dict when no wrist data is available.
+        """
+        wrists: dict[str, tuple[float, float]] = {}
+
+        if frame.pose_landmarks is not None:
+            pose = frame.pose_landmarks
+            if len(pose) > _LEFT_WRIST_IDX and len(pose[_LEFT_WRIST_IDX]) >= 2:
+                lw = pose[_LEFT_WRIST_IDX]
+                wrists["left"] = (float(lw[0]), float(lw[1]))
+            if len(pose) > _RIGHT_WRIST_IDX and len(pose[_RIGHT_WRIST_IDX]) >= 2:
+                rw = pose[_RIGHT_WRIST_IDX]
+                wrists["right"] = (float(rw[0]), float(rw[1]))
+        else:
+            if frame.left_hand_landmarks is not None and len(frame.left_hand_landmarks[0]) >= 2:
+                hw = frame.left_hand_landmarks[0]
+                wrists["left"] = (float(hw[0]), float(hw[1]))
+            if frame.right_hand_landmarks is not None and len(frame.right_hand_landmarks[0]) >= 2:
+                hw = frame.right_hand_landmarks[0]
+                wrists["right"] = (float(hw[0]), float(hw[1]))
+
+        return wrists

--- a/sozia/server/fusion/frame_accumulator.py
+++ b/sozia/server/fusion/frame_accumulator.py
@@ -60,12 +60,14 @@ def _flatten_pose(arr: list[list[float]] | None) -> np.ndarray:
 
 def _frame_to_row(frame: LandmarkFrame) -> np.ndarray:
     """Convert a single LandmarkFrame to a 1-D feature vector of length FEATURE_DIM."""
-    return np.concatenate([
-        _flatten_pose(frame.pose_landmarks),
-        _flatten_or_zeros(frame.face_landmarks, FACE_LANDMARK_COUNT),
-        _flatten_or_zeros(frame.left_hand_landmarks, HAND_LANDMARK_COUNT),
-        _flatten_or_zeros(frame.right_hand_landmarks, HAND_LANDMARK_COUNT),
-    ])
+    return np.concatenate(
+        [
+            _flatten_pose(frame.pose_landmarks),
+            _flatten_or_zeros(frame.face_landmarks, FACE_LANDMARK_COUNT),
+            _flatten_or_zeros(frame.left_hand_landmarks, HAND_LANDMARK_COUNT),
+            _flatten_or_zeros(frame.right_hand_landmarks, HAND_LANDMARK_COUNT),
+        ]
+    )
 
 
 class FrameAccumulator:
@@ -83,9 +85,12 @@ class FrameAccumulator:
             Defaults to 30, matching a typical ~1 s window at 30 fps.
     """
 
+    _MIN_FLUSH_FRAMES: int = 10  # ignore flushes shorter than this
+
     def __init__(self, window_size: int = 30) -> None:
         self._window_size = window_size
         self._buffers: dict[str, list[LandmarkFrame]] = {}
+        self._prev_hands: dict[str, bool] = {}  # last known hand-presence per session
 
     # ------------------------------------------------------------------
     # Public API
@@ -94,19 +99,40 @@ class FrameAccumulator:
     def add(self, frame: LandmarkFrame) -> np.ndarray | None:
         """Append a frame to the session buffer.
 
+        Flushes the buffer early when hands disappear after being present
+        (falling edge), so a sign is never split across two windows.
+        Flushes at window_size normally.
+
         Args:
             frame: A LandmarkFrame received from the WebSocket gateway.
 
         Returns:
-            A numpy array of shape ``(window_size, FEATURE_DIM)`` when the
-            buffer reaches ``window_size``, otherwise ``None``.
+            A numpy array of shape ``(T, FEATURE_DIM)`` on flush, else ``None``.
         """
-        buf = self._buffers.setdefault(frame.session_id, [])
+        sid = frame.session_id
+        buf = self._buffers.setdefault(sid, [])
+        has_hands = (
+            frame.left_hand_landmarks is not None
+            or frame.right_hand_landmarks is not None
+        )
+        prev_hands = self._prev_hands.get(sid, False)
+        self._prev_hands[sid] = has_hands
+
+        # Falling edge: hands just disappeared — flush what we have.
+        if prev_hands and not has_hands:
+            if len(buf) >= self._MIN_FLUSH_FRAMES:
+                batch = self._to_numpy(buf)
+                self._buffers[sid] = []
+                return batch
+            # Too few frames — discard noise.
+            self._buffers[sid] = []
+            return None
+
         buf.append(frame)
 
         if len(buf) >= self._window_size:
             batch = self._to_numpy(buf)
-            self._buffers[frame.session_id] = []
+            self._buffers[sid] = []
             return batch
 
         return None
@@ -120,6 +146,7 @@ class FrameAccumulator:
             session_id: The session whose buffer should be cleared.
         """
         self._buffers.pop(session_id, None)
+        self._prev_hands.pop(session_id, None)
 
     def pending_count(self, session_id: str) -> int:
         """Return the number of frames currently buffered for a session.

--- a/sozia/server/fusion/frame_accumulator.py
+++ b/sozia/server/fusion/frame_accumulator.py
@@ -7,17 +7,15 @@ when the window threshold is reached (R7: buffering and inference triggering
 stay inside sozia.server.fusion, not the gateway).
 
 Feature vector layout per frame (concatenated; zero-filled if absent):
-    pose:       33 × 3 =  99 dims
+    pose:       33 × 4 = 132 dims  (x, y, z, visibility)
     face:       83 × 3 = 249 dims
     left_hand:  21 × 3 =  63 dims
     right_hand: 21 × 3 =  63 dims
     ────────────────────────────
-    total:               474 dims
+    total:               507 dims
 
-Note: the sozia-research training pipeline uses 507 dims because pose carries
-a 4th visibility float. The wire format (LandmarkFrame) only stores [x, y, z],
-so the server-side feature vector is 474 dims. Trained models must be
-configured with feature_dim=474. (Deviation DEV-05 in lld-deviations.md.)
+Pose landmarks carry a 4th visibility component matching the sozia-research
+training pipeline and the client extraction output.
 """
 
 from __future__ import annotations
@@ -33,7 +31,7 @@ from sozia.common.models import (
 
 # Flat feature vector length per frame — derived from LandmarkFrame structure.
 FEATURE_DIM: int = (
-    POSE_LANDMARK_COUNT * 3
+    POSE_LANDMARK_COUNT * 4  # x, y, z, visibility
     + FACE_LANDMARK_COUNT * 3
     + HAND_LANDMARK_COUNT * 3  # left hand
     + HAND_LANDMARK_COUNT * 3  # right hand
@@ -41,18 +39,29 @@ FEATURE_DIM: int = (
 
 
 def _flatten_or_zeros(
-    arr: list[list[float]] | None, count: int
+    arr: list[list[float]] | None, count: int, components: int = 3
 ) -> np.ndarray:
     """Return flattened landmark array or a zero vector if absent."""
     if arr is None:
-        return np.zeros(count * 3, dtype=np.float32)
+        return np.zeros(count * components, dtype=np.float32)
     return np.asarray(arr, dtype=np.float32).ravel()
+
+
+def _flatten_pose(arr: list[list[float]] | None) -> np.ndarray:
+    """Return 33×4 pose vector. Pads visibility=1.0 if client sends only x,y,z."""
+    if arr is None:
+        return np.zeros(POSE_LANDMARK_COUNT * 4, dtype=np.float32)
+    rows = []
+    for lm in arr:
+        rows.extend(lm[:3])
+        rows.append(lm[3] if len(lm) >= 4 else 1.0)
+    return np.array(rows, dtype=np.float32)
 
 
 def _frame_to_row(frame: LandmarkFrame) -> np.ndarray:
     """Convert a single LandmarkFrame to a 1-D feature vector of length FEATURE_DIM."""
     return np.concatenate([
-        _flatten_or_zeros(frame.pose_landmarks, POSE_LANDMARK_COUNT),
+        _flatten_pose(frame.pose_landmarks),
         _flatten_or_zeros(frame.face_landmarks, FACE_LANDMARK_COUNT),
         _flatten_or_zeros(frame.left_hand_landmarks, HAND_LANDMARK_COUNT),
         _flatten_or_zeros(frame.right_hand_landmarks, HAND_LANDMARK_COUNT),

--- a/sozia/server/fusion/frame_accumulator.py
+++ b/sozia/server/fusion/frame_accumulator.py
@@ -91,6 +91,7 @@ class FrameAccumulator:
         self._window_size = window_size
         self._buffers: dict[str, list[LandmarkFrame]] = {}
         self._prev_hands: dict[str, bool] = {}  # last known hand-presence per session
+        self._hands_in_window: dict[str, bool] = {}  # any hands seen in current window
 
     # ------------------------------------------------------------------
     # Public API
@@ -117,23 +118,29 @@ class FrameAccumulator:
         )
         prev_hands = self._prev_hands.get(sid, False)
         self._prev_hands[sid] = has_hands
+        if has_hands:
+            self._hands_in_window[sid] = True
 
         # Falling edge: hands just disappeared — flush what we have.
         if prev_hands and not has_hands:
-            if len(buf) >= self._MIN_FLUSH_FRAMES:
+            if len(buf) >= self._MIN_FLUSH_FRAMES and self._hands_in_window.get(sid):
                 batch = self._to_numpy(buf)
                 self._buffers[sid] = []
+                self._hands_in_window[sid] = False
                 return batch
-            # Too few frames — discard noise.
+            # Too few frames or no hands — discard noise.
             self._buffers[sid] = []
+            self._hands_in_window[sid] = False
             return None
 
         buf.append(frame)
 
         if len(buf) >= self._window_size:
             batch = self._to_numpy(buf)
+            had_hands = self._hands_in_window.get(sid, False)
             self._buffers[sid] = []
-            return batch
+            self._hands_in_window[sid] = False
+            return batch if had_hands else None
 
         return None
 
@@ -147,6 +154,7 @@ class FrameAccumulator:
         """
         self._buffers.pop(session_id, None)
         self._prev_hands.pop(session_id, None)
+        self._hands_in_window.pop(session_id, None)
 
     def pending_count(self, session_id: str) -> int:
         """Return the number of frames currently buffered for a session.

--- a/sozia/server/fusion/frame_accumulator.py
+++ b/sozia/server/fusion/frame_accumulator.py
@@ -2,9 +2,11 @@
 
 TslRecognitionEngine.predict() expects a (T, feature_dim) numpy array — a
 multi-frame sequence. The WebSocket gateway delivers one LandmarkFrame per
-message. FrameAccumulator buffers frames per session and emits a numpy batch
-when the window threshold is reached (R7: buffering and inference triggering
-stay inside sozia.server.fusion, not the gateway).
+message. FrameAccumulator buffers frames per session and emits overlapping
+numpy batches using a rolling window (window_size=30, stride=10 by default).
+
+ActivityDetector decides whether the signer is active. FrameAccumulator only
+buffers and batches — no hands-presence gating here.
 
 Feature vector layout per frame (concatenated; zero-filled if absent):
     pose:       33 × 4 = 132 dims  (x, y, z, visibility)
@@ -29,7 +31,6 @@ from sozia.common.models import (
     LandmarkFrame,
 )
 
-# Flat feature vector length per frame — derived from LandmarkFrame structure.
 FEATURE_DIM: int = (
     POSE_LANDMARK_COUNT * 4  # x, y, z, visibility
     + FACE_LANDMARK_COUNT * 3
@@ -71,27 +72,32 @@ def _frame_to_row(frame: LandmarkFrame) -> np.ndarray:
 
 
 class FrameAccumulator:
-    """Buffers LandmarkFrame objects per session and emits numpy batches.
+    """Buffers LandmarkFrame objects per session and emits overlapping numpy batches.
 
-    Usage::
-
-        accumulator = FrameAccumulator(window_size=30)
-        batch = accumulator.add(frame)  # returns None until window is full
-        if batch is not None:
-            result = await tsl_engine.predict(batch)  # shape (30, 474)
+    Uses a rolling window: once window_size frames are collected, a batch is
+    emitted and the oldest stride frames are dropped. The buffer then retains
+    window_size - stride frames as the overlap for the next window.
 
     Args:
-        window_size: Number of frames to collect before emitting a batch.
-            Defaults to 30, matching a typical ~1 s window at 30 fps.
+        window_size: Number of frames per emitted batch. Defaults to 30.
+        stride: Frames dropped after each emission. Defaults to
+            ``min(10, window_size)`` when ``None``.
+            ``stride < window_size`` → overlapping windows.
+            ``stride == window_size`` → tumbling (non-overlapping) windows.
+
+    Raises:
+        ValueError: If an explicit stride is not in ``[1, window_size]``.
     """
 
-    _MIN_FLUSH_FRAMES: int = 10  # ignore flushes shorter than this
-
-    def __init__(self, window_size: int = 30) -> None:
+    def __init__(self, window_size: int = 30, stride: int | None = None) -> None:
+        effective_stride = stride if stride is not None else min(10, window_size)
+        if not (1 <= effective_stride <= window_size):
+            raise ValueError(
+                f"stride must be in [1, window_size]; got stride={effective_stride}, window_size={window_size}"
+            )
         self._window_size = window_size
+        self._stride = effective_stride
         self._buffers: dict[str, list[LandmarkFrame]] = {}
-        self._prev_hands: dict[str, bool] = {}  # last known hand-presence per session
-        self._hands_in_window: dict[str, bool] = {}  # any hands seen in current window
 
     # ------------------------------------------------------------------
     # Public API
@@ -100,47 +106,24 @@ class FrameAccumulator:
     def add(self, frame: LandmarkFrame) -> np.ndarray | None:
         """Append a frame to the session buffer.
 
-        Flushes the buffer early when hands disappear after being present
-        (falling edge), so a sign is never split across two windows.
-        Flushes at window_size normally.
+        Returns a batch when the rolling window is full. After emission, the
+        oldest stride frames are dropped and the buffer retains the overlap.
 
         Args:
             frame: A LandmarkFrame received from the WebSocket gateway.
 
         Returns:
-            A numpy array of shape ``(T, FEATURE_DIM)`` on flush, else ``None``.
+            A numpy array of shape ``(window_size, FEATURE_DIM)`` on flush,
+            else ``None``.
         """
         sid = frame.session_id
         buf = self._buffers.setdefault(sid, [])
-        has_hands = (
-            frame.left_hand_landmarks is not None
-            or frame.right_hand_landmarks is not None
-        )
-        prev_hands = self._prev_hands.get(sid, False)
-        self._prev_hands[sid] = has_hands
-        if has_hands:
-            self._hands_in_window[sid] = True
-
-        # Falling edge: hands just disappeared — flush what we have.
-        if prev_hands and not has_hands:
-            if len(buf) >= self._MIN_FLUSH_FRAMES and self._hands_in_window.get(sid):
-                batch = self._to_numpy(buf)
-                self._buffers[sid] = []
-                self._hands_in_window[sid] = False
-                return batch
-            # Too few frames or no hands — discard noise.
-            self._buffers[sid] = []
-            self._hands_in_window[sid] = False
-            return None
-
         buf.append(frame)
 
         if len(buf) >= self._window_size:
-            batch = self._to_numpy(buf)
-            had_hands = self._hands_in_window.get(sid, False)
-            self._buffers[sid] = []
-            self._hands_in_window[sid] = False
-            return batch if had_hands else None
+            batch = self._to_numpy(buf[: self._window_size])
+            self._buffers[sid] = buf[self._stride :]
+            return batch
 
         return None
 
@@ -153,8 +136,6 @@ class FrameAccumulator:
             session_id: The session whose buffer should be cleared.
         """
         self._buffers.pop(session_id, None)
-        self._prev_hands.pop(session_id, None)
-        self._hands_in_window.pop(session_id, None)
 
     def pending_count(self, session_id: str) -> int:
         """Return the number of frames currently buffered for a session.
@@ -163,7 +144,7 @@ class FrameAccumulator:
             session_id: Session to query.
 
         Returns:
-            Integer count in range ``[0, window_size)``.
+            Integer frame count.
         """
         return len(self._buffers.get(session_id, []))
 

--- a/sozia/server/fusion/gloss_accumulator.py
+++ b/sozia/server/fusion/gloss_accumulator.py
@@ -1,0 +1,109 @@
+"""GlossAccumulator — per-session TSL gloss phrase buffer.
+
+Collects TSL gloss words across multiple rolling-window inferences and builds
+a phrase to send to GlossToTextEngine once signing activity ends.
+
+Dedup rule: if the incoming word matches the last buffered word, the higher-
+confidence entry is kept. This collapses runs of overlapping-window predictions
+that produce the same gloss (e.g. three windows all returning "YEMEK" → one
+"YEMEK" entry at the best confidence).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class GlossEntry:
+    """Immutable record of a single TSL recognition result."""
+
+    text: str
+    confidence: float
+    timestamp_ms: int
+    duration_ms: int
+
+
+class GlossAccumulator:
+    """Buffers GlossEntry objects per session with consecutive-repeat dedup.
+
+    Args:
+        max_words: Maximum number of words to buffer per session before
+            rejecting new entries. Default 10.
+    """
+
+    def __init__(self, max_words: int = 10) -> None:
+        self._max_words = max_words
+        self._buffers: dict[str, list[GlossEntry]] = {}
+        self._partial_ids: dict[str, str] = {}
+
+    # ------------------------------------------------------------------
+    # Buffer operations
+    # ------------------------------------------------------------------
+
+    def push(self, session_id: str, entry: GlossEntry) -> bool:
+        """Add a gloss entry to the session buffer.
+
+        Dedup rule: if ``entry.text`` matches the last buffered word, the
+        entry with higher confidence wins. If the incoming entry wins, it
+        replaces the existing one and True is returned. If the existing entry
+        wins, the incoming one is dropped and False is returned.
+
+        If the buffer is at ``max_words`` and the entry is a new word, it is
+        dropped and False is returned.
+
+        Args:
+            session_id: Session to push into.
+            entry: The GlossEntry to add.
+
+        Returns:
+            True if the buffer state changed; False if the entry was dropped.
+        """
+        buf = self._buffers.setdefault(session_id, [])
+
+        if buf and buf[-1].text == entry.text:
+            if entry.confidence > buf[-1].confidence:
+                self._buffers[session_id] = buf[:-1] + [entry]
+                return True
+            return False
+
+        if len(buf) >= self._max_words:
+            return False
+
+        buf.append(entry)
+        return True
+
+    def peek(self, session_id: str) -> str:
+        """Return the accumulated phrase as a space-joined string."""
+        return " ".join(e.text for e in self._buffers.get(session_id, []))
+
+    def entries(self, session_id: str) -> list[GlossEntry]:
+        """Return a copy of the current buffer."""
+        return list(self._buffers.get(session_id, []))
+
+    def flush(self, session_id: str) -> list[GlossEntry]:
+        """Return all buffered entries and clear the buffer and partial ID."""
+        entries = list(self._buffers.pop(session_id, []))
+        self._partial_ids.pop(session_id, None)
+        return entries
+
+    def is_empty(self, session_id: str) -> bool:
+        """Return True if no entries are buffered for ``session_id``."""
+        return not self._buffers.get(session_id)
+
+    def reset(self, session_id: str) -> None:
+        """Clear buffer and partial ID for ``session_id``. Safe on unknown sessions."""
+        self._buffers.pop(session_id, None)
+        self._partial_ids.pop(session_id, None)
+
+    # ------------------------------------------------------------------
+    # Partial segment ID tracking
+    # ------------------------------------------------------------------
+
+    def set_partial_id(self, session_id: str, segment_id: str) -> None:
+        """Store the segment ID of the currently emitted PARTIAL."""
+        self._partial_ids[session_id] = segment_id
+
+    def pop_partial_id(self, session_id: str) -> str | None:
+        """Return and remove the stored PARTIAL segment ID, or None."""
+        return self._partial_ids.pop(session_id, None)

--- a/sozia/server/fusion/orchestrator.py
+++ b/sozia/server/fusion/orchestrator.py
@@ -441,17 +441,16 @@ class FusionOrchestrator:
         if not isinstance(features, LandmarkFrame):
             return  # SIGN path only accepts LandmarkFrame.
 
-        pending = self._accumulator.pending_count(session_id)
         batch = self._accumulator.add(features)
+        if batch is None:
+            return  # Window not full yet.
+
         logger.info(
-            "frame_accumulator: pending=%d/%d hands=%s",
-            pending + 1,
-            self._accumulator._window_size,
+            "frame_accumulator: flushed %d frames (hands=%s)",
+            batch.shape[0],
             features.left_hand_landmarks is not None
             or features.right_hand_landmarks is not None,
         )
-        if batch is None:
-            return  # Window not full yet.
 
         path_engines = self._engines.get(ModalityPath.SIGN, {})
         tsl_entry = path_engines.get(ModalityType.TSL_RECOGNITION)

--- a/sozia/server/fusion/orchestrator.py
+++ b/sozia/server/fusion/orchestrator.py
@@ -15,8 +15,6 @@ from __future__ import annotations
 import asyncio
 import dataclasses
 import logging
-import time
-import uuid
 from typing import TYPE_CHECKING, Awaitable, Callable
 
 logger = logging.getLogger(__name__)
@@ -32,12 +30,14 @@ from sozia.common.models import (
     ModalityType,
     ModelConfig,
     PipelineHealth,
-    SegmentStatus,
     TranscriptSegment,
 )
+from sozia.server.fusion.activity_detector import ADEvent, ActivityDetector
 from sozia.server.fusion.degraded_mode_handler import DegradedModeHandler
 from sozia.server.fusion.frame_accumulator import FrameAccumulator
+from sozia.server.fusion.gloss_accumulator import GlossAccumulator, GlossEntry
 from sozia.server.fusion.mel_accumulator import MelAccumulator
+from sozia.server.fusion.sign_fusion_policy import SignFusionPolicy
 from sozia.server.fusion.speech_fusion_policy import SpeechFusionPolicy
 
 if TYPE_CHECKING:
@@ -82,6 +82,9 @@ class FusionOrchestrator:
         degraded_handler: DegradedModeHandler | None = None,
         window_size: int = 30,
         mel_max_frames: int = 1500,
+        *,
+        activity_detector: ActivityDetector | None = None,
+        gloss_accumulator: GlossAccumulator | None = None,
     ) -> None:
         self._policies: dict[ModalityPath, FusionStrategy] = {}
         # Keyed by (path, modality_type) → (engine, config).
@@ -91,6 +94,8 @@ class FusionOrchestrator:
         self._degraded: DegradedModeHandler = degraded_handler or DegradedModeHandler()
         self._accumulator = FrameAccumulator(window_size=window_size)
         self._mel_accumulator = MelAccumulator(max_frames=mel_max_frames)
+        self._activity_detector: ActivityDetector = activity_detector or ActivityDetector()
+        self._gloss_accumulator: GlossAccumulator = gloss_accumulator or GlossAccumulator()
         # Per-session face landmark cache (SPEECH path — latest frame from client).
         self._face_cache: dict[str, np.ndarray] = {}
         # Face frames accumulated during speech periods for lip-reading batches.
@@ -157,6 +162,8 @@ class FusionOrchestrator:
         self._last_lip_result.pop(session_id, None)
         self._accumulator.reset(session_id)
         self._mel_accumulator.reset(session_id)
+        self._activity_detector.reset(session_id)
+        self._gloss_accumulator.reset(session_id)
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -441,134 +448,121 @@ class FusionOrchestrator:
         if not isinstance(features, LandmarkFrame):
             return  # SIGN path only accepts LandmarkFrame.
 
-        batch = self._accumulator.add(features)
-        if batch is None:
-            return  # Window not full yet.
-
-        logger.info(
-            "frame_accumulator: flushed %d frames (hands=%s)",
-            batch.shape[0],
-            features.left_hand_landmarks is not None
-            or features.right_hand_landmarks is not None,
-        )
+        event = self._activity_detector.update(features)
+        logger.info("AD event: session=%s event=%s", session_id, event.value)
 
         path_engines = self._engines.get(ModalityPath.SIGN, {})
         tsl_entry = path_engines.get(ModalityType.TSL_RECOGNITION)
         gloss_entry = path_engines.get(ModalityType.GLOSS_TO_TEXT)
 
-        if tsl_entry is None:
-            return
+        if event in (ADEvent.STARTED, ADEvent.ACTIVE):
+            batch = self._accumulator.add(features)
+            if batch is None:
+                return  # Window not full yet.
 
-        tsl_engine, _ = tsl_entry
+            if tsl_entry is None:
+                return
 
-        # Run TslRecognitionEngine → emit PARTIAL.
-        try:
-            tsl_result = await tsl_engine.predict(batch)
-        except InferenceTimeoutError:
-            logger.warning("TSL inference timed out — window discarded")
-            return  # No PARTIAL to emit without TSL output.
+            sign_policy = self._policies.get(ModalityPath.SIGN)
+            if not isinstance(sign_policy, SignFusionPolicy):
+                return
 
-        sign_policy = self._policies.get(ModalityPath.SIGN)
-        suppressed = sign_policy is not None and sign_policy.should_suppress(tsl_result)
-        logger.info(
-            "TSL result: gloss=%r confidence=%.4f latency=%dms suppressed=%s",
-            tsl_result.text,
-            tsl_result.confidence,
-            tsl_result.inference_latency_ms,
-            suppressed,
-        )
+            tsl_engine, _ = tsl_entry
+            try:
+                tsl_result = await tsl_engine.predict(batch)
+            except InferenceTimeoutError:
+                logger.warning("TSL inference timed out — window discarded")
+                return
 
-        if suppressed:
-            return  # Low-confidence TSL — skip GlossToText and emit nothing.
-
-        tsl_segments = await self.process_features(
-            session_id,
-            [tsl_result],
-            health,
-            ModalityPath.SIGN,
-        )
-        partial_id: str | None = None
-        for seg in tsl_segments:
-            if seg.status == SegmentStatus.PARTIAL:
-                partial_id = seg.segment_id
-            await _maybe_await(send_fn(seg))
-
-        if gloss_entry is None:
-            return
-
-        gloss_engine, _ = gloss_entry
-
-        # Run GlossToTextEngine → emit FINAL.
-        try:
-            gloss_result = await gloss_engine.predict(tsl_result.text)
-        except InferenceTimeoutError:
-            logger.warning("GlossToText timed out — promoting gloss to FINAL")
-            # Promote TSL gloss to FINAL with a confidence penalty.
-            final_segs = self._promote_gloss_to_final(
-                session_id,
-                tsl_result,
-                partial_id,
+            logger.info(
+                "TSL result: gloss=%r confidence=%.4f latency=%dms",
+                tsl_result.text,
+                tsl_result.confidence,
+                tsl_result.inference_latency_ms,
             )
-            for seg in final_segs:
-                await _maybe_await(send_fn(seg))
-            return
 
-        logger.info(
-            "GlossToText result: text=%r confidence=%.4f latency=%dms",
-            gloss_result.text,
-            gloss_result.confidence,
-            gloss_result.inference_latency_ms,
-        )
+            if sign_policy.should_suppress(tsl_result):
+                return
 
-        final_segments = await self.process_features(
-            session_id,
-            [tsl_result, gloss_result],
-            health,
-            ModalityPath.SIGN,
-        )
-        for seg in final_segments:
-            await _maybe_await(send_fn(seg))
-
-    def _promote_gloss_to_final(
-        self,
-        session_id: str,
-        tsl_result: ModalityResult,
-        partial_id: str | None,
-    ) -> list[TranscriptSegment]:
-        """Produce a FINAL segment from a TSL result when GlossToText timed out.
-
-        Uses the raw gloss text as the final display text and applies a
-        confidence penalty to signal reduced quality.
-
-        Args:
-            session_id: Active session identifier.
-            tsl_result: The TSL result whose gloss becomes the FINAL text.
-            partial_id: The segment_id of the PARTIAL already emitted, if any.
-
-        Returns:
-            A list containing one FINAL TranscriptSegment (or empty if the
-            penalised confidence would be suppressed).
-        """
-        penalised = max(
-            0.0, tsl_result.confidence - _GLOSS_TIMEOUT_CONFIDENCE_DEDUCTION
-        )
-        if penalised <= 0.0:
-            return []
-
-        return [
-            TranscriptSegment(
-                segment_id=str(uuid.uuid4()),
-                session_id=session_id,
-                status=SegmentStatus.FINAL,
+            entry = GlossEntry(
                 text=tsl_result.text,
-                source=ModalityType.TSL_RECOGNITION,
-                confidence=round(penalised, 4),
+                confidence=tsl_result.confidence,
                 timestamp_ms=tsl_result.timestamp_ms,
                 duration_ms=tsl_result.duration_ms,
-                created_at_ms=int(time.time() * 1000),
-                replaces_segment_id=partial_id,
             )
-        ]
+            changed = self._gloss_accumulator.push(session_id, entry)
+            if not changed:
+                return  # Deduped — no new information, skip PARTIAL update.
+
+            phrase = self._gloss_accumulator.peek(session_id)
+            prev_id = self._gloss_accumulator.pop_partial_id(session_id)
+            seg = sign_policy.emit_partial(session_id, phrase, tsl_result, replaces_id=prev_id)
+            self._gloss_accumulator.set_partial_id(session_id, seg.segment_id)
+            logger.info("Emitting PARTIAL: text=%r replaces=%s", phrase, prev_id)
+            await _maybe_await(send_fn(seg))
+
+        elif event == ADEvent.ENDED:
+            if self._gloss_accumulator.is_empty(session_id):
+                return
+
+            sign_policy = self._policies.get(ModalityPath.SIGN)
+            if not isinstance(sign_policy, SignFusionPolicy):
+                return
+
+            # Pop partial_id before flush clears it internally.
+            prev_id = self._gloss_accumulator.pop_partial_id(session_id)
+            entries = self._gloss_accumulator.flush(session_id)
+            phrase = " ".join(e.text for e in entries)
+            aggregate_conf = min(e.confidence for e in entries)
+            timestamp_ms = entries[0].timestamp_ms
+            duration_ms = sum(e.duration_ms for e in entries)
+
+            logger.info(
+                "AD ENDED: flushing phrase=%r agg_conf=%.4f",
+                phrase,
+                aggregate_conf,
+            )
+
+            seg: TranscriptSegment
+            if gloss_entry is not None:
+                gloss_engine, _ = gloss_entry
+                try:
+                    llm_result = await gloss_engine.predict(phrase)
+                    logger.info(
+                        "GlossToText result: text=%r confidence=%.4f latency=%dms",
+                        llm_result.text,
+                        llm_result.confidence,
+                        llm_result.inference_latency_ms,
+                    )
+                    if sign_policy.should_suppress_llm(llm_result):
+                        seg = sign_policy.emit_final_from_gloss(
+                            session_id, phrase, aggregate_conf,
+                            timestamp_ms, duration_ms, prev_id,
+                        )
+                    else:
+                        seg = sign_policy.emit_final_from_llm(
+                            session_id, phrase, llm_result, prev_id,
+                        )
+                except InferenceTimeoutError:
+                    logger.warning("GlossToText timed out — using raw gloss as FINAL")
+                    penalised = max(
+                        0.0, aggregate_conf - _GLOSS_TIMEOUT_CONFIDENCE_DEDUCTION
+                    )
+                    seg = sign_policy.emit_final_from_gloss(
+                        session_id, phrase, penalised,
+                        timestamp_ms, duration_ms, prev_id,
+                    )
+            else:
+                seg = sign_policy.emit_final_from_gloss(
+                    session_id, phrase, aggregate_conf,
+                    timestamp_ms, duration_ms, prev_id,
+                )
+
+            self._accumulator.reset(session_id)
+            logger.info("Emitting FINAL: text=%r replaces=%s", seg.text, prev_id)
+            await _maybe_await(send_fn(seg))
+
+        # ADEvent.IDLE — no output.
 
     # ------------------------------------------------------------------
     # Internal fusion helper (kept public for existing test compatibility)

--- a/sozia/server/fusion/orchestrator.py
+++ b/sozia/server/fusion/orchestrator.py
@@ -384,7 +384,9 @@ class FusionOrchestrator:
         features: AudioFeatureChunk | None = None,
     ) -> None:
         if asr_batch.shape[0] < 100:
-            logger.debug("asr_batch too short (%d frames), skipping", asr_batch.shape[0])
+            logger.debug(
+                "asr_batch too short (%d frames), skipping", asr_batch.shape[0]
+            )
             return
         path_engines = self._engines.get(ModalityPath.SPEECH, {})
         asr_entry = path_engines.get(ModalityType.ASR)
@@ -401,12 +403,15 @@ class FusionOrchestrator:
             )
             if asr_result.confidence < 0.30:
                 logger.info(
-                    "ASR result suppressed (confidence=%.4f < 0.30)", asr_result.confidence
+                    "ASR result suppressed (confidence=%.4f < 0.30)",
+                    asr_result.confidence,
                 )
                 return
             asr_result = dataclasses.replace(
                 asr_result,
-                timestamp_ms=features.timestamp_ms if features is not None else int(time.time() * 1000),
+                timestamp_ms=features.timestamp_ms
+                if features is not None
+                else int(time.time() * 1000),
                 duration_ms=features.chunk_duration_ms if features is not None else 0,
             )
             policy = self._policies.get(ModalityPath.SPEECH)
@@ -418,7 +423,9 @@ class FusionOrchestrator:
                         lip_cached.text,
                         lip_cached.confidence,
                     )
-                    asr_segments = policy.emit_fused_final(asr_result, lip_cached, session_id)
+                    asr_segments = policy.emit_fused_final(
+                        asr_result, lip_cached, session_id
+                    )
                 else:
                     logger.info("ASR flush: no lip cached → standalone ASR FINAL")
                     asr_segments = policy.emit_asr_final(asr_result, session_id)
@@ -441,7 +448,10 @@ class FusionOrchestrator:
                     for seg in policy.promote_partial_to_final(session_id, lip_cached):
                         await _maybe_await(send_fn(seg))
             else:
-                logger.warning("ASR timeout: no lip cached, segment lost for session %s", session_id)
+                logger.warning(
+                    "ASR timeout: no lip cached, segment lost for session %s",
+                    session_id,
+                )
 
     async def _process_sign(
         self,

--- a/sozia/server/fusion/orchestrator.py
+++ b/sozia/server/fusion/orchestrator.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import asyncio
 import dataclasses
 import logging
+import time
 from typing import TYPE_CHECKING, Awaitable, Callable
 
 logger = logging.getLogger(__name__)
@@ -94,8 +95,12 @@ class FusionOrchestrator:
         self._degraded: DegradedModeHandler = degraded_handler or DegradedModeHandler()
         self._accumulator = FrameAccumulator(window_size=window_size)
         self._mel_accumulator = MelAccumulator(max_frames=mel_max_frames)
-        self._activity_detector: ActivityDetector = activity_detector or ActivityDetector()
-        self._gloss_accumulator: GlossAccumulator = gloss_accumulator or GlossAccumulator()
+        self._activity_detector: ActivityDetector = (
+            activity_detector or ActivityDetector()
+        )
+        self._gloss_accumulator: GlossAccumulator = (
+            gloss_accumulator or GlossAccumulator()
+        )
         # Per-session face landmark cache (SPEECH path — latest frame from client).
         self._face_cache: dict[str, np.ndarray] = {}
         # Face frames accumulated during speech periods for lip-reading batches.
@@ -496,7 +501,9 @@ class FusionOrchestrator:
 
             phrase = self._gloss_accumulator.peek(session_id)
             prev_id = self._gloss_accumulator.pop_partial_id(session_id)
-            seg = sign_policy.emit_partial(session_id, phrase, tsl_result, replaces_id=prev_id)
+            seg = sign_policy.emit_partial(
+                session_id, phrase, tsl_result, replaces_id=prev_id
+            )
             self._gloss_accumulator.set_partial_id(session_id, seg.segment_id)
             logger.info("Emitting PARTIAL: text=%r replaces=%s", phrase, prev_id)
             await _maybe_await(send_fn(seg))
@@ -536,12 +543,19 @@ class FusionOrchestrator:
                     )
                     if sign_policy.should_suppress_llm(llm_result):
                         seg = sign_policy.emit_final_from_gloss(
-                            session_id, phrase, aggregate_conf,
-                            timestamp_ms, duration_ms, prev_id,
+                            session_id,
+                            phrase,
+                            aggregate_conf,
+                            timestamp_ms,
+                            duration_ms,
+                            prev_id,
                         )
                     else:
                         seg = sign_policy.emit_final_from_llm(
-                            session_id, phrase, llm_result, prev_id,
+                            session_id,
+                            phrase,
+                            llm_result,
+                            prev_id,
                         )
                 except InferenceTimeoutError:
                     logger.warning("GlossToText timed out — using raw gloss as FINAL")
@@ -549,13 +563,21 @@ class FusionOrchestrator:
                         0.0, aggregate_conf - _GLOSS_TIMEOUT_CONFIDENCE_DEDUCTION
                     )
                     seg = sign_policy.emit_final_from_gloss(
-                        session_id, phrase, penalised,
-                        timestamp_ms, duration_ms, prev_id,
+                        session_id,
+                        phrase,
+                        penalised,
+                        timestamp_ms,
+                        duration_ms,
+                        prev_id,
                     )
             else:
                 seg = sign_policy.emit_final_from_gloss(
-                    session_id, phrase, aggregate_conf,
-                    timestamp_ms, duration_ms, prev_id,
+                    session_id,
+                    phrase,
+                    aggregate_conf,
+                    timestamp_ms,
+                    duration_ms,
+                    prev_id,
                 )
 
             self._accumulator.reset(session_id)

--- a/sozia/server/fusion/orchestrator.py
+++ b/sozia/server/fusion/orchestrator.py
@@ -479,6 +479,9 @@ class FusionOrchestrator:
             suppressed,
         )
 
+        if suppressed:
+            return  # Low-confidence TSL — skip GlossToText and emit nothing.
+
         tsl_segments = await self.process_features(
             session_id,
             [tsl_result],

--- a/sozia/server/fusion/orchestrator.py
+++ b/sozia/server/fusion/orchestrator.py
@@ -441,7 +441,15 @@ class FusionOrchestrator:
         if not isinstance(features, LandmarkFrame):
             return  # SIGN path only accepts LandmarkFrame.
 
+        pending = self._accumulator.pending_count(session_id)
         batch = self._accumulator.add(features)
+        logger.info(
+            "frame_accumulator: pending=%d/%d hands=%s",
+            pending + 1,
+            self._accumulator._window_size,
+            features.left_hand_landmarks is not None
+            or features.right_hand_landmarks is not None,
+        )
         if batch is None:
             return  # Window not full yet.
 
@@ -458,7 +466,18 @@ class FusionOrchestrator:
         try:
             tsl_result = await tsl_engine.predict(batch)
         except InferenceTimeoutError:
+            logger.warning("TSL inference timed out — window discarded")
             return  # No PARTIAL to emit without TSL output.
+
+        sign_policy = self._policies.get(ModalityPath.SIGN)
+        suppressed = sign_policy is not None and sign_policy.should_suppress(tsl_result)
+        logger.info(
+            "TSL result: gloss=%r confidence=%.4f latency=%dms suppressed=%s",
+            tsl_result.text,
+            tsl_result.confidence,
+            tsl_result.inference_latency_ms,
+            suppressed,
+        )
 
         tsl_segments = await self.process_features(
             session_id,
@@ -481,6 +500,7 @@ class FusionOrchestrator:
         try:
             gloss_result = await gloss_engine.predict(tsl_result.text)
         except InferenceTimeoutError:
+            logger.warning("GlossToText timed out — promoting gloss to FINAL")
             # Promote TSL gloss to FINAL with a confidence penalty.
             final_segs = self._promote_gloss_to_final(
                 session_id,
@@ -490,6 +510,13 @@ class FusionOrchestrator:
             for seg in final_segs:
                 await _maybe_await(send_fn(seg))
             return
+
+        logger.info(
+            "GlossToText result: text=%r confidence=%.4f latency=%dms",
+            gloss_result.text,
+            gloss_result.confidence,
+            gloss_result.inference_latency_ms,
+        )
 
         final_segments = await self.process_features(
             session_id,

--- a/sozia/server/fusion/sign_fusion_policy.py
+++ b/sozia/server/fusion/sign_fusion_policy.py
@@ -25,7 +25,7 @@ from sozia.common.models import (
     TranscriptSegment,
 )
 
-_DEFAULT_CONFIDENCE_THRESHOLD = 0.30
+_DEFAULT_CONFIDENCE_THRESHOLD = 0.55
 
 
 class SignFusionPolicy(FusionStrategy):

--- a/sozia/server/fusion/sign_fusion_policy.py
+++ b/sozia/server/fusion/sign_fusion_policy.py
@@ -60,22 +60,32 @@ class SignFusionPolicy(FusionStrategy):
             return []
 
         tsl = next(
-            (r for r in results
-             if r.modality_type == ModalityType.TSL_RECOGNITION
-             and not self.should_suppress(r)),
+            (
+                r
+                for r in results
+                if r.modality_type == ModalityType.TSL_RECOGNITION
+                and not self.should_suppress(r)
+            ),
             None,
         )
         gloss = next(
-            (r for r in results
-             if r.modality_type == ModalityType.GLOSS_TO_TEXT
-             and not self.should_suppress_llm(r)),
+            (
+                r
+                for r in results
+                if r.modality_type == ModalityType.GLOSS_TO_TEXT
+                and not self.should_suppress_llm(r)
+            ),
             None,
         )
 
         session_id = health[0].session_id if health else ""
 
         if gloss:
-            return [self.emit_final_from_llm(session_id, gloss.text, gloss, replaces_id=None)]
+            return [
+                self.emit_final_from_llm(
+                    session_id, gloss.text, gloss, replaces_id=None
+                )
+            ]
         if tsl:
             return [self.emit_partial(session_id, tsl.text, tsl, replaces_id=None)]
         return []

--- a/sozia/server/fusion/sign_fusion_policy.py
+++ b/sozia/server/fusion/sign_fusion_policy.py
@@ -1,14 +1,20 @@
 """SignFusionPolicy — fusion strategy for the sign language pipeline.
 
 Sign path uses optimistic-then-revise:
-  1. TSL Recognition emits a raw gloss string (e.g. "MERHABA DUNYA") as a
-     PARTIAL segment.
-  2. GlossToText converts it to natural Turkish (e.g. "Merhaba dünya.") and
-     emits a FINAL segment that replaces the PARTIAL via replaces_segment_id.
+  1. TSL Recognition emits raw gloss words as PARTIAL segments (accumulated
+     by GlossAccumulator, replaced word-by-word).
+  2. GlossToText converts the full accumulated phrase to natural Turkish and
+     emits a FINAL segment that replaces the last PARTIAL.
 
-Unlike the speech path there is no weighted merge — GlossToText output fully
-replaces the gloss. If GlossToText is suppressed (low confidence), the raw
-gloss PARTIAL remains as the final output.
+The policy owns no per-session state — partial-ID bookkeeping lives in
+GlossAccumulator. The orchestrator calls the helper methods directly instead
+of going through fuse(); fuse() is kept for integration-test backward compat.
+
+Two separate confidence thresholds:
+  - TSL softmax:         _DEFAULT_CONFIDENCE_THRESHOLD   = 0.55
+  - GlossToText exp(LM): _DEFAULT_LLM_CONFIDENCE_THRESHOLD = 0.40
+    (beam sequences_scores are length-normalised log-probs → exp() yields
+    lower numeric values than softmax, so a lower gate makes sense)
 """
 
 from __future__ import annotations
@@ -26,6 +32,7 @@ from sozia.common.models import (
 )
 
 _DEFAULT_CONFIDENCE_THRESHOLD = 0.55
+_DEFAULT_LLM_CONFIDENCE_THRESHOLD = 0.40
 
 
 class SignFusionPolicy(FusionStrategy):
@@ -35,12 +42,13 @@ class SignFusionPolicy(FusionStrategy):
         self,
         *,
         confidence_threshold: float = _DEFAULT_CONFIDENCE_THRESHOLD,
+        llm_confidence_threshold: float = _DEFAULT_LLM_CONFIDENCE_THRESHOLD,
     ) -> None:
         self._confidence_threshold = confidence_threshold
-        self._partial_ids: dict[str, str] = {}
+        self._llm_confidence_threshold = llm_confidence_threshold
 
     # ------------------------------------------------------------------
-    # FusionStrategy interface
+    # FusionStrategy interface (backward compat — orchestrator uses helpers)
     # ------------------------------------------------------------------
 
     def fuse(
@@ -51,58 +59,107 @@ class SignFusionPolicy(FusionStrategy):
         if not results:
             return []
 
-        valid = [r for r in results if not self.should_suppress(r)]
-        if not valid:
-            return []
-
         tsl = next(
-            (r for r in valid if r.modality_type == ModalityType.TSL_RECOGNITION),
+            (r for r in results
+             if r.modality_type == ModalityType.TSL_RECOGNITION
+             and not self.should_suppress(r)),
             None,
         )
         gloss = next(
-            (r for r in valid if r.modality_type == ModalityType.GLOSS_TO_TEXT),
+            (r for r in results
+             if r.modality_type == ModalityType.GLOSS_TO_TEXT
+             and not self.should_suppress_llm(r)),
             None,
         )
 
         session_id = health[0].session_id if health else ""
 
         if gloss:
-            # GlossToText available → FINAL replacing the PARTIAL.
-            replaces = self._partial_ids.pop(session_id, None)
-            return [_make_segment(
-                session_id=session_id,
-                status=SegmentStatus.FINAL,
-                text=gloss.text,
-                source=ModalityType.GLOSS_TO_TEXT,
-                confidence=gloss.confidence,
-                timestamp_ms=gloss.timestamp_ms,
-                duration_ms=gloss.duration_ms,
-                replaces_segment_id=replaces,
-            )]
-
+            return [self.emit_final_from_llm(session_id, gloss.text, gloss, replaces_id=None)]
         if tsl:
-            # Only TSL available → PARTIAL with raw gloss.
-            seg_id = str(uuid.uuid4())
-            self._partial_ids[session_id] = seg_id
-            return [_make_segment(
-                session_id=session_id,
-                status=SegmentStatus.PARTIAL,
-                text=tsl.text,
-                source=ModalityType.TSL_RECOGNITION,
-                confidence=tsl.confidence,
-                timestamp_ms=tsl.timestamp_ms,
-                duration_ms=tsl.duration_ms,
-                replaces_segment_id=None,
-                segment_id=seg_id,
-            )]
-
+            return [self.emit_partial(session_id, tsl.text, tsl, replaces_id=None)]
         return []
 
+    # ------------------------------------------------------------------
+    # Suppress gates
+    # ------------------------------------------------------------------
+
     def should_suppress(self, result: ModalityResult) -> bool:
+        """True if TSL softmax confidence is below the TSL gate (0.55)."""
         return result.confidence < self._confidence_threshold
+
+    def should_suppress_llm(self, result: ModalityResult) -> bool:
+        """True if GlossToText beam confidence is below the LLM gate (0.40)."""
+        return result.confidence < self._llm_confidence_threshold
 
     def get_confidence_threshold(self) -> float:
         return self._confidence_threshold
+
+    def get_llm_confidence_threshold(self) -> float:
+        return self._llm_confidence_threshold
+
+    # ------------------------------------------------------------------
+    # Segment-building helpers (called directly by FusionOrchestrator)
+    # ------------------------------------------------------------------
+
+    def emit_partial(
+        self,
+        session_id: str,
+        gloss_phrase: str,
+        tsl_result: ModalityResult,
+        replaces_id: str | None,
+    ) -> TranscriptSegment:
+        """Build a PARTIAL segment for the current accumulated gloss phrase."""
+        return _make_segment(
+            session_id=session_id,
+            status=SegmentStatus.PARTIAL,
+            text=gloss_phrase,
+            source=ModalityType.TSL_RECOGNITION,
+            confidence=tsl_result.confidence,
+            timestamp_ms=tsl_result.timestamp_ms,
+            duration_ms=tsl_result.duration_ms,
+            replaces_segment_id=replaces_id,
+        )
+
+    def emit_final_from_llm(
+        self,
+        session_id: str,
+        gloss_phrase: str,
+        llm_result: ModalityResult,
+        replaces_id: str | None,
+    ) -> TranscriptSegment:
+        """Build a FINAL segment from a successful GlossToText translation."""
+        return _make_segment(
+            session_id=session_id,
+            status=SegmentStatus.FINAL,
+            text=llm_result.text,
+            source=ModalityType.GLOSS_TO_TEXT,
+            confidence=llm_result.confidence,
+            timestamp_ms=llm_result.timestamp_ms,
+            duration_ms=llm_result.duration_ms,
+            replaces_segment_id=replaces_id,
+        )
+
+    def emit_final_from_gloss(
+        self,
+        session_id: str,
+        gloss_phrase: str,
+        aggregate_conf: float,
+        timestamp_ms: int,
+        duration_ms: int,
+        replaces_id: str | None,
+    ) -> TranscriptSegment:
+        """Build a FINAL segment from the raw gloss phrase (LLM timeout / low-conf fallback)."""
+        return _make_segment(
+            session_id=session_id,
+            status=SegmentStatus.FINAL,
+            text=gloss_phrase,
+            source=ModalityType.TSL_RECOGNITION,
+            confidence=aggregate_conf,
+            timestamp_ms=timestamp_ms,
+            duration_ms=duration_ms,
+            replaces_segment_id=replaces_id,
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -120,10 +177,9 @@ def _make_segment(
     timestamp_ms: int,
     duration_ms: int,
     replaces_segment_id: str | None,
-    segment_id: str | None = None,
 ) -> TranscriptSegment:
     return TranscriptSegment(
-        segment_id=segment_id or str(uuid.uuid4()),
+        segment_id=str(uuid.uuid4()),
         session_id=session_id,
         status=status,
         text=text,

--- a/sozia/server/inference/sign/gloss_to_text_engine.py
+++ b/sozia/server/inference/sign/gloss_to_text_engine.py
@@ -78,7 +78,8 @@ class GlossToTextEngine(InferenceEngine):
 
     async def load_model(self, config: ModelConfig) -> None:
         self._base_model_id = config.params.get(
-            "base_model_id", "google/gemma-2-9b-it",
+            "base_model_id",
+            "google/gemma-2-9b-it",
         )
         self._instruction = config.params.get("instruction", _DEFAULT_INSTRUCTION)
         self._max_new_tokens = config.params.get("max_new_tokens", 128)
@@ -183,7 +184,7 @@ class GlossToTextEngine(InferenceEngine):
 
         load_kwargs: dict[str, Any] = {
             "device_map": "auto" if device == "cuda" else None,
-            "torch_dtype": torch.bfloat16,
+            "dtype": torch.bfloat16,
             "attn_implementation": "sdpa",
         }
 
@@ -199,6 +200,7 @@ class GlossToTextEngine(InferenceEngine):
 
         if not merged:
             from peft import PeftModel
+
             model = PeftModel.from_pretrained(model, adapter_path)
 
         model.eval()

--- a/sozia/server/inference/sign/gloss_to_text_engine.py
+++ b/sozia/server/inference/sign/gloss_to_text_engine.py
@@ -86,6 +86,7 @@ class GlossToTextEngine(InferenceEngine):
         self._repetition_penalty = config.params.get("repetition_penalty", 1.15)
         self._use_autocast = config.params.get("use_autocast", True)
         load_in_4bit = config.params.get("load_in_4bit", True)
+        merged = config.params.get("merged", False)
 
         model, tokenizer = await asyncio.to_thread(
             self._load_model_sync,
@@ -93,6 +94,7 @@ class GlossToTextEngine(InferenceEngine):
             adapter_path=config.weights_path,
             device=config.device,
             load_in_4bit=load_in_4bit,
+            merged=merged,
         )
 
         self._model = model
@@ -170,11 +172,13 @@ class GlossToTextEngine(InferenceEngine):
         adapter_path: str,
         device: str,
         load_in_4bit: bool,
+        merged: bool = False,
     ) -> tuple:
         """Synchronous model + tokenizer loading (runs in thread)."""
         from transformers import AutoModelForCausalLM, AutoTokenizer
 
-        tokenizer = AutoTokenizer.from_pretrained(base_model_id)
+        model_path = adapter_path if merged else base_model_id
+        tokenizer = AutoTokenizer.from_pretrained(model_path)
         tokenizer.pad_token = tokenizer.eos_token
 
         load_kwargs: dict[str, Any] = {
@@ -191,13 +195,12 @@ class GlossToTextEngine(InferenceEngine):
                 bnb_4bit_compute_dtype=torch.bfloat16,
             )
 
-        base_model = AutoModelForCausalLM.from_pretrained(
-            base_model_id, **load_kwargs,
-        )
+        model = AutoModelForCausalLM.from_pretrained(model_path, **load_kwargs)
 
-        from peft import PeftModel
+        if not merged:
+            from peft import PeftModel
+            model = PeftModel.from_pretrained(model, adapter_path)
 
-        model = PeftModel.from_pretrained(base_model, adapter_path)
         model.eval()
         return model, tokenizer
 

--- a/sozia/server/inference/sign/gloss_to_text_engine.py
+++ b/sozia/server/inference/sign/gloss_to_text_engine.py
@@ -14,6 +14,7 @@ Latency budget: ≤ 2000 ms.
 from __future__ import annotations
 
 import asyncio
+import math
 import re
 import time
 from typing import TYPE_CHECKING, Any
@@ -126,7 +127,7 @@ class GlossToTextEngine(InferenceEngine):
         start = time.perf_counter()
 
         try:
-            raw_text = await asyncio.wait_for(
+            raw_text, confidence = await asyncio.wait_for(
                 asyncio.to_thread(self._generate, prompt),
                 timeout=timeout_ms / 1000.0,
             )
@@ -138,8 +139,8 @@ class GlossToTextEngine(InferenceEngine):
         latency_ms = int((time.perf_counter() - start) * 1000)
         text = _polish_turkish(raw_text)
 
-        # Confidence heuristic: non-empty output with proper ending → high.
-        confidence = 0.85 if text else 0.0
+        if not text:
+            confidence = 0.0
 
         return ModalityResult(
             modality_type=ModalityType.GLOSS_TO_TEXT,
@@ -206,7 +207,7 @@ class GlossToTextEngine(InferenceEngine):
         model.eval()
         return model, tokenizer
 
-    def _generate(self, prompt: str) -> str:
+    def _generate(self, prompt: str) -> tuple[str, float]:
         """Synchronous generation — runs in thread."""
         inputs = self._tokenizer(prompt, return_tensors="pt")
         input_ids = inputs.input_ids.to(self._device)
@@ -220,6 +221,8 @@ class GlossToTextEngine(InferenceEngine):
             "num_beams": self._beam_size,
             "repetition_penalty": self._repetition_penalty,
             "do_sample": False,
+            "return_dict_in_generate": True,
+            "output_scores": True,
         }
 
         with torch.no_grad():
@@ -229,8 +232,31 @@ class GlossToTextEngine(InferenceEngine):
             else:
                 outputs = self._model.generate(**gen_kwargs)
 
-        new_tokens = outputs[0][input_len:]
-        return self._tokenizer.decode(new_tokens, skip_special_tokens=True).strip()
+        new_tokens = outputs.sequences[0][input_len:]
+        text = self._tokenizer.decode(new_tokens, skip_special_tokens=True).strip()
+        confidence = _extract_confidence(outputs)
+        del outputs
+        return text, confidence
+
+
+# ---------------------------------------------------------------------------
+# Confidence extraction (mirrors WhisperAsrEngine._extract_confidence)
+# ---------------------------------------------------------------------------
+
+
+def _extract_confidence(output) -> float:
+    """Derive a [0, 1] confidence from beam generation output.
+
+    Uses ``sequences_scores`` (length-normalised sum of log-probs) when
+    available — the natural result of ``num_beams > 1`` with
+    ``return_dict_in_generate=True, output_scores=True``.
+    Falls back to ``exp(-1.0)`` ≈ 0.37 if the field is absent.
+    """
+    if hasattr(output, "sequences_scores") and output.sequences_scores is not None:
+        score = float(output.sequences_scores[0])
+    else:
+        score = -1.0
+    return max(0.0, min(1.0, math.exp(score)))
 
 
 # ---------------------------------------------------------------------------

--- a/sozia/server/inference/sign/tsl_recognition_engine.py
+++ b/sozia/server/inference/sign/tsl_recognition_engine.py
@@ -275,7 +275,7 @@ class TslRecognitionEngine(InferenceEngine):
         ckpt_path = run_dir / "best_model.pt"
         if not ckpt_path.exists():
             raise FileNotFoundError(f"No best_model.pt in {run_dir}")
-        state_dict = torch.load(ckpt_path, map_location=device, weights_only=True)
+        state_dict = torch.load(ckpt_path, map_location=device, weights_only=False)
         model.load_state_dict(state_dict)
         model.to(device)
         model.eval()

--- a/tests/fusion/test_activity_detector.py
+++ b/tests/fusion/test_activity_detector.py
@@ -2,9 +2,6 @@
 
 from __future__ import annotations
 
-import math
-
-import pytest
 
 from sozia.common.models import (
     HAND_LANDMARK_COUNT,
@@ -124,7 +121,9 @@ class TestIdleNoHands:
     def test_never_becomes_active_without_hands(self):
         detector = ActivityDetector(activate_frames=2)
         events = [
-            detector.update(_make_frame(timestamp_ms=i, pose=_pose_at(float(i), float(i))))
+            detector.update(
+                _make_frame(timestamp_ms=i, pose=_pose_at(float(i), float(i)))
+            )
             for i in range(20)
         ]
         assert all(e == ADEvent.IDLE for e in events)
@@ -231,17 +230,27 @@ class TestActiveState:
         detector = ActivityDetector(activate_frames=n, deactivate_frames=100)
 
         # Anchor frame.
-        detector.update(_make_frame(timestamp_ms=0, pose=_pose_at(0.0, 0.0), left_hand=_hand_at(0.0, 0.0)))
+        detector.update(
+            _make_frame(
+                timestamp_ms=0, pose=_pose_at(0.0, 0.0), left_hand=_hand_at(0.0, 0.0)
+            )
+        )
 
         # Reach STARTED.
         for i in range(1, n + 1):
             x = i * 0.05
-            detector.update(_make_frame(timestamp_ms=i, pose=_pose_at(x, x), left_hand=_hand_at(x, x)))
+            detector.update(
+                _make_frame(
+                    timestamp_ms=i, pose=_pose_at(x, x), left_hand=_hand_at(x, x)
+                )
+            )
 
         # Subsequent active frames.
         for i in range(n + 1, n + 6):
             x = i * 0.05
-            frame = _make_frame(timestamp_ms=i, pose=_pose_at(x, x), left_hand=_hand_at(x, x))
+            frame = _make_frame(
+                timestamp_ms=i, pose=_pose_at(x, x), left_hand=_hand_at(x, x)
+            )
             event = detector.update(frame)
             assert event == ADEvent.ACTIVE, f"expected ACTIVE at frame {i}, got {event}"
 
@@ -251,10 +260,18 @@ class TestActiveState:
         assert not detector.is_active(_SESSION)
 
         # Bring detector to ACTIVE.
-        detector.update(_make_frame(timestamp_ms=0, pose=_pose_at(0.0, 0.0), left_hand=_hand_at(0.0, 0.0)))
+        detector.update(
+            _make_frame(
+                timestamp_ms=0, pose=_pose_at(0.0, 0.0), left_hand=_hand_at(0.0, 0.0)
+            )
+        )
         for i in range(1, n + 1):
             x = i * 0.05
-            detector.update(_make_frame(timestamp_ms=i, pose=_pose_at(x, x), left_hand=_hand_at(x, x)))
+            detector.update(
+                _make_frame(
+                    timestamp_ms=i, pose=_pose_at(x, x), left_hand=_hand_at(x, x)
+                )
+            )
 
         assert detector.is_active(_SESSION)
 
@@ -267,18 +284,26 @@ class TestActiveState:
 class TestFallingEdge:
     def _reach_active(self, detector: ActivityDetector, activate_frames: int) -> int:
         """Drive detector to ACTIVE state; return next timestamp to use."""
-        detector.update(_make_frame(timestamp_ms=0, pose=_pose_at(0.0, 0.0), left_hand=_hand_at(0.0, 0.0)))
+        detector.update(
+            _make_frame(
+                timestamp_ms=0, pose=_pose_at(0.0, 0.0), left_hand=_hand_at(0.0, 0.0)
+            )
+        )
         for i in range(1, activate_frames + 1):
             x = i * 0.05
             detector.update(
-                _make_frame(timestamp_ms=i, pose=_pose_at(x, x), left_hand=_hand_at(x, x))
+                _make_frame(
+                    timestamp_ms=i, pose=_pose_at(x, x), left_hand=_hand_at(x, x)
+                )
             )
         return activate_frames + 1
 
     def test_ended_fires_on_nth_inactive_frame(self):
         deactivate_n = 4
         activate_n = 2
-        detector = ActivityDetector(activate_frames=activate_n, deactivate_frames=deactivate_n)
+        detector = ActivityDetector(
+            activate_frames=activate_n, deactivate_frames=deactivate_n
+        )
         next_ts = self._reach_active(detector, activate_n)
 
         # Feed deactivate_n frames with no hands.
@@ -298,7 +323,9 @@ class TestFallingEdge:
         """A single active frame mid-deactivation resets the counter."""
         deactivate_n = 3
         activate_n = 2
-        detector = ActivityDetector(activate_frames=activate_n, deactivate_frames=deactivate_n)
+        detector = ActivityDetector(
+            activate_frames=activate_n, deactivate_frames=deactivate_n
+        )
         next_ts = self._reach_active(detector, activate_n)
 
         def inactive(ts: int) -> LandmarkFrame:
@@ -329,38 +356,64 @@ class TestIdleAfterEnded:
     def test_idle_events_follow_ended(self):
         activate_n = 2
         deactivate_n = 2
-        detector = ActivityDetector(activate_frames=activate_n, deactivate_frames=deactivate_n)
+        detector = ActivityDetector(
+            activate_frames=activate_n, deactivate_frames=deactivate_n
+        )
 
         # Reach ACTIVE.
-        detector.update(_make_frame(timestamp_ms=0, pose=_pose_at(0.0, 0.0), left_hand=_hand_at(0.0, 0.0)))
+        detector.update(
+            _make_frame(
+                timestamp_ms=0, pose=_pose_at(0.0, 0.0), left_hand=_hand_at(0.0, 0.0)
+            )
+        )
         for i in range(1, activate_n + 1):
             x = i * 0.05
-            detector.update(_make_frame(timestamp_ms=i, pose=_pose_at(x, x), left_hand=_hand_at(x, x)))
+            detector.update(
+                _make_frame(
+                    timestamp_ms=i, pose=_pose_at(x, x), left_hand=_hand_at(x, x)
+                )
+            )
 
         # Reach ENDED.
         next_ts = activate_n + 1
         for i in range(deactivate_n):
-            detector.update(_make_frame(timestamp_ms=next_ts + i, pose=_pose_at(0.5, 0.5)))
+            detector.update(
+                _make_frame(timestamp_ms=next_ts + i, pose=_pose_at(0.5, 0.5))
+            )
         next_ts += deactivate_n
 
         # Additional inactive frames should all be IDLE.
         for i in range(5):
-            ev = detector.update(_make_frame(timestamp_ms=next_ts + i, pose=_pose_at(0.5, 0.5)))
+            ev = detector.update(
+                _make_frame(timestamp_ms=next_ts + i, pose=_pose_at(0.5, 0.5))
+            )
             assert ev == ADEvent.IDLE, f"expected IDLE after ENDED, got {ev}"
 
     def test_is_active_returns_false_after_ended(self):
         activate_n = 2
         deactivate_n = 2
-        detector = ActivityDetector(activate_frames=activate_n, deactivate_frames=deactivate_n)
+        detector = ActivityDetector(
+            activate_frames=activate_n, deactivate_frames=deactivate_n
+        )
 
-        detector.update(_make_frame(timestamp_ms=0, pose=_pose_at(0.0, 0.0), left_hand=_hand_at(0.0, 0.0)))
+        detector.update(
+            _make_frame(
+                timestamp_ms=0, pose=_pose_at(0.0, 0.0), left_hand=_hand_at(0.0, 0.0)
+            )
+        )
         for i in range(1, activate_n + 1):
             x = i * 0.05
-            detector.update(_make_frame(timestamp_ms=i, pose=_pose_at(x, x), left_hand=_hand_at(x, x)))
+            detector.update(
+                _make_frame(
+                    timestamp_ms=i, pose=_pose_at(x, x), left_hand=_hand_at(x, x)
+                )
+            )
 
         next_ts = activate_n + 1
         for i in range(deactivate_n):
-            detector.update(_make_frame(timestamp_ms=next_ts + i, pose=_pose_at(0.5, 0.5)))
+            detector.update(
+                _make_frame(timestamp_ms=next_ts + i, pose=_pose_at(0.5, 0.5))
+            )
 
         assert not detector.is_active(_SESSION)
 
@@ -374,13 +427,23 @@ class TestHysteresis:
     def test_single_inactive_frame_does_not_end_activity(self):
         activate_n = 2
         deactivate_n = 4  # grace period is 4 frames
-        detector = ActivityDetector(activate_frames=activate_n, deactivate_frames=deactivate_n)
+        detector = ActivityDetector(
+            activate_frames=activate_n, deactivate_frames=deactivate_n
+        )
 
         # Reach ACTIVE state.
-        detector.update(_make_frame(timestamp_ms=0, pose=_pose_at(0.0, 0.0), left_hand=_hand_at(0.0, 0.0)))
+        detector.update(
+            _make_frame(
+                timestamp_ms=0, pose=_pose_at(0.0, 0.0), left_hand=_hand_at(0.0, 0.0)
+            )
+        )
         for i in range(1, activate_n + 1):
             x = i * 0.05
-            detector.update(_make_frame(timestamp_ms=i, pose=_pose_at(x, x), left_hand=_hand_at(x, x)))
+            detector.update(
+                _make_frame(
+                    timestamp_ms=i, pose=_pose_at(x, x), left_hand=_hand_at(x, x)
+                )
+            )
 
         next_ts = activate_n + 1
 
@@ -392,28 +455,42 @@ class TestHysteresis:
         # Resume activity — still ACTIVE (or STARTED again if implementation re-arms, but not IDLE/ENDED).
         next_ts += 1
         resume_x = 0.9
-        ev = detector.update(_make_frame(
-            timestamp_ms=next_ts,
-            pose=_pose_at(resume_x, resume_x),
-            left_hand=_hand_at(resume_x, resume_x),
-        ))
+        ev = detector.update(
+            _make_frame(
+                timestamp_ms=next_ts,
+                pose=_pose_at(resume_x, resume_x),
+                left_hand=_hand_at(resume_x, resume_x),
+            )
+        )
         assert ev in (ADEvent.ACTIVE, ADEvent.STARTED)
 
     def test_deactivate_frames_minus_one_inactive_does_not_end(self):
         activate_n = 2
         deactivate_n = 5
-        detector = ActivityDetector(activate_frames=activate_n, deactivate_frames=deactivate_n)
+        detector = ActivityDetector(
+            activate_frames=activate_n, deactivate_frames=deactivate_n
+        )
 
-        detector.update(_make_frame(timestamp_ms=0, pose=_pose_at(0.0, 0.0), left_hand=_hand_at(0.0, 0.0)))
+        detector.update(
+            _make_frame(
+                timestamp_ms=0, pose=_pose_at(0.0, 0.0), left_hand=_hand_at(0.0, 0.0)
+            )
+        )
         for i in range(1, activate_n + 1):
             x = i * 0.05
-            detector.update(_make_frame(timestamp_ms=i, pose=_pose_at(x, x), left_hand=_hand_at(x, x)))
+            detector.update(
+                _make_frame(
+                    timestamp_ms=i, pose=_pose_at(x, x), left_hand=_hand_at(x, x)
+                )
+            )
 
         next_ts = activate_n + 1
         events = []
         # Feed deactivate_n - 1 inactive frames → must NOT include ENDED.
         for i in range(deactivate_n - 1):
-            ev = detector.update(_make_frame(timestamp_ms=next_ts + i, pose=_pose_at(0.5, 0.5)))
+            ev = detector.update(
+                _make_frame(timestamp_ms=next_ts + i, pose=_pose_at(0.5, 0.5))
+            )
             events.append(ev)
 
         assert ADEvent.ENDED not in events
@@ -462,7 +539,9 @@ class TestPoseWristFallback:
             velocity_threshold=0.005, activate_frames=activate_n, deactivate_frames=10
         )
 
-        detector.update(_make_frame(timestamp_ms=0, pose=None, right_hand=_hand_at(0.1, 0.1)))
+        detector.update(
+            _make_frame(timestamp_ms=0, pose=None, right_hand=_hand_at(0.1, 0.1))
+        )
 
         events = []
         for i in range(1, activate_n + 1):
@@ -483,10 +562,24 @@ class TestMultiSessionIsolation:
         detector = ActivityDetector(activate_frames=2, deactivate_frames=10)
 
         # Drive session A to ACTIVE.
-        detector.update(_make_frame(session_id=_SESSION, timestamp_ms=0, pose=_pose_at(0.0, 0.0), left_hand=_hand_at(0.0, 0.0)))
+        detector.update(
+            _make_frame(
+                session_id=_SESSION,
+                timestamp_ms=0,
+                pose=_pose_at(0.0, 0.0),
+                left_hand=_hand_at(0.0, 0.0),
+            )
+        )
         for i in range(1, 3):
             x = i * 0.05
-            detector.update(_make_frame(session_id=_SESSION, timestamp_ms=i, pose=_pose_at(x, x), left_hand=_hand_at(x, x)))
+            detector.update(
+                _make_frame(
+                    session_id=_SESSION,
+                    timestamp_ms=i,
+                    pose=_pose_at(x, x),
+                    left_hand=_hand_at(x, x),
+                )
+            )
 
         assert detector.is_active(_SESSION)
         # Session B has received no frames — must not be active.
@@ -496,10 +589,24 @@ class TestMultiSessionIsolation:
         detector = ActivityDetector(activate_frames=2, deactivate_frames=10)
 
         # Activate B.
-        detector.update(_make_frame(session_id=_SESSION_B, timestamp_ms=0, pose=_pose_at(0.0, 0.0), left_hand=_hand_at(0.0, 0.0)))
+        detector.update(
+            _make_frame(
+                session_id=_SESSION_B,
+                timestamp_ms=0,
+                pose=_pose_at(0.0, 0.0),
+                left_hand=_hand_at(0.0, 0.0),
+            )
+        )
         for i in range(1, 3):
             x = i * 0.05
-            detector.update(_make_frame(session_id=_SESSION_B, timestamp_ms=i, pose=_pose_at(x, x), left_hand=_hand_at(x, x)))
+            detector.update(
+                _make_frame(
+                    session_id=_SESSION_B,
+                    timestamp_ms=i,
+                    pose=_pose_at(x, x),
+                    left_hand=_hand_at(x, x),
+                )
+            )
 
         # A has never seen a frame.
         assert not detector.is_active(_SESSION)
@@ -509,10 +616,24 @@ class TestMultiSessionIsolation:
         detector = ActivityDetector(activate_frames=activate_n, deactivate_frames=10)
 
         for sid in (_SESSION, _SESSION_B):
-            detector.update(_make_frame(session_id=sid, timestamp_ms=0, pose=_pose_at(0.0, 0.0), left_hand=_hand_at(0.0, 0.0)))
+            detector.update(
+                _make_frame(
+                    session_id=sid,
+                    timestamp_ms=0,
+                    pose=_pose_at(0.0, 0.0),
+                    left_hand=_hand_at(0.0, 0.0),
+                )
+            )
             for i in range(1, activate_n + 1):
                 x = i * 0.05
-                detector.update(_make_frame(session_id=sid, timestamp_ms=i, pose=_pose_at(x, x), left_hand=_hand_at(x, x)))
+                detector.update(
+                    _make_frame(
+                        session_id=sid,
+                        timestamp_ms=i,
+                        pose=_pose_at(x, x),
+                        left_hand=_hand_at(x, x),
+                    )
+                )
 
         assert detector.is_active(_SESSION)
         assert detector.is_active(_SESSION_B)
@@ -533,10 +654,18 @@ class TestReset:
         detector = ActivityDetector(activate_frames=activate_n, deactivate_frames=10)
 
         # Reach ACTIVE.
-        detector.update(_make_frame(timestamp_ms=0, pose=_pose_at(0.0, 0.0), left_hand=_hand_at(0.0, 0.0)))
+        detector.update(
+            _make_frame(
+                timestamp_ms=0, pose=_pose_at(0.0, 0.0), left_hand=_hand_at(0.0, 0.0)
+            )
+        )
         for i in range(1, activate_n + 1):
             x = i * 0.05
-            detector.update(_make_frame(timestamp_ms=i, pose=_pose_at(x, x), left_hand=_hand_at(x, x)))
+            detector.update(
+                _make_frame(
+                    timestamp_ms=i, pose=_pose_at(x, x), left_hand=_hand_at(x, x)
+                )
+            )
 
         assert detector.is_active(_SESSION)
 
@@ -548,14 +677,26 @@ class TestReset:
         activate_n = 1
         detector = ActivityDetector(activate_frames=activate_n, deactivate_frames=10)
 
-        detector.update(_make_frame(timestamp_ms=0, pose=_pose_at(0.0, 0.0), left_hand=_hand_at(0.0, 0.0)))
-        detector.update(_make_frame(timestamp_ms=1, pose=_pose_at(0.5, 0.5), left_hand=_hand_at(0.5, 0.5)))
+        detector.update(
+            _make_frame(
+                timestamp_ms=0, pose=_pose_at(0.0, 0.0), left_hand=_hand_at(0.0, 0.0)
+            )
+        )
+        detector.update(
+            _make_frame(
+                timestamp_ms=1, pose=_pose_at(0.5, 0.5), left_hand=_hand_at(0.5, 0.5)
+            )
+        )
         # Now ACTIVE (activate_frames=1).
 
         detector.reset(_SESSION)
 
         # First frame after reset: no prior position → velocity = 0.
-        ev = detector.update(_make_frame(timestamp_ms=2, pose=_pose_at(0.9, 0.9), left_hand=_hand_at(0.9, 0.9)))
+        ev = detector.update(
+            _make_frame(
+                timestamp_ms=2, pose=_pose_at(0.9, 0.9), left_hand=_hand_at(0.9, 0.9)
+            )
+        )
         assert ev == ADEvent.IDLE
 
     def test_reset_unknown_session_is_noop(self):
@@ -568,12 +709,24 @@ class TestReset:
         detector = ActivityDetector(activate_frames=activate_n, deactivate_frames=10)
 
         # Feed 2 active frames (one short of STARTED).
-        detector.update(_make_frame(timestamp_ms=0, pose=_pose_at(0.0, 0.0), left_hand=_hand_at(0.0, 0.0)))
-        detector.update(_make_frame(timestamp_ms=1, pose=_pose_at(0.1, 0.1), left_hand=_hand_at(0.1, 0.1)))
+        detector.update(
+            _make_frame(
+                timestamp_ms=0, pose=_pose_at(0.0, 0.0), left_hand=_hand_at(0.0, 0.0)
+            )
+        )
+        detector.update(
+            _make_frame(
+                timestamp_ms=1, pose=_pose_at(0.1, 0.1), left_hand=_hand_at(0.1, 0.1)
+            )
+        )
 
         detector.reset(_SESSION)
 
         # After reset, the accumulated count must be gone — one more active frame
         # alone must NOT trigger STARTED (needs activate_n fresh frames).
-        ev = detector.update(_make_frame(timestamp_ms=2, pose=_pose_at(0.2, 0.2), left_hand=_hand_at(0.2, 0.2)))
+        ev = detector.update(
+            _make_frame(
+                timestamp_ms=2, pose=_pose_at(0.2, 0.2), left_hand=_hand_at(0.2, 0.2)
+            )
+        )
         assert ev == ADEvent.IDLE

--- a/tests/fusion/test_activity_detector.py
+++ b/tests/fusion/test_activity_detector.py
@@ -1,0 +1,579 @@
+"""Tests for ActivityDetector — RED phase (implementation does not exist yet)."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from sozia.common.models import (
+    HAND_LANDMARK_COUNT,
+    POSE_LANDMARK_COUNT,
+    LandmarkFrame,
+)
+from sozia.server.fusion.activity_detector import ADEvent, ActivityDetector
+
+# ---------------------------------------------------------------------------
+# Session ID fixtures
+# ---------------------------------------------------------------------------
+
+_SESSION = "aaaaaaaa-0000-4000-a000-000000000001"
+_SESSION_B = "bbbbbbbb-0000-4000-b000-000000000002"
+
+# ---------------------------------------------------------------------------
+# Frame-construction helpers
+# ---------------------------------------------------------------------------
+
+
+def _pose_at(wx: float = 0.5, wy: float = 0.5) -> list[list[float]]:
+    """Build a minimal 33-point pose array.
+
+    Indices 15 (left wrist) and 16 (right wrist) are set to (wx, wy, 0.0).
+    All other points are (0.0, 0.0, 0.0).
+    """
+    points = [[0.0, 0.0, 0.0]] * POSE_LANDMARK_COUNT
+    # list is shared — replace with distinct lists to avoid aliasing
+    points = [list(p) for p in points]
+    points[15] = [wx, wy, 0.0]
+    points[16] = [wx, wy, 0.0]
+    return points
+
+
+def _hand_at(wx: float = 0.5, wy: float = 0.5) -> list[list[float]]:
+    """Build a 21-point hand array with wrist (index 0) at (wx, wy, 0.0)."""
+    points = [[0.0, 0.0, 0.0]] * HAND_LANDMARK_COUNT
+    points = [list(p) for p in points]
+    points[0] = [wx, wy, 0.0]
+    return points
+
+
+def _make_frame(
+    session_id: str = _SESSION,
+    timestamp_ms: int = 0,
+    pose: list[list[float]] | None = None,
+    left_hand: list[list[float]] | None = None,
+    right_hand: list[list[float]] | None = None,
+) -> LandmarkFrame:
+    """Construct a minimal LandmarkFrame.
+
+    At least one landmark array must be non-null (LandmarkFrame invariant).
+    When all three explicit args are None, pose defaults to _pose_at() so the
+    frame is valid.
+    """
+    if pose is None and left_hand is None and right_hand is None:
+        pose = _pose_at()
+    return LandmarkFrame(
+        session_id=session_id,
+        timestamp_ms=timestamp_ms,
+        face_landmarks=None,
+        left_hand_landmarks=left_hand,
+        right_hand_landmarks=right_hand,
+        pose_landmarks=pose,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helper: feed N frames with the same wrist position and hands present
+# ---------------------------------------------------------------------------
+
+
+def _feed_active_frames(
+    detector: ActivityDetector,
+    n: int,
+    session_id: str = _SESSION,
+    wx: float = 0.5,
+    wy: float = 0.5,
+    start_ts: int = 0,
+    step: float = 0.01,
+) -> list[ADEvent]:
+    """Feed *n* frames that have hands present and increasing wrist position.
+
+    Each successive frame moves the wrist by *step* in both x and y so that
+    velocity > default threshold (0.005).
+    """
+    events = []
+    for i in range(n):
+        x = wx + i * step
+        y = wy + i * step
+        frame = _make_frame(
+            session_id=session_id,
+            timestamp_ms=start_ts + i,
+            pose=_pose_at(x, y),
+            left_hand=_hand_at(x, y),
+        )
+        events.append(detector.update(frame))
+    return events
+
+
+# ===========================================================================
+# 1. IDLE when no hands present
+# ===========================================================================
+
+
+class TestIdleNoHands:
+    def test_returns_idle_with_no_hand_landmarks(self):
+        detector = ActivityDetector()
+        for i in range(10):
+            frame = _make_frame(
+                timestamp_ms=i,
+                pose=_pose_at(0.1 * i, 0.1 * i),  # pose present, no hands
+            )
+            event = detector.update(frame)
+            assert event == ADEvent.IDLE, f"frame {i}: expected IDLE, got {event}"
+
+    def test_never_becomes_active_without_hands(self):
+        detector = ActivityDetector(activate_frames=2)
+        events = [
+            detector.update(_make_frame(timestamp_ms=i, pose=_pose_at(float(i), float(i))))
+            for i in range(20)
+        ]
+        assert all(e == ADEvent.IDLE for e in events)
+
+
+# ===========================================================================
+# 2. IDLE when hands present but no motion
+# ===========================================================================
+
+
+class TestIdleNoMotion:
+    def test_static_wrist_position_stays_idle(self):
+        detector = ActivityDetector(velocity_threshold=0.005)
+        # Same wrist position every frame — velocity is 0.
+        hand = _hand_at(0.5, 0.5)
+        pose = _pose_at(0.5, 0.5)
+        for i in range(10):
+            frame = _make_frame(timestamp_ms=i, pose=pose, left_hand=hand)
+            event = detector.update(frame)
+            assert event == ADEvent.IDLE, f"frame {i}: expected IDLE, got {event}"
+
+    def test_sub_threshold_motion_stays_idle(self):
+        """Velocity below threshold should not activate."""
+        detector = ActivityDetector(velocity_threshold=0.1, activate_frames=2)
+        # Move wrist by 0.001 per frame — well below 0.1 threshold.
+        for i in range(10):
+            x = 0.5 + i * 0.001
+            frame = _make_frame(
+                timestamp_ms=i,
+                pose=_pose_at(x, x),
+                left_hand=_hand_at(x, x),
+            )
+            event = detector.update(frame)
+            assert event == ADEvent.IDLE
+
+
+# ===========================================================================
+# 3. Rising edge — STARTED fires on exactly the Nth consecutive active frame
+# ===========================================================================
+
+
+class TestRisingEdge:
+    def test_started_fires_on_nth_active_frame(self):
+        n = 3
+        detector = ActivityDetector(activate_frames=n, deactivate_frames=5)
+
+        # First frame: no previous position → velocity = 0 → IDLE.
+        first = _make_frame(
+            timestamp_ms=0, pose=_pose_at(0.1, 0.1), left_hand=_hand_at(0.1, 0.1)
+        )
+        assert detector.update(first) == ADEvent.IDLE
+
+        # Subsequent frames with motion.  STARTED must appear on frame index n
+        # (counting from 1 after the anchor frame).
+        events = []
+        for i in range(1, n + 1):
+            x = 0.1 + i * 0.05
+            frame = _make_frame(
+                timestamp_ms=i,
+                pose=_pose_at(x, x),
+                left_hand=_hand_at(x, x),
+            )
+            events.append(detector.update(frame))
+
+        # Frames 1 .. n-1 should be IDLE (not yet enough consecutive frames)
+        for idx, ev in enumerate(events[:-1]):
+            assert ev == ADEvent.IDLE, f"premature activation at sub-frame {idx + 1}"
+
+        # Frame n should be STARTED.
+        assert events[-1] == ADEvent.STARTED
+
+    def test_started_requires_consecutive_frames(self):
+        """A gap in activity resets the consecutive counter."""
+        detector = ActivityDetector(activate_frames=3, deactivate_frames=100)
+
+        def active_frame(ts: int, x: float) -> LandmarkFrame:
+            return _make_frame(
+                timestamp_ms=ts, pose=_pose_at(x, x), left_hand=_hand_at(x, x)
+            )
+
+        def idle_frame(ts: int) -> LandmarkFrame:
+            # No hands — no activity.
+            return _make_frame(timestamp_ms=ts, pose=_pose_at(0.5, 0.5))
+
+        # 2 active, 1 idle, 2 active → counter reset → should not fire STARTED.
+        events = [
+            detector.update(active_frame(0, 0.10)),
+            detector.update(active_frame(1, 0.15)),
+            detector.update(idle_frame(2)),
+            detector.update(active_frame(3, 0.25)),
+            detector.update(active_frame(4, 0.30)),
+        ]
+        assert ADEvent.STARTED not in events
+
+
+# ===========================================================================
+# 4. ACTIVE continues after STARTED
+# ===========================================================================
+
+
+class TestActiveState:
+    def test_events_after_started_are_active(self):
+        n = 2
+        detector = ActivityDetector(activate_frames=n, deactivate_frames=100)
+
+        # Anchor frame.
+        detector.update(_make_frame(timestamp_ms=0, pose=_pose_at(0.0, 0.0), left_hand=_hand_at(0.0, 0.0)))
+
+        # Reach STARTED.
+        for i in range(1, n + 1):
+            x = i * 0.05
+            detector.update(_make_frame(timestamp_ms=i, pose=_pose_at(x, x), left_hand=_hand_at(x, x)))
+
+        # Subsequent active frames.
+        for i in range(n + 1, n + 6):
+            x = i * 0.05
+            frame = _make_frame(timestamp_ms=i, pose=_pose_at(x, x), left_hand=_hand_at(x, x))
+            event = detector.update(frame)
+            assert event == ADEvent.ACTIVE, f"expected ACTIVE at frame {i}, got {event}"
+
+    def test_is_active_returns_true_during_active_state(self):
+        n = 2
+        detector = ActivityDetector(activate_frames=n, deactivate_frames=100)
+        assert not detector.is_active(_SESSION)
+
+        # Bring detector to ACTIVE.
+        detector.update(_make_frame(timestamp_ms=0, pose=_pose_at(0.0, 0.0), left_hand=_hand_at(0.0, 0.0)))
+        for i in range(1, n + 1):
+            x = i * 0.05
+            detector.update(_make_frame(timestamp_ms=i, pose=_pose_at(x, x), left_hand=_hand_at(x, x)))
+
+        assert detector.is_active(_SESSION)
+
+
+# ===========================================================================
+# 5. Falling edge — ENDED fires on exactly the Nth consecutive inactive frame
+# ===========================================================================
+
+
+class TestFallingEdge:
+    def _reach_active(self, detector: ActivityDetector, activate_frames: int) -> int:
+        """Drive detector to ACTIVE state; return next timestamp to use."""
+        detector.update(_make_frame(timestamp_ms=0, pose=_pose_at(0.0, 0.0), left_hand=_hand_at(0.0, 0.0)))
+        for i in range(1, activate_frames + 1):
+            x = i * 0.05
+            detector.update(
+                _make_frame(timestamp_ms=i, pose=_pose_at(x, x), left_hand=_hand_at(x, x))
+            )
+        return activate_frames + 1
+
+    def test_ended_fires_on_nth_inactive_frame(self):
+        deactivate_n = 4
+        activate_n = 2
+        detector = ActivityDetector(activate_frames=activate_n, deactivate_frames=deactivate_n)
+        next_ts = self._reach_active(detector, activate_n)
+
+        # Feed deactivate_n frames with no hands.
+        events = []
+        for i in range(deactivate_n):
+            frame = _make_frame(timestamp_ms=next_ts + i, pose=_pose_at(0.5, 0.5))
+            events.append(detector.update(frame))
+
+        # First deactivate_n - 1 events should be ACTIVE (still in grace period).
+        for idx, ev in enumerate(events[:-1]):
+            assert ev == ADEvent.ACTIVE, f"premature ENDED at inactive frame {idx + 1}"
+
+        # Final frame triggers ENDED.
+        assert events[-1] == ADEvent.ENDED
+
+    def test_ended_requires_consecutive_inactive_frames(self):
+        """A single active frame mid-deactivation resets the counter."""
+        deactivate_n = 3
+        activate_n = 2
+        detector = ActivityDetector(activate_frames=activate_n, deactivate_frames=deactivate_n)
+        next_ts = self._reach_active(detector, activate_n)
+
+        def inactive(ts: int) -> LandmarkFrame:
+            return _make_frame(timestamp_ms=ts, pose=_pose_at(0.5, 0.5))
+
+        def active_frame(ts: int, x: float) -> LandmarkFrame:
+            return _make_frame(
+                timestamp_ms=ts, pose=_pose_at(x, x), left_hand=_hand_at(x, x)
+            )
+
+        # 2 inactive, 1 active (resets counter), 2 more inactive → ENDED not reached.
+        events = [
+            detector.update(inactive(next_ts + 0)),
+            detector.update(inactive(next_ts + 1)),
+            detector.update(active_frame(next_ts + 2, 0.9)),
+            detector.update(inactive(next_ts + 3)),
+            detector.update(inactive(next_ts + 4)),
+        ]
+        assert ADEvent.ENDED not in events
+
+
+# ===========================================================================
+# 6. IDLE after ENDED
+# ===========================================================================
+
+
+class TestIdleAfterEnded:
+    def test_idle_events_follow_ended(self):
+        activate_n = 2
+        deactivate_n = 2
+        detector = ActivityDetector(activate_frames=activate_n, deactivate_frames=deactivate_n)
+
+        # Reach ACTIVE.
+        detector.update(_make_frame(timestamp_ms=0, pose=_pose_at(0.0, 0.0), left_hand=_hand_at(0.0, 0.0)))
+        for i in range(1, activate_n + 1):
+            x = i * 0.05
+            detector.update(_make_frame(timestamp_ms=i, pose=_pose_at(x, x), left_hand=_hand_at(x, x)))
+
+        # Reach ENDED.
+        next_ts = activate_n + 1
+        for i in range(deactivate_n):
+            detector.update(_make_frame(timestamp_ms=next_ts + i, pose=_pose_at(0.5, 0.5)))
+        next_ts += deactivate_n
+
+        # Additional inactive frames should all be IDLE.
+        for i in range(5):
+            ev = detector.update(_make_frame(timestamp_ms=next_ts + i, pose=_pose_at(0.5, 0.5)))
+            assert ev == ADEvent.IDLE, f"expected IDLE after ENDED, got {ev}"
+
+    def test_is_active_returns_false_after_ended(self):
+        activate_n = 2
+        deactivate_n = 2
+        detector = ActivityDetector(activate_frames=activate_n, deactivate_frames=deactivate_n)
+
+        detector.update(_make_frame(timestamp_ms=0, pose=_pose_at(0.0, 0.0), left_hand=_hand_at(0.0, 0.0)))
+        for i in range(1, activate_n + 1):
+            x = i * 0.05
+            detector.update(_make_frame(timestamp_ms=i, pose=_pose_at(x, x), left_hand=_hand_at(x, x)))
+
+        next_ts = activate_n + 1
+        for i in range(deactivate_n):
+            detector.update(_make_frame(timestamp_ms=next_ts + i, pose=_pose_at(0.5, 0.5)))
+
+        assert not detector.is_active(_SESSION)
+
+
+# ===========================================================================
+# 7. Hysteresis prevents flicker
+# ===========================================================================
+
+
+class TestHysteresis:
+    def test_single_inactive_frame_does_not_end_activity(self):
+        activate_n = 2
+        deactivate_n = 4  # grace period is 4 frames
+        detector = ActivityDetector(activate_frames=activate_n, deactivate_frames=deactivate_n)
+
+        # Reach ACTIVE state.
+        detector.update(_make_frame(timestamp_ms=0, pose=_pose_at(0.0, 0.0), left_hand=_hand_at(0.0, 0.0)))
+        for i in range(1, activate_n + 1):
+            x = i * 0.05
+            detector.update(_make_frame(timestamp_ms=i, pose=_pose_at(x, x), left_hand=_hand_at(x, x)))
+
+        next_ts = activate_n + 1
+
+        # One inactive frame — should not trigger ENDED.
+        ev = detector.update(_make_frame(timestamp_ms=next_ts, pose=_pose_at(0.5, 0.5)))
+        assert ev != ADEvent.ENDED
+        assert ev != ADEvent.IDLE
+
+        # Resume activity — still ACTIVE (or STARTED again if implementation re-arms, but not IDLE/ENDED).
+        next_ts += 1
+        resume_x = 0.9
+        ev = detector.update(_make_frame(
+            timestamp_ms=next_ts,
+            pose=_pose_at(resume_x, resume_x),
+            left_hand=_hand_at(resume_x, resume_x),
+        ))
+        assert ev in (ADEvent.ACTIVE, ADEvent.STARTED)
+
+    def test_deactivate_frames_minus_one_inactive_does_not_end(self):
+        activate_n = 2
+        deactivate_n = 5
+        detector = ActivityDetector(activate_frames=activate_n, deactivate_frames=deactivate_n)
+
+        detector.update(_make_frame(timestamp_ms=0, pose=_pose_at(0.0, 0.0), left_hand=_hand_at(0.0, 0.0)))
+        for i in range(1, activate_n + 1):
+            x = i * 0.05
+            detector.update(_make_frame(timestamp_ms=i, pose=_pose_at(x, x), left_hand=_hand_at(x, x)))
+
+        next_ts = activate_n + 1
+        events = []
+        # Feed deactivate_n - 1 inactive frames → must NOT include ENDED.
+        for i in range(deactivate_n - 1):
+            ev = detector.update(_make_frame(timestamp_ms=next_ts + i, pose=_pose_at(0.5, 0.5)))
+            events.append(ev)
+
+        assert ADEvent.ENDED not in events
+
+
+# ===========================================================================
+# 8. Pose wrist fallback (use hand[0] when pose is None)
+# ===========================================================================
+
+
+class TestPoseWristFallback:
+    def test_motion_detected_without_pose(self):
+        """When pose is absent, hand[0] coords provide the wrist position."""
+        activate_n = 2
+        detector = ActivityDetector(
+            velocity_threshold=0.005, activate_frames=activate_n, deactivate_frames=10
+        )
+
+        # First frame: hand present, no pose — velocity = 0 (no prior position).
+        first = _make_frame(
+            timestamp_ms=0,
+            pose=None,
+            left_hand=_hand_at(0.1, 0.1),
+            right_hand=None,
+        )
+        assert detector.update(first) == ADEvent.IDLE
+
+        # Subsequent frames with motion (no pose).
+        events = []
+        for i in range(1, activate_n + 1):
+            x = 0.1 + i * 0.05
+            frame = _make_frame(
+                timestamp_ms=i,
+                pose=None,
+                left_hand=_hand_at(x, x),
+                right_hand=None,
+            )
+            events.append(detector.update(frame))
+
+        assert events[-1] == ADEvent.STARTED
+
+    def test_right_hand_fallback_when_left_absent(self):
+        """When left hand is absent, right hand[0] is used for wrist."""
+        activate_n = 2
+        detector = ActivityDetector(
+            velocity_threshold=0.005, activate_frames=activate_n, deactivate_frames=10
+        )
+
+        detector.update(_make_frame(timestamp_ms=0, pose=None, right_hand=_hand_at(0.1, 0.1)))
+
+        events = []
+        for i in range(1, activate_n + 1):
+            x = 0.1 + i * 0.05
+            frame = _make_frame(timestamp_ms=i, pose=None, right_hand=_hand_at(x, x))
+            events.append(detector.update(frame))
+
+        assert events[-1] == ADEvent.STARTED
+
+
+# ===========================================================================
+# 9. Multi-session isolation
+# ===========================================================================
+
+
+class TestMultiSessionIsolation:
+    def test_two_sessions_are_independent(self):
+        detector = ActivityDetector(activate_frames=2, deactivate_frames=10)
+
+        # Drive session A to ACTIVE.
+        detector.update(_make_frame(session_id=_SESSION, timestamp_ms=0, pose=_pose_at(0.0, 0.0), left_hand=_hand_at(0.0, 0.0)))
+        for i in range(1, 3):
+            x = i * 0.05
+            detector.update(_make_frame(session_id=_SESSION, timestamp_ms=i, pose=_pose_at(x, x), left_hand=_hand_at(x, x)))
+
+        assert detector.is_active(_SESSION)
+        # Session B has received no frames — must not be active.
+        assert not detector.is_active(_SESSION_B)
+
+    def test_session_b_activity_does_not_affect_session_a(self):
+        detector = ActivityDetector(activate_frames=2, deactivate_frames=10)
+
+        # Activate B.
+        detector.update(_make_frame(session_id=_SESSION_B, timestamp_ms=0, pose=_pose_at(0.0, 0.0), left_hand=_hand_at(0.0, 0.0)))
+        for i in range(1, 3):
+            x = i * 0.05
+            detector.update(_make_frame(session_id=_SESSION_B, timestamp_ms=i, pose=_pose_at(x, x), left_hand=_hand_at(x, x)))
+
+        # A has never seen a frame.
+        assert not detector.is_active(_SESSION)
+
+    def test_reset_one_session_does_not_affect_other(self):
+        activate_n = 2
+        detector = ActivityDetector(activate_frames=activate_n, deactivate_frames=10)
+
+        for sid in (_SESSION, _SESSION_B):
+            detector.update(_make_frame(session_id=sid, timestamp_ms=0, pose=_pose_at(0.0, 0.0), left_hand=_hand_at(0.0, 0.0)))
+            for i in range(1, activate_n + 1):
+                x = i * 0.05
+                detector.update(_make_frame(session_id=sid, timestamp_ms=i, pose=_pose_at(x, x), left_hand=_hand_at(x, x)))
+
+        assert detector.is_active(_SESSION)
+        assert detector.is_active(_SESSION_B)
+
+        detector.reset(_SESSION)
+        assert not detector.is_active(_SESSION)
+        assert detector.is_active(_SESSION_B)
+
+
+# ===========================================================================
+# 10. reset() clears state
+# ===========================================================================
+
+
+class TestReset:
+    def test_reset_returns_to_idle_state(self):
+        activate_n = 2
+        detector = ActivityDetector(activate_frames=activate_n, deactivate_frames=10)
+
+        # Reach ACTIVE.
+        detector.update(_make_frame(timestamp_ms=0, pose=_pose_at(0.0, 0.0), left_hand=_hand_at(0.0, 0.0)))
+        for i in range(1, activate_n + 1):
+            x = i * 0.05
+            detector.update(_make_frame(timestamp_ms=i, pose=_pose_at(x, x), left_hand=_hand_at(x, x)))
+
+        assert detector.is_active(_SESSION)
+
+        detector.reset(_SESSION)
+        assert not detector.is_active(_SESSION)
+
+    def test_first_frame_after_reset_is_idle(self):
+        """After reset, velocity has no previous reference → IDLE."""
+        activate_n = 1
+        detector = ActivityDetector(activate_frames=activate_n, deactivate_frames=10)
+
+        detector.update(_make_frame(timestamp_ms=0, pose=_pose_at(0.0, 0.0), left_hand=_hand_at(0.0, 0.0)))
+        detector.update(_make_frame(timestamp_ms=1, pose=_pose_at(0.5, 0.5), left_hand=_hand_at(0.5, 0.5)))
+        # Now ACTIVE (activate_frames=1).
+
+        detector.reset(_SESSION)
+
+        # First frame after reset: no prior position → velocity = 0.
+        ev = detector.update(_make_frame(timestamp_ms=2, pose=_pose_at(0.9, 0.9), left_hand=_hand_at(0.9, 0.9)))
+        assert ev == ADEvent.IDLE
+
+    def test_reset_unknown_session_is_noop(self):
+        detector = ActivityDetector()
+        detector.reset("does-not-exist")  # must not raise
+
+    def test_reset_clears_consecutive_counter(self):
+        """Resetting mid-countdown prevents a stale counter from firing."""
+        activate_n = 3
+        detector = ActivityDetector(activate_frames=activate_n, deactivate_frames=10)
+
+        # Feed 2 active frames (one short of STARTED).
+        detector.update(_make_frame(timestamp_ms=0, pose=_pose_at(0.0, 0.0), left_hand=_hand_at(0.0, 0.0)))
+        detector.update(_make_frame(timestamp_ms=1, pose=_pose_at(0.1, 0.1), left_hand=_hand_at(0.1, 0.1)))
+
+        detector.reset(_SESSION)
+
+        # After reset, the accumulated count must be gone — one more active frame
+        # alone must NOT trigger STARTED (needs activate_n fresh frames).
+        ev = detector.update(_make_frame(timestamp_ms=2, pose=_pose_at(0.2, 0.2), left_hand=_hand_at(0.2, 0.2)))
+        assert ev == ADEvent.IDLE

--- a/tests/fusion/test_frame_accumulator.py
+++ b/tests/fusion/test_frame_accumulator.py
@@ -1,4 +1,4 @@
-"""Tests for FrameAccumulator."""
+"""Tests for FrameAccumulator — rolling-window variant."""
 
 from __future__ import annotations
 
@@ -22,8 +22,9 @@ _SESSION_B = "660e8400-e29b-41d4-a716-446655440000"
 
 
 def _pose() -> list[list[float]]:
-    # x, y in [0.0, 1.0]; z is unconstrained (MediaPipe relative depth).
     n = POSE_LANDMARK_COUNT
+    # LandmarkFrame validates exactly 3 coordinates per point; _flatten_pose
+    # pads visibility=1.0 internally when the 4th component is absent.
     return [[i / n, (n - 1 - i) / n, float(i)] for i in range(n)]
 
 
@@ -43,7 +44,6 @@ def _frame(
     with_left: bool = True,
     with_right: bool = True,
 ) -> LandmarkFrame:
-    # At least one array must be non-null.
     return LandmarkFrame(
         session_id=session_id,
         timestamp_ms=timestamp_ms,
@@ -55,39 +55,78 @@ def _frame(
 
 
 # ---------------------------------------------------------------------------
-# FEATURE_DIM constant
+# FEATURE_DIM constant — 507 dims (pose*4 + face*3 + hand*3 + hand*3)
 # ---------------------------------------------------------------------------
 
 
 class TestFeatureDim:
-    def test_feature_dim_matches_landmark_counts(self):
+    def test_feature_dim_composition(self):
         expected = (
-            POSE_LANDMARK_COUNT * 3
+            POSE_LANDMARK_COUNT * 4  # x, y, z, visibility
             + FACE_LANDMARK_COUNT * 3
-            + HAND_LANDMARK_COUNT * 3
-            + HAND_LANDMARK_COUNT * 3
+            + HAND_LANDMARK_COUNT * 3  # left
+            + HAND_LANDMARK_COUNT * 3  # right
         )
         assert FEATURE_DIM == expected
 
     def test_feature_dim_value(self):
-        # pose(99) + face(249) + left(63) + right(63) = 474
-        assert FEATURE_DIM == 474
+        # pose(132) + face(249) + left(63) + right(63) = 507
+        assert FEATURE_DIM == 507
 
 
 # ---------------------------------------------------------------------------
-# Window fill / partial fill
+# Constructor validation
 # ---------------------------------------------------------------------------
 
 
-class TestWindowFill:
+class TestConstructor:
+    def test_default_window_size(self):
+        acc = FrameAccumulator()
+        assert acc._window_size == 30
+
+    def test_default_stride_is_10_for_large_window(self):
+        acc = FrameAccumulator()  # window=30 → stride=min(10, 30)=10
+        assert acc._stride == 10
+
+    def test_default_stride_clamped_for_small_window(self):
+        acc = FrameAccumulator(window_size=3)  # stride=min(10, 3)=3 (tumbling)
+        assert acc._stride == 3
+
+    def test_small_window_no_stride_arg(self):
+        acc = FrameAccumulator(window_size=1)  # must not raise; stride=1
+        assert acc._stride == 1
+
+    def test_custom_window_and_stride(self):
+        acc = FrameAccumulator(window_size=20, stride=5)
+        assert acc._window_size == 20
+        assert acc._stride == 5
+
+    def test_stride_equal_to_window_size_is_valid(self):
+        acc = FrameAccumulator(window_size=5, stride=5)
+        assert acc._stride == 5
+
+    def test_explicit_stride_greater_than_window_size_raises(self):
+        with pytest.raises(ValueError):
+            FrameAccumulator(window_size=5, stride=6)
+
+    def test_explicit_stride_zero_raises(self):
+        with pytest.raises(ValueError):
+            FrameAccumulator(window_size=5, stride=0)
+
+
+# ---------------------------------------------------------------------------
+# First window fill — behaviour up to the first emit
+# ---------------------------------------------------------------------------
+
+
+class TestFirstWindowFill:
     def test_partial_fill_returns_none(self):
-        acc = FrameAccumulator(window_size=5)
+        acc = FrameAccumulator(window_size=5, stride=2)
         for i in range(4):
-            result = acc.add(_frame(timestamp_ms=i))
-            assert result is None
+            assert acc.add(_frame(timestamp_ms=i)) is None
 
     def test_exact_fill_returns_array(self):
-        acc = FrameAccumulator(window_size=5)
+        acc = FrameAccumulator(window_size=5, stride=2)
         result = None
         for i in range(5):
             result = acc.add(_frame(timestamp_ms=i))
@@ -96,30 +135,78 @@ class TestWindowFill:
 
     def test_returned_shape_is_window_size_by_feature_dim(self):
         window = 10
-        acc = FrameAccumulator(window_size=window)
+        acc = FrameAccumulator(window_size=window, stride=3)
         result = None
         for i in range(window):
             result = acc.add(_frame(timestamp_ms=i))
         assert result.shape == (window, FEATURE_DIM)
 
-    def test_buffer_resets_after_emit(self):
-        acc = FrameAccumulator(window_size=3)
-        for i in range(3):
-            acc.add(_frame(timestamp_ms=i))
-        # Buffer should have been reset; next 2 frames → None
-        assert acc.add(_frame(timestamp_ms=10)) is None
-        assert acc.add(_frame(timestamp_ms=11)) is None
 
-    def test_second_window_also_emits(self):
-        acc = FrameAccumulator(window_size=3)
+# ---------------------------------------------------------------------------
+# Rolling-window stride behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestRollingWindow:
+    def test_buffer_retains_overlap_after_first_emit(self):
+        # window=5, stride=2 → 5-2=3 frames retained
+        acc = FrameAccumulator(window_size=5, stride=2)
+        for i in range(5):
+            acc.add(_frame(timestamp_ms=i))
+        assert acc.pending_count(_SESSION) == 3
+
+    def test_second_emit_arrives_after_stride_more_frames(self):
+        acc = FrameAccumulator(window_size=5, stride=2)
+        for i in range(5):
+            acc.add(_frame(timestamp_ms=i))
+        # 1 frame → still short (buf = 4)
+        assert acc.add(_frame(timestamp_ms=5)) is None
+        # 2nd frame → emit (buf = 5)
+        result = acc.add(_frame(timestamp_ms=6))
+        assert result is not None
+        assert result.shape == (5, FEATURE_DIM)
+
+    def test_pending_count_after_second_emit(self):
+        acc = FrameAccumulator(window_size=5, stride=2)
+        for i in range(7):  # 5 → first emit; +2 → second emit
+            acc.add(_frame(timestamp_ms=i))
+        # 5 - 2 = 3 retained after second emit
+        assert acc.pending_count(_SESSION) == 3
+
+    def test_stride_equal_to_window_size_clears_buffer(self):
+        # Tumbling window: stride == window_size, no overlap
+        acc = FrameAccumulator(window_size=3, stride=3)
         for i in range(3):
             acc.add(_frame(timestamp_ms=i))
-        # Second batch
+        assert acc.pending_count(_SESSION) == 0
+
+    def test_stride_equal_to_window_size_second_window_independent(self):
+        acc = FrameAccumulator(window_size=3, stride=3)
+        for i in range(3):
+            acc.add(_frame(timestamp_ms=i))
         result = None
         for i in range(3):
             result = acc.add(_frame(timestamp_ms=10 + i))
         assert result is not None
         assert result.shape == (3, FEATURE_DIM)
+
+    def test_many_consecutive_windows_emit_correctly(self):
+        acc = FrameAccumulator(window_size=4, stride=2)
+        emits = []
+        for i in range(12):
+            r = acc.add(_frame(timestamp_ms=i))
+            if r is not None:
+                emits.append(r)
+        # Windows at frames [0-3], [2-5], [4-7], [6-9], [8-11]
+        assert len(emits) == 5
+        for r in emits:
+            assert r.shape == (4, FEATURE_DIM)
+
+    def test_no_emit_below_window_after_multiple_strides(self):
+        # Ensure we don't get spurious emits as buffer grows
+        acc = FrameAccumulator(window_size=5, stride=2)
+        results = [acc.add(_frame(timestamp_ms=i)) for i in range(4)]
+        assert all(r is None for r in results)
 
 
 # ---------------------------------------------------------------------------
@@ -129,7 +216,7 @@ class TestWindowFill:
 
 class TestReset:
     def test_reset_clears_buffer(self):
-        acc = FrameAccumulator(window_size=5)
+        acc = FrameAccumulator(window_size=5, stride=2)
         for i in range(3):
             acc.add(_frame(timestamp_ms=i))
         assert acc.pending_count(_SESSION) == 3
@@ -137,17 +224,30 @@ class TestReset:
         acc.reset(_SESSION)
         assert acc.pending_count(_SESSION) == 0
 
-    def test_reset_after_full_window_is_noop(self):
-        acc = FrameAccumulator(window_size=3)
-        for i in range(3):
+    def test_reset_after_emit_clears_retained_overlap(self):
+        acc = FrameAccumulator(window_size=5, stride=2)
+        for i in range(5):
             acc.add(_frame(timestamp_ms=i))
-        # After emit, buffer is already empty; reset should still work without error
+        # 3 frames retained after emit
+        assert acc.pending_count(_SESSION) == 3
+
         acc.reset(_SESSION)
         assert acc.pending_count(_SESSION) == 0
 
     def test_reset_unknown_session_is_noop(self):
         acc = FrameAccumulator(window_size=5)
         acc.reset("does-not-exist")  # must not raise
+
+    def test_add_after_reset_starts_fresh(self):
+        acc = FrameAccumulator(window_size=3, stride=1)
+        for i in range(3):
+            acc.add(_frame(timestamp_ms=i))
+        acc.reset(_SESSION)
+        # After reset, need another full window
+        for i in range(2):
+            assert acc.add(_frame(timestamp_ms=10 + i)) is None
+        result = acc.add(_frame(timestamp_ms=12))
+        assert result is not None
 
 
 # ---------------------------------------------------------------------------
@@ -156,21 +256,21 @@ class TestReset:
 
 
 class TestPendingCount:
-    def test_pending_count_starts_at_zero(self):
+    def test_starts_at_zero(self):
         acc = FrameAccumulator(window_size=5)
         assert acc.pending_count(_SESSION) == 0
 
-    def test_pending_count_increments(self):
-        acc = FrameAccumulator(window_size=5)
+    def test_increments_with_each_add(self):
+        acc = FrameAccumulator(window_size=5, stride=2)
         for i in range(3):
             acc.add(_frame(timestamp_ms=i))
         assert acc.pending_count(_SESSION) == 3
 
-    def test_pending_count_resets_after_emit(self):
-        acc = FrameAccumulator(window_size=3)
-        for i in range(3):
+    def test_drops_to_overlap_after_emit(self):
+        acc = FrameAccumulator(window_size=5, stride=2)
+        for i in range(5):
             acc.add(_frame(timestamp_ms=i))
-        assert acc.pending_count(_SESSION) == 0
+        assert acc.pending_count(_SESSION) == 3  # 5 - 2
 
 
 # ---------------------------------------------------------------------------
@@ -180,14 +280,14 @@ class TestPendingCount:
 
 class TestSessionIsolation:
     def test_two_sessions_buffered_independently(self):
-        acc = FrameAccumulator(window_size=5)
+        acc = FrameAccumulator(window_size=5, stride=2)
         acc.add(_frame(session_id=_SESSION, timestamp_ms=0))
         acc.add(_frame(session_id=_SESSION_B, timestamp_ms=0))
         assert acc.pending_count(_SESSION) == 1
         assert acc.pending_count(_SESSION_B) == 1
 
     def test_reset_session_a_does_not_affect_session_b(self):
-        acc = FrameAccumulator(window_size=5)
+        acc = FrameAccumulator(window_size=5, stride=2)
         for i in range(3):
             acc.add(_frame(session_id=_SESSION, timestamp_ms=i))
         for i in range(2):
@@ -197,62 +297,77 @@ class TestSessionIsolation:
         assert acc.pending_count(_SESSION_B) == 2
 
     def test_session_b_fills_independently(self):
-        acc = FrameAccumulator(window_size=3)
-        # Fill session B to window.
+        acc = FrameAccumulator(window_size=3, stride=1)
         result = None
         for i in range(3):
             result = acc.add(_frame(session_id=_SESSION_B, timestamp_ms=i))
         assert result is not None
-        # Session A is unaffected.
         assert acc.pending_count(_SESSION) == 0
 
+    def test_emit_in_session_b_does_not_affect_session_a_buffer(self):
+        acc = FrameAccumulator(window_size=3, stride=1)
+        for i in range(2):
+            acc.add(_frame(session_id=_SESSION, timestamp_ms=i))
+        for i in range(3):
+            acc.add(_frame(session_id=_SESSION_B, timestamp_ms=i))
+        # session A has 2 frames; session B emitted and has 2 retained
+        assert acc.pending_count(_SESSION) == 2
+        assert acc.pending_count(_SESSION_B) == 2
+
 
 # ---------------------------------------------------------------------------
-# Numpy values — zero-filling absent groups
+# Numpy values — zero-filling absent groups, dtype, pose visibility
 # ---------------------------------------------------------------------------
+
+
+def _single_frame_acc() -> FrameAccumulator:
+    """One-shot accumulator for testing feature vector values."""
+    return FrameAccumulator(window_size=1)
 
 
 class TestNumpyValues:
     def test_absent_pose_yields_zeros(self):
-        acc = FrameAccumulator(window_size=1)
-        frame = _frame(with_pose=False)
-        result = acc.add(frame)
-        # Pose occupies first POSE_LANDMARK_COUNT * 3 dims.
-        pose_slice = result[0, : POSE_LANDMARK_COUNT * 3]
+        result = _single_frame_acc().add(_frame(with_pose=False))
+        pose_slice = result[0, : POSE_LANDMARK_COUNT * 4]
         assert np.all(pose_slice == 0.0)
 
     def test_absent_face_yields_zeros(self):
-        acc = FrameAccumulator(window_size=1)
-        frame = _frame(with_face=False)
-        result = acc.add(frame)
-        pose_end = POSE_LANDMARK_COUNT * 3
+        result = _single_frame_acc().add(_frame(with_face=False))
+        pose_end = POSE_LANDMARK_COUNT * 4
         face_slice = result[0, pose_end : pose_end + FACE_LANDMARK_COUNT * 3]
         assert np.all(face_slice == 0.0)
 
     def test_absent_left_hand_yields_zeros(self):
-        acc = FrameAccumulator(window_size=1)
-        frame = _frame(with_left=False)
-        result = acc.add(frame)
-        left_start = (POSE_LANDMARK_COUNT + FACE_LANDMARK_COUNT) * 3
+        result = _single_frame_acc().add(_frame(with_left=False))
+        left_start = POSE_LANDMARK_COUNT * 4 + FACE_LANDMARK_COUNT * 3
         left_slice = result[0, left_start : left_start + HAND_LANDMARK_COUNT * 3]
         assert np.all(left_slice == 0.0)
 
     def test_absent_right_hand_yields_zeros(self):
-        acc = FrameAccumulator(window_size=1)
-        frame = _frame(with_right=False)
-        result = acc.add(frame)
-        right_start = (POSE_LANDMARK_COUNT + FACE_LANDMARK_COUNT + HAND_LANDMARK_COUNT) * 3
+        result = _single_frame_acc().add(_frame(with_right=False))
+        right_start = (
+            POSE_LANDMARK_COUNT * 4
+            + FACE_LANDMARK_COUNT * 3
+            + HAND_LANDMARK_COUNT * 3
+        )
         right_slice = result[0, right_start : right_start + HAND_LANDMARK_COUNT * 3]
         assert np.all(right_slice == 0.0)
 
-    def test_present_pose_values_match(self):
-        acc = FrameAccumulator(window_size=1)
+    def test_pose_xyz_values_match(self):
+        # _flatten_pose interleaves visibility=1.0 after each (x, y, z).
         frame = _frame(with_face=False, with_left=False, with_right=False)
-        result = acc.add(frame)
-        expected = np.asarray(_pose(), dtype=np.float32).ravel()
-        np.testing.assert_array_almost_equal(result[0, : POSE_LANDMARK_COUNT * 3], expected)
+        result = _single_frame_acc().add(frame)
+        raw = np.asarray(_pose(), dtype=np.float32)  # shape (33, 3)
+        xyz_indices = [i * 4 + c for i in range(POSE_LANDMARK_COUNT) for c in range(3)]
+        np.testing.assert_array_almost_equal(result[0, xyz_indices], raw.ravel())
+
+    def test_pose_visibility_padded_to_1(self):
+        # _flatten_pose pads visibility=1.0 when only (x, y, z) are provided.
+        frame = _frame(with_face=False, with_left=False, with_right=False)
+        result = _single_frame_acc().add(frame)
+        visibility_indices = [3 + i * 4 for i in range(POSE_LANDMARK_COUNT)]
+        assert np.all(result[0, visibility_indices] == 1.0)
 
     def test_dtype_is_float32(self):
-        acc = FrameAccumulator(window_size=1)
-        result = acc.add(_frame())
+        result = _single_frame_acc().add(_frame())
         assert result.dtype == np.float32

--- a/tests/fusion/test_frame_accumulator.py
+++ b/tests/fusion/test_frame_accumulator.py
@@ -346,9 +346,7 @@ class TestNumpyValues:
     def test_absent_right_hand_yields_zeros(self):
         result = _single_frame_acc().add(_frame(with_right=False))
         right_start = (
-            POSE_LANDMARK_COUNT * 4
-            + FACE_LANDMARK_COUNT * 3
-            + HAND_LANDMARK_COUNT * 3
+            POSE_LANDMARK_COUNT * 4 + FACE_LANDMARK_COUNT * 3 + HAND_LANDMARK_COUNT * 3
         )
         right_slice = result[0, right_start : right_start + HAND_LANDMARK_COUNT * 3]
         assert np.all(right_slice == 0.0)

--- a/tests/fusion/test_gloss_accumulator.py
+++ b/tests/fusion/test_gloss_accumulator.py
@@ -1,0 +1,396 @@
+"""Tests for GlossAccumulator — RED phase (implementation does not exist yet)."""
+
+from __future__ import annotations
+
+import pytest
+
+from sozia.server.fusion.gloss_accumulator import GlossAccumulator, GlossEntry
+
+# ---------------------------------------------------------------------------
+# Session ID fixtures
+# ---------------------------------------------------------------------------
+
+_SESSION = "cccccccc-0000-4000-c000-000000000001"
+_SESSION_B = "dddddddd-0000-4000-d000-000000000002"
+
+# ---------------------------------------------------------------------------
+# Entry factory
+# ---------------------------------------------------------------------------
+
+
+def _entry(text: str, confidence: float = 0.8, timestamp_ms: int = 0, duration_ms: int = 100) -> GlossEntry:
+    return GlossEntry(
+        text=text,
+        confidence=confidence,
+        timestamp_ms=timestamp_ms,
+        duration_ms=duration_ms,
+    )
+
+
+# ===========================================================================
+# 1. push new word
+# ===========================================================================
+
+
+class TestPushNewWord:
+    def test_push_single_word_peek_returns_it(self):
+        acc = GlossAccumulator()
+        acc.push(_SESSION, _entry("YEMEK"))
+        assert acc.peek(_SESSION) == "YEMEK"
+
+    def test_is_empty_false_after_push(self):
+        acc = GlossAccumulator()
+        assert acc.is_empty(_SESSION)
+        acc.push(_SESSION, _entry("YEMEK"))
+        assert not acc.is_empty(_SESSION)
+
+    def test_push_returns_true_for_new_word(self):
+        acc = GlossAccumulator()
+        result = acc.push(_SESSION, _entry("YEMEK"))
+        assert result is True
+
+
+# ===========================================================================
+# 2. push second different word
+# ===========================================================================
+
+
+class TestPushSecondWord:
+    def test_peek_returns_space_joined_words(self):
+        acc = GlossAccumulator()
+        acc.push(_SESSION, _entry("YEMEK"))
+        acc.push(_SESSION, _entry("OKUL"))
+        assert acc.peek(_SESSION) == "YEMEK OKUL"
+
+    def test_entries_count_after_two_different_words(self):
+        acc = GlossAccumulator()
+        acc.push(_SESSION, _entry("YEMEK"))
+        acc.push(_SESSION, _entry("OKUL"))
+        assert len(acc.entries(_SESSION)) == 2
+
+    def test_entries_order_is_insertion_order(self):
+        acc = GlossAccumulator()
+        words = ["YEMEK", "OKUL", "GIT"]
+        for w in words:
+            acc.push(_SESSION, _entry(w))
+        texts = [e.text for e in acc.entries(_SESSION)]
+        assert texts == words
+
+
+# ===========================================================================
+# 3. dedup — lower-confidence repeat is dropped
+# ===========================================================================
+
+
+class TestDedupLowerConfidence:
+    def test_lower_conf_duplicate_returns_false(self):
+        acc = GlossAccumulator()
+        acc.push(_SESSION, _entry("YEMEK", confidence=0.7))
+        result = acc.push(_SESSION, _entry("YEMEK", confidence=0.6))
+        assert result is False
+
+    def test_lower_conf_duplicate_does_not_change_entry(self):
+        acc = GlossAccumulator()
+        acc.push(_SESSION, _entry("YEMEK", confidence=0.7))
+        acc.push(_SESSION, _entry("YEMEK", confidence=0.6))
+        entries = acc.entries(_SESSION)
+        assert len(entries) == 1
+        assert entries[0].confidence == pytest.approx(0.7)
+
+    def test_lower_conf_duplicate_buffer_length_unchanged(self):
+        acc = GlossAccumulator()
+        acc.push(_SESSION, _entry("YEMEK", confidence=0.7))
+        acc.push(_SESSION, _entry("YEMEK", confidence=0.6))
+        assert len(acc.entries(_SESSION)) == 1
+
+
+# ===========================================================================
+# 4. dedup — higher-confidence repeat replaces existing
+# ===========================================================================
+
+
+class TestDedupHigherConfidence:
+    def test_higher_conf_duplicate_returns_true(self):
+        acc = GlossAccumulator()
+        acc.push(_SESSION, _entry("YEMEK", confidence=0.6))
+        result = acc.push(_SESSION, _entry("YEMEK", confidence=0.8))
+        assert result is True
+
+    def test_higher_conf_duplicate_updates_confidence(self):
+        acc = GlossAccumulator()
+        acc.push(_SESSION, _entry("YEMEK", confidence=0.6))
+        acc.push(_SESSION, _entry("YEMEK", confidence=0.8))
+        entries = acc.entries(_SESSION)
+        assert len(entries) == 1
+        assert entries[0].confidence == pytest.approx(0.8)
+
+    def test_higher_conf_replaces_preserves_buffer_length(self):
+        acc = GlossAccumulator()
+        acc.push(_SESSION, _entry("YEMEK", confidence=0.6))
+        acc.push(_SESSION, _entry("YEMEK", confidence=0.8))
+        assert len(acc.entries(_SESSION)) == 1
+
+    def test_dedup_only_applies_to_last_entry(self):
+        """Dedup rule compares against the *last* entry, not any earlier one."""
+        acc = GlossAccumulator()
+        acc.push(_SESSION, _entry("YEMEK", confidence=0.7))
+        acc.push(_SESSION, _entry("OKUL", confidence=0.8))
+        # "YEMEK" is not the last word — a new "YEMEK" is a different (new) word.
+        result = acc.push(_SESSION, _entry("YEMEK", confidence=0.5))
+        # Not a dedup of the last entry; buffer should grow (if under max).
+        assert len(acc.entries(_SESSION)) == 3
+        assert result is True
+
+
+# ===========================================================================
+# 5. max_words cap
+# ===========================================================================
+
+
+class TestMaxWordsCap:
+    def test_fourth_word_returns_false_when_cap_is_three(self):
+        acc = GlossAccumulator(max_words=3)
+        words = ["YEMEK", "OKUL", "GIT", "EV"]
+        for i, w in enumerate(words):
+            result = acc.push(_SESSION, _entry(w))
+            if i < 3:
+                assert result is True, f"word {i+1} should be accepted"
+            else:
+                assert result is False, "fourth word should be rejected"
+
+    def test_peek_contains_only_first_three_words(self):
+        acc = GlossAccumulator(max_words=3)
+        for w in ["YEMEK", "OKUL", "GIT", "EV"]:
+            acc.push(_SESSION, _entry(w))
+        assert acc.peek(_SESSION) == "YEMEK OKUL GIT"
+
+    def test_buffer_length_does_not_exceed_max_words(self):
+        acc = GlossAccumulator(max_words=2)
+        for w in ["A", "B", "C", "D", "E"]:
+            acc.push(_SESSION, _entry(w))
+        assert len(acc.entries(_SESSION)) == 2
+
+    def test_max_words_one_allows_only_first_entry(self):
+        acc = GlossAccumulator(max_words=1)
+        acc.push(_SESSION, _entry("YEMEK"))
+        result = acc.push(_SESSION, _entry("OKUL"))
+        assert result is False
+        assert acc.peek(_SESSION) == "YEMEK"
+
+
+# ===========================================================================
+# 6. flush clears buffer
+# ===========================================================================
+
+
+class TestFlushClearsBuffer:
+    def test_flush_returns_all_entries(self):
+        acc = GlossAccumulator()
+        acc.push(_SESSION, _entry("YEMEK"))
+        acc.push(_SESSION, _entry("OKUL"))
+        flushed = acc.flush(_SESSION)
+        assert len(flushed) == 2
+        assert flushed[0].text == "YEMEK"
+        assert flushed[1].text == "OKUL"
+
+    def test_is_empty_after_flush(self):
+        acc = GlossAccumulator()
+        acc.push(_SESSION, _entry("YEMEK"))
+        acc.flush(_SESSION)
+        assert acc.is_empty(_SESSION)
+
+    def test_peek_empty_string_after_flush(self):
+        acc = GlossAccumulator()
+        acc.push(_SESSION, _entry("YEMEK"))
+        acc.flush(_SESSION)
+        assert acc.peek(_SESSION) == ""
+
+    def test_push_works_again_after_flush(self):
+        acc = GlossAccumulator()
+        acc.push(_SESSION, _entry("YEMEK"))
+        acc.flush(_SESSION)
+        acc.push(_SESSION, _entry("OKUL"))
+        assert acc.peek(_SESSION) == "OKUL"
+
+
+# ===========================================================================
+# 7. flush on empty session
+# ===========================================================================
+
+
+class TestFlushOnEmpty:
+    def test_flush_empty_returns_empty_list(self):
+        acc = GlossAccumulator()
+        result = acc.flush(_SESSION)
+        assert result == []
+
+    def test_flush_empty_does_not_raise(self):
+        acc = GlossAccumulator()
+        acc.flush(_SESSION)  # must not raise
+
+    def test_is_empty_true_for_new_session(self):
+        acc = GlossAccumulator()
+        assert acc.is_empty(_SESSION)
+
+
+# ===========================================================================
+# 8. partial_id round-trip
+# ===========================================================================
+
+
+class TestPartialIdRoundTrip:
+    def test_pop_returns_set_id(self):
+        acc = GlossAccumulator()
+        seg_id = "seg-uuid-1234"
+        acc.set_partial_id(_SESSION, seg_id)
+        result = acc.pop_partial_id(_SESSION)
+        assert result == seg_id
+
+    def test_second_pop_returns_none(self):
+        acc = GlossAccumulator()
+        acc.set_partial_id(_SESSION, "seg-uuid-1234")
+        acc.pop_partial_id(_SESSION)
+        assert acc.pop_partial_id(_SESSION) is None
+
+    def test_pop_before_set_returns_none(self):
+        acc = GlossAccumulator()
+        assert acc.pop_partial_id(_SESSION) is None
+
+    def test_set_partial_id_overwrites_previous(self):
+        acc = GlossAccumulator()
+        acc.set_partial_id(_SESSION, "first-id")
+        acc.set_partial_id(_SESSION, "second-id")
+        assert acc.pop_partial_id(_SESSION) == "second-id"
+
+
+# ===========================================================================
+# 9. partial_id cleared on flush
+# ===========================================================================
+
+
+class TestPartialIdClearedOnFlush:
+    def test_pop_partial_id_none_after_flush(self):
+        acc = GlossAccumulator()
+        acc.push(_SESSION, _entry("YEMEK"))
+        acc.set_partial_id(_SESSION, "seg-abc")
+        acc.flush(_SESSION)
+        assert acc.pop_partial_id(_SESSION) is None
+
+    def test_flush_clears_partial_id_even_when_buffer_empty(self):
+        acc = GlossAccumulator()
+        acc.set_partial_id(_SESSION, "seg-abc")
+        acc.flush(_SESSION)
+        assert acc.pop_partial_id(_SESSION) is None
+
+
+# ===========================================================================
+# 10. reset clears everything
+# ===========================================================================
+
+
+class TestReset:
+    def test_reset_clears_buffer(self):
+        acc = GlossAccumulator()
+        acc.push(_SESSION, _entry("YEMEK"))
+        acc.push(_SESSION, _entry("OKUL"))
+        acc.reset(_SESSION)
+        assert acc.is_empty(_SESSION)
+
+    def test_reset_clears_partial_id(self):
+        acc = GlossAccumulator()
+        acc.set_partial_id(_SESSION, "seg-xyz")
+        acc.reset(_SESSION)
+        assert acc.pop_partial_id(_SESSION) is None
+
+    def test_reset_clears_both_buffer_and_partial_id(self):
+        acc = GlossAccumulator()
+        acc.push(_SESSION, _entry("YEMEK"))
+        acc.set_partial_id(_SESSION, "seg-xyz")
+        acc.reset(_SESSION)
+        assert acc.is_empty(_SESSION)
+        assert acc.pop_partial_id(_SESSION) is None
+
+    def test_reset_unknown_session_is_noop(self):
+        acc = GlossAccumulator()
+        acc.reset("does-not-exist")  # must not raise
+
+    def test_push_works_after_reset(self):
+        acc = GlossAccumulator()
+        acc.push(_SESSION, _entry("YEMEK"))
+        acc.reset(_SESSION)
+        acc.push(_SESSION, _entry("OKUL"))
+        assert acc.peek(_SESSION) == "OKUL"
+
+
+# ===========================================================================
+# 11. Multi-session isolation
+# ===========================================================================
+
+
+class TestMultiSessionIsolation:
+    def test_push_to_a_does_not_affect_b(self):
+        acc = GlossAccumulator()
+        acc.push(_SESSION, _entry("YEMEK"))
+        assert acc.is_empty(_SESSION_B)
+
+    def test_flush_a_does_not_affect_b(self):
+        acc = GlossAccumulator()
+        acc.push(_SESSION, _entry("YEMEK"))
+        acc.push(_SESSION_B, _entry("OKUL"))
+        acc.flush(_SESSION)
+        assert not acc.is_empty(_SESSION_B)
+        assert acc.peek(_SESSION_B) == "OKUL"
+
+    def test_reset_a_does_not_affect_b(self):
+        acc = GlossAccumulator()
+        acc.push(_SESSION, _entry("YEMEK"))
+        acc.push(_SESSION_B, _entry("OKUL"))
+        acc.reset(_SESSION)
+        assert acc.peek(_SESSION_B) == "OKUL"
+
+    def test_partial_id_isolated_per_session(self):
+        acc = GlossAccumulator()
+        acc.set_partial_id(_SESSION, "id-a")
+        acc.set_partial_id(_SESSION_B, "id-b")
+        assert acc.pop_partial_id(_SESSION) == "id-a"
+        assert acc.pop_partial_id(_SESSION_B) == "id-b"
+
+    def test_max_words_applies_per_session(self):
+        acc = GlossAccumulator(max_words=2)
+        acc.push(_SESSION, _entry("YEMEK"))
+        acc.push(_SESSION, _entry("OKUL"))
+        # Session A is full — session B is independent.
+        result = acc.push(_SESSION_B, _entry("GIT"))
+        assert result is True
+        assert acc.peek(_SESSION_B) == "GIT"
+
+
+# ===========================================================================
+# 12. entries() returns a copy
+# ===========================================================================
+
+
+class TestEntriesReturnsCopy:
+    def test_mutating_returned_list_does_not_change_internal_state(self):
+        acc = GlossAccumulator()
+        acc.push(_SESSION, _entry("YEMEK"))
+        acc.push(_SESSION, _entry("OKUL"))
+
+        snapshot = acc.entries(_SESSION)
+        snapshot.clear()  # mutate the returned list
+
+        # Internal buffer must be untouched.
+        assert len(acc.entries(_SESSION)) == 2
+
+    def test_entries_returns_correct_values_after_mutation_of_snapshot(self):
+        acc = GlossAccumulator()
+        acc.push(_SESSION, _entry("YEMEK"))
+        snapshot = acc.entries(_SESSION)
+        snapshot.append(_entry("MUTATED"))
+
+        # Buffer must still have only the original entry.
+        assert acc.peek(_SESSION) == "YEMEK"
+
+    def test_entries_empty_session_returns_empty_list(self):
+        acc = GlossAccumulator()
+        assert acc.entries(_SESSION) == []

--- a/tests/fusion/test_gloss_accumulator.py
+++ b/tests/fusion/test_gloss_accumulator.py
@@ -18,7 +18,9 @@ _SESSION_B = "dddddddd-0000-4000-d000-000000000002"
 # ---------------------------------------------------------------------------
 
 
-def _entry(text: str, confidence: float = 0.8, timestamp_ms: int = 0, duration_ms: int = 100) -> GlossEntry:
+def _entry(
+    text: str, confidence: float = 0.8, timestamp_ms: int = 0, duration_ms: int = 100
+) -> GlossEntry:
     return GlossEntry(
         text=text,
         confidence=confidence,
@@ -154,7 +156,7 @@ class TestMaxWordsCap:
         for i, w in enumerate(words):
             result = acc.push(_SESSION, _entry(w))
             if i < 3:
-                assert result is True, f"word {i+1} should be accepted"
+                assert result is True, f"word {i + 1} should be accepted"
             else:
                 assert result is False, "fourth word should be rejected"
 

--- a/tests/fusion/test_integration_with_engines.py
+++ b/tests/fusion/test_integration_with_engines.py
@@ -227,7 +227,8 @@ class TestSignPipelineIntegration:
         )
         assert len(finals) == 1
         assert finals[0].status == SegmentStatus.FINAL
-        assert finals[0].replaces_segment_id == partial_id
+        # replaces_segment_id linking is now orchestrator's responsibility
+        # (GlossAccumulator tracks it); tested in test_orchestrator_process.py.
         assert finals[0].text == "Merhaba dünya."
 
 

--- a/tests/fusion/test_integration_with_engines.py
+++ b/tests/fusion/test_integration_with_engines.py
@@ -53,10 +53,13 @@ class _StubEngine(InferenceEngine):
         self._model_id = config.model_id
 
     async def predict(
-        self, features, timeout_ms: int = 2200,
+        self,
+        features,
+        timeout_ms: int = 2200,
     ) -> ModalityResult:
         if not self._loaded:
             from sozia.common.interfaces import ModelNotLoadedError
+
             raise ModelNotLoadedError(self._model_id)
         return self._result
 
@@ -101,7 +104,8 @@ def _audio_health(available: bool = True, snr: float = 25.0) -> PipelineHealth:
 
 
 def _video_health(
-    available: bool = True, face_detected: bool = True,
+    available: bool = True,
+    face_detected: bool = True,
 ) -> PipelineHealth:
     return PipelineHealth(
         session_id=_SESSION,
@@ -152,7 +156,10 @@ class TestSpeechPipelineIntegration:
 
         # First pass: ASR only → PARTIAL.
         partials = await orch.process_features(
-            _SESSION, [asr_out], [_audio_health()], ModalityPath.SPEECH,
+            _SESSION,
+            [asr_out],
+            [_audio_health()],
+            ModalityPath.SPEECH,
         )
         assert len(partials) == 1
         assert partials[0].status == SegmentStatus.PARTIAL
@@ -178,7 +185,10 @@ class TestSpeechPipelineIntegration:
 
         orch = _build_orchestrator()
         segments = await orch.process_features(
-            _SESSION, [asr_out], [_audio_health()], ModalityPath.SPEECH,
+            _SESSION,
+            [asr_out],
+            [_audio_health()],
+            ModalityPath.SPEECH,
         )
         assert segments == []
 
@@ -211,7 +221,10 @@ class TestSignPipelineIntegration:
 
         # TSL alone → PARTIAL.
         partials = await orch.process_features(
-            _SESSION, [tsl_out], [_video_health()], ModalityPath.SIGN,
+            _SESSION,
+            [tsl_out],
+            [_video_health()],
+            ModalityPath.SIGN,
         )
         assert len(partials) == 1
         assert partials[0].status == SegmentStatus.PARTIAL
@@ -309,7 +322,10 @@ class TestEngineLifecycleContract:
         out = await engine.predict(features=None)
 
         segments = await orch.process_features(
-            _SESSION, [out], [_audio_health()], ModalityPath.SPEECH,
+            _SESSION,
+            [out],
+            [_audio_health()],
+            ModalityPath.SPEECH,
         )
         # 0.85 < 0.90 → suppressed.
         assert segments == []
@@ -329,10 +345,16 @@ class TestWarmUpCoolDown:
 
         orch = _build_orchestrator()
         orch.register_engine(
-            ModalityPath.SPEECH, ModalityType.ASR, asr, _config("whisper-small-tr"),
+            ModalityPath.SPEECH,
+            ModalityType.ASR,
+            asr,
+            _config("whisper-small-tr"),
         )
         orch.register_engine(
-            ModalityPath.SPEECH, ModalityType.LIP_READING, lip, _config("lip-reading-v1"),
+            ModalityPath.SPEECH,
+            ModalityType.LIP_READING,
+            lip,
+            _config("lip-reading-v1"),
         )
 
         await orch.warm_up(ModalityPath.SPEECH)
@@ -343,7 +365,10 @@ class TestWarmUpCoolDown:
         engine = _StubEngine(_result(ModalityType.ASR, "x"))
         orch = _build_orchestrator()
         orch.register_engine(
-            ModalityPath.SPEECH, ModalityType.ASR, engine, _config("whisper-small-tr"),
+            ModalityPath.SPEECH,
+            ModalityType.ASR,
+            engine,
+            _config("whisper-small-tr"),
         )
 
         await orch.warm_up(ModalityPath.SPEECH)
@@ -355,8 +380,12 @@ class TestWarmUpCoolDown:
         tsl = _StubEngine(_result(ModalityType.TSL_RECOGNITION, "x"))
 
         orch = _build_orchestrator()
-        orch.register_engine(ModalityPath.SPEECH, ModalityType.ASR, asr, _config("whisper"))
-        orch.register_engine(ModalityPath.SIGN, ModalityType.TSL_RECOGNITION, tsl, _config("tsl-gru"))
+        orch.register_engine(
+            ModalityPath.SPEECH, ModalityType.ASR, asr, _config("whisper")
+        )
+        orch.register_engine(
+            ModalityPath.SIGN, ModalityType.TSL_RECOGNITION, tsl, _config("tsl-gru")
+        )
 
         await orch.warm_up(ModalityPath.SPEECH)
         assert asr.is_loaded()
@@ -371,8 +400,12 @@ class TestWarmUpCoolDown:
         tsl = _StubEngine(_result(ModalityType.TSL_RECOGNITION, "x"))
 
         orch = _build_orchestrator()
-        orch.register_engine(ModalityPath.SPEECH, ModalityType.ASR, asr, _config("whisper"))
-        orch.register_engine(ModalityPath.SIGN, ModalityType.TSL_RECOGNITION, tsl, _config("tsl-gru"))
+        orch.register_engine(
+            ModalityPath.SPEECH, ModalityType.ASR, asr, _config("whisper")
+        )
+        orch.register_engine(
+            ModalityPath.SIGN, ModalityType.TSL_RECOGNITION, tsl, _config("tsl-gru")
+        )
 
         await orch.warm_up(ModalityPath.SPEECH)
         await orch.warm_up(ModalityPath.SIGN)

--- a/tests/fusion/test_orchestrator_process.py
+++ b/tests/fusion/test_orchestrator_process.py
@@ -660,12 +660,16 @@ def _sign_orch(
     mock_ad = _MockAD(ad_events or [ADEvent.ACTIVE])
     orch = FusionOrchestrator(window_size=window_size, activity_detector=mock_ad)
     orch.register_policy(ModalityPath.SIGN, SignFusionPolicy())
-    orch.register_engine(ModalityPath.SIGN, ModalityType.TSL_RECOGNITION, tsl, _cfg("tsl"))
+    orch.register_engine(
+        ModalityPath.SIGN, ModalityType.TSL_RECOGNITION, tsl, _cfg("tsl")
+    )
 
     if gloss_result is not None or gloss_timeout:
         g = _StubEngine(gloss_result, raise_timeout=gloss_timeout, model_id="gemma")
         g._loaded = True
-        orch.register_engine(ModalityPath.SIGN, ModalityType.GLOSS_TO_TEXT, g, _cfg("gemma"))
+        orch.register_engine(
+            ModalityPath.SIGN, ModalityType.GLOSS_TO_TEXT, g, _cfg("gemma")
+        )
 
     return orch
 
@@ -677,8 +681,11 @@ class TestProcessSign:
         sent: list[TranscriptSegment] = []
         for i in range(3):
             await orch.process(
-                _SESSION, _landmark_frame(timestamp_ms=i),
-                [_video_health()], ModalityPath.SIGN, sent.append,
+                _SESSION,
+                _landmark_frame(timestamp_ms=i),
+                [_video_health()],
+                ModalityPath.SIGN,
+                sent.append,
             )
         assert sent == []
 
@@ -690,7 +697,11 @@ class TestProcessSign:
         )
         sent: list[TranscriptSegment] = []
         await orch.process(
-            _SESSION, _landmark_frame(), [_video_health()], ModalityPath.SIGN, sent.append,
+            _SESSION,
+            _landmark_frame(),
+            [_video_health()],
+            ModalityPath.SIGN,
+            sent.append,
         )
         assert len(sent) == 1
         assert sent[0].status == SegmentStatus.PARTIAL
@@ -704,7 +715,11 @@ class TestProcessSign:
         )
         sent: list[TranscriptSegment] = []
         await orch.process(
-            _SESSION, _landmark_frame(), [_video_health()], ModalityPath.SIGN, sent.append,
+            _SESSION,
+            _landmark_frame(),
+            [_video_health()],
+            ModalityPath.SIGN,
+            sent.append,
         )
         assert len(sent) == 1
         assert sent[0].status == SegmentStatus.PARTIAL
@@ -720,13 +735,27 @@ class TestProcessSign:
         mock_ad = _MockAD([ADEvent.ACTIVE, ADEvent.ACTIVE])
         orch = FusionOrchestrator(window_size=1, activity_detector=mock_ad)
         orch.register_policy(ModalityPath.SIGN, SignFusionPolicy())
-        orch.register_engine(ModalityPath.SIGN, ModalityType.TSL_RECOGNITION, tsl_stub, _cfg("tsl"))
+        orch.register_engine(
+            ModalityPath.SIGN, ModalityType.TSL_RECOGNITION, tsl_stub, _cfg("tsl")
+        )
 
         sent: list[TranscriptSegment] = []
-        await orch.process(_SESSION, _landmark_frame(timestamp_ms=0), [_video_health()], ModalityPath.SIGN, sent.append)
+        await orch.process(
+            _SESSION,
+            _landmark_frame(timestamp_ms=0),
+            [_video_health()],
+            ModalityPath.SIGN,
+            sent.append,
+        )
         # Swap TSL result for second window.
         tsl_stub._result = tsl2
-        await orch.process(_SESSION, _landmark_frame(timestamp_ms=1), [_video_health()], ModalityPath.SIGN, sent.append)
+        await orch.process(
+            _SESSION,
+            _landmark_frame(timestamp_ms=1),
+            [_video_health()],
+            ModalityPath.SIGN,
+            sent.append,
+        )
 
         assert len(sent) == 2
         assert sent[0].text == "YEMEK"
@@ -742,11 +771,25 @@ class TestProcessSign:
         mock_ad = _MockAD([ADEvent.ACTIVE, ADEvent.ACTIVE])
         orch = FusionOrchestrator(window_size=1, activity_detector=mock_ad)
         orch.register_policy(ModalityPath.SIGN, SignFusionPolicy())
-        orch.register_engine(ModalityPath.SIGN, ModalityType.TSL_RECOGNITION, tsl_stub, _cfg("tsl"))
+        orch.register_engine(
+            ModalityPath.SIGN, ModalityType.TSL_RECOGNITION, tsl_stub, _cfg("tsl")
+        )
 
         sent: list[TranscriptSegment] = []
-        await orch.process(_SESSION, _landmark_frame(timestamp_ms=0), [_video_health()], ModalityPath.SIGN, sent.append)
-        await orch.process(_SESSION, _landmark_frame(timestamp_ms=1), [_video_health()], ModalityPath.SIGN, sent.append)
+        await orch.process(
+            _SESSION,
+            _landmark_frame(timestamp_ms=0),
+            [_video_health()],
+            ModalityPath.SIGN,
+            sent.append,
+        )
+        await orch.process(
+            _SESSION,
+            _landmark_frame(timestamp_ms=1),
+            [_video_health()],
+            ModalityPath.SIGN,
+            sent.append,
+        )
 
         assert len(sent) == 1  # Second window deduped.
 
@@ -760,9 +803,21 @@ class TestProcessSign:
         )
         sent: list[TranscriptSegment] = []
         # Frame 1: ACTIVE → window fills → TSL → PARTIAL
-        await orch.process(_SESSION, _landmark_frame(timestamp_ms=0), [_video_health()], ModalityPath.SIGN, sent.append)
+        await orch.process(
+            _SESSION,
+            _landmark_frame(timestamp_ms=0),
+            [_video_health()],
+            ModalityPath.SIGN,
+            sent.append,
+        )
         # Frame 2: ENDED → flush → GlossToText → FINAL
-        await orch.process(_SESSION, _landmark_frame(timestamp_ms=1), [_video_health()], ModalityPath.SIGN, sent.append)
+        await orch.process(
+            _SESSION,
+            _landmark_frame(timestamp_ms=1),
+            [_video_health()],
+            ModalityPath.SIGN,
+            sent.append,
+        )
 
         assert len(sent) == 2
         partial = next(s for s in sent if s.status == SegmentStatus.PARTIAL)
@@ -780,8 +835,20 @@ class TestProcessSign:
             ad_events=[ADEvent.ACTIVE, ADEvent.ENDED],
         )
         sent: list[TranscriptSegment] = []
-        await orch.process(_SESSION, _landmark_frame(timestamp_ms=0), [_video_health()], ModalityPath.SIGN, sent.append)
-        await orch.process(_SESSION, _landmark_frame(timestamp_ms=1), [_video_health()], ModalityPath.SIGN, sent.append)
+        await orch.process(
+            _SESSION,
+            _landmark_frame(timestamp_ms=0),
+            [_video_health()],
+            ModalityPath.SIGN,
+            sent.append,
+        )
+        await orch.process(
+            _SESSION,
+            _landmark_frame(timestamp_ms=1),
+            [_video_health()],
+            ModalityPath.SIGN,
+            sent.append,
+        )
 
         final = next(s for s in sent if s.status == SegmentStatus.FINAL)
         assert final.text == "MERHABA"
@@ -795,8 +862,20 @@ class TestProcessSign:
             ad_events=[ADEvent.ACTIVE, ADEvent.ENDED],
         )
         sent: list[TranscriptSegment] = []
-        await orch.process(_SESSION, _landmark_frame(timestamp_ms=0), [_video_health()], ModalityPath.SIGN, sent.append)
-        await orch.process(_SESSION, _landmark_frame(timestamp_ms=1), [_video_health()], ModalityPath.SIGN, sent.append)
+        await orch.process(
+            _SESSION,
+            _landmark_frame(timestamp_ms=0),
+            [_video_health()],
+            ModalityPath.SIGN,
+            sent.append,
+        )
+        await orch.process(
+            _SESSION,
+            _landmark_frame(timestamp_ms=1),
+            [_video_health()],
+            ModalityPath.SIGN,
+            sent.append,
+        )
 
         final = next(s for s in sent if s.status == SegmentStatus.FINAL)
         assert final.text == "MERHABA"
@@ -812,7 +891,11 @@ class TestProcessSign:
         )
         sent: list[TranscriptSegment] = []
         await orch.process(
-            _SESSION, _landmark_frame(), [_video_health()], ModalityPath.SIGN, sent.append,
+            _SESSION,
+            _landmark_frame(),
+            [_video_health()],
+            ModalityPath.SIGN,
+            sent.append,
         )
         assert sent == []
 
@@ -821,7 +904,11 @@ class TestProcessSign:
         orch = _sign_orch(tsl_timeout=True, ad_events=[ADEvent.ACTIVE])
         sent: list[TranscriptSegment] = []
         await orch.process(
-            _SESSION, _landmark_frame(), [_video_health()], ModalityPath.SIGN, sent.append,
+            _SESSION,
+            _landmark_frame(),
+            [_video_health()],
+            ModalityPath.SIGN,
+            sent.append,
         )
         assert sent == []
 
@@ -833,7 +920,11 @@ class TestProcessSign:
         )
         sent: list[TranscriptSegment] = []
         await orch.process(
-            _SESSION, _landmark_frame(), [_video_health()], ModalityPath.SIGN, sent.append,
+            _SESSION,
+            _landmark_frame(),
+            [_video_health()],
+            ModalityPath.SIGN,
+            sent.append,
         )
         assert sent == []
 
@@ -843,8 +934,11 @@ class TestProcessSign:
         sent: list[TranscriptSegment] = []
         for i in range(2):
             await orch.process(
-                _SESSION, _landmark_frame(timestamp_ms=i),
-                [_video_health()], ModalityPath.SIGN, sent.append,
+                _SESSION,
+                _landmark_frame(timestamp_ms=i),
+                [_video_health()],
+                ModalityPath.SIGN,
+                sent.append,
             )
         assert sent == []
 
@@ -901,13 +995,18 @@ class TestResetSession:
 
         orch = FusionOrchestrator(window_size=3, activity_detector=mock_ad)
         orch.register_policy(ModalityPath.SIGN, SignFusionPolicy())
-        orch.register_engine(ModalityPath.SIGN, ModalityType.TSL_RECOGNITION, tsl, _cfg("tsl"))
+        orch.register_engine(
+            ModalityPath.SIGN, ModalityType.TSL_RECOGNITION, tsl, _cfg("tsl")
+        )
 
         # Push 2 of 3 frames (window not yet full).
         for i in range(2):
             await orch.process(
-                _SESSION, _landmark_frame(timestamp_ms=i),
-                [_video_health()], ModalityPath.SIGN, lambda _: None,
+                _SESSION,
+                _landmark_frame(timestamp_ms=i),
+                [_video_health()],
+                ModalityPath.SIGN,
+                lambda _: None,
             )
         orch.reset_session(_SESSION)
 
@@ -915,8 +1014,11 @@ class TestResetSession:
         sent: list[TranscriptSegment] = []
         for i in range(2):
             await orch.process(
-                _SESSION, _landmark_frame(timestamp_ms=i + 10),
-                [_video_health()], ModalityPath.SIGN, sent.append,
+                _SESSION,
+                _landmark_frame(timestamp_ms=i + 10),
+                [_video_health()],
+                ModalityPath.SIGN,
+                sent.append,
             )
         assert sent == []
 

--- a/tests/fusion/test_orchestrator_process.py
+++ b/tests/fusion/test_orchestrator_process.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-
 from sozia.common.interfaces import InferenceEngine, InferenceTimeoutError
 from sozia.common.models import (
     FACE_LANDMARK_COUNT,
@@ -18,6 +17,8 @@ from sozia.common.models import (
     SegmentStatus,
     TranscriptSegment,
 )
+from sozia.server.fusion.activity_detector import ADEvent, ActivityDetector
+from sozia.server.fusion.gloss_accumulator import GlossAccumulator
 from sozia.server.fusion.orchestrator import FusionOrchestrator
 from sozia.server.fusion.sign_fusion_policy import SignFusionPolicy
 from sozia.server.fusion.speech_fusion_policy import SpeechFusionPolicy
@@ -137,6 +138,23 @@ class _StubEngine(InferenceEngine):
         return self._model_id if self._loaded else ""
 
 
+class _MockAD:
+    """Stub ActivityDetector that returns a fixed sequence of ADEvents."""
+
+    def __init__(self, events: list[ADEvent], default: ADEvent = ADEvent.IDLE) -> None:
+        self._events = iter(events)
+        self._default = default
+
+    def update(self, frame: LandmarkFrame) -> ADEvent:
+        return next(self._events, self._default)
+
+    def reset(self, session_id: str) -> None:
+        pass
+
+    def is_active(self, session_id: str) -> bool:
+        return False
+
+
 def _make_orchestrator(
     window_size: int = 1,
     mel_max_frames: int = 1500,
@@ -146,8 +164,15 @@ def _make_orchestrator(
     lip_engine: _StubEngine | None = None,
     tsl_engine: _StubEngine | None = None,
     gloss_engine: _StubEngine | None = None,
+    activity_detector: ActivityDetector | None = None,
+    gloss_accumulator: GlossAccumulator | None = None,
 ) -> FusionOrchestrator:
-    orch = FusionOrchestrator(window_size=window_size, mel_max_frames=mel_max_frames)
+    orch = FusionOrchestrator(
+        window_size=window_size,
+        mel_max_frames=mel_max_frames,
+        activity_detector=activity_detector,
+        gloss_accumulator=gloss_accumulator,
+    )
     orch.register_policy(ModalityPath.SPEECH, SpeechFusionPolicy())
     orch.register_policy(ModalityPath.SIGN, SignFusionPolicy())
 
@@ -612,170 +637,215 @@ class TestProcessSpeech:
 
 
 # ---------------------------------------------------------------------------
-# process() — Path B (SIGN)
+# process() — Path B (SIGN) — AD-gated multi-word accumulation flow
 # ---------------------------------------------------------------------------
 
 
+def _sign_orch(
+    tsl_result: ModalityResult | None = None,
+    gloss_result: ModalityResult | None = None,
+    tsl_timeout: bool = False,
+    gloss_timeout: bool = False,
+    ad_events: list[ADEvent] | None = None,
+    window_size: int = 1,
+) -> FusionOrchestrator:
+    """Build an orchestrator wired for sign-path tests with a controlled AD."""
+    tsl = _StubEngine(
+        tsl_result or _result(ModalityType.TSL_RECOGNITION, "MERHABA", 0.80),
+        raise_timeout=tsl_timeout,
+        model_id="tsl",
+    )
+    tsl._loaded = True
+
+    mock_ad = _MockAD(ad_events or [ADEvent.ACTIVE])
+    orch = FusionOrchestrator(window_size=window_size, activity_detector=mock_ad)
+    orch.register_policy(ModalityPath.SIGN, SignFusionPolicy())
+    orch.register_engine(ModalityPath.SIGN, ModalityType.TSL_RECOGNITION, tsl, _cfg("tsl"))
+
+    if gloss_result is not None or gloss_timeout:
+        g = _StubEngine(gloss_result, raise_timeout=gloss_timeout, model_id="gemma")
+        g._loaded = True
+        orch.register_engine(ModalityPath.SIGN, ModalityType.GLOSS_TO_TEXT, g, _cfg("gemma"))
+
+    return orch
+
+
 class TestProcessSign:
-    async def test_partial_window_emits_nothing(self):
-        orch = _make_orchestrator(window_size=5, with_sign=True)
-        sent: list[TranscriptSegment] = []
-        for i in range(4):
-            await orch.process(
-                _SESSION,
-                _landmark_frame(timestamp_ms=i),
-                [_video_health()],
-                ModalityPath.SIGN,
-                sent.append,
-            )
-        assert sent == []
-
-    async def test_full_window_emits_partial_from_tsl(self):
-        tsl = _StubEngine(
-            _result(ModalityType.TSL_RECOGNITION, "MERHABA", 0.80), model_id="tsl"
-        )
-        tsl._loaded = True
-        gloss = _StubEngine(
-            _result(ModalityType.GLOSS_TO_TEXT, "Merhaba.", 0.88), model_id="gemma"
-        )
-        gloss._loaded = True
-
-        orch = FusionOrchestrator(window_size=3)
-        orch.register_policy(ModalityPath.SIGN, SignFusionPolicy())
-        orch.register_engine(
-            ModalityPath.SIGN, ModalityType.TSL_RECOGNITION, tsl, _cfg("tsl")
-        )
-        orch.register_engine(
-            ModalityPath.SIGN, ModalityType.GLOSS_TO_TEXT, gloss, _cfg("gemma")
-        )
-
+    async def test_idle_event_produces_nothing(self):
+        """AD returning IDLE means no frames reach the accumulator."""
+        orch = _sign_orch(ad_events=[ADEvent.IDLE, ADEvent.IDLE, ADEvent.IDLE])
         sent: list[TranscriptSegment] = []
         for i in range(3):
             await orch.process(
-                _SESSION,
-                _landmark_frame(timestamp_ms=i),
-                [_video_health()],
-                ModalityPath.SIGN,
-                sent.append,
+                _SESSION, _landmark_frame(timestamp_ms=i),
+                [_video_health()], ModalityPath.SIGN, sent.append,
             )
+        assert sent == []
 
-        # Should have: PARTIAL (TSL) + FINAL (gloss)
-        assert len(sent) == 2
-        statuses = {s.status for s in sent}
-        assert SegmentStatus.PARTIAL in statuses
-        assert SegmentStatus.FINAL in statuses
-
-    async def test_full_window_partial_text_is_gloss(self):
-        tsl = _StubEngine(
-            _result(ModalityType.TSL_RECOGNITION, "MERHABA DUNYA", 0.80), model_id="tsl"
+    async def test_active_window_emits_partial(self):
+        """ACTIVE event + full window → TSL predict → PARTIAL emitted."""
+        orch = _sign_orch(
+            tsl_result=_result(ModalityType.TSL_RECOGNITION, "MERHABA", 0.80),
+            ad_events=[ADEvent.ACTIVE],
         )
-        tsl._loaded = True
-        gloss = _StubEngine(
-            _result(ModalityType.GLOSS_TO_TEXT, "Merhaba dünya.", 0.88),
-            model_id="gemma",
-        )
-        gloss._loaded = True
-
-        orch = FusionOrchestrator(window_size=1)
-        orch.register_policy(ModalityPath.SIGN, SignFusionPolicy())
-        orch.register_engine(
-            ModalityPath.SIGN, ModalityType.TSL_RECOGNITION, tsl, _cfg("tsl")
-        )
-        orch.register_engine(
-            ModalityPath.SIGN, ModalityType.GLOSS_TO_TEXT, gloss, _cfg("gemma")
-        )
-
         sent: list[TranscriptSegment] = []
         await orch.process(
-            _SESSION,
-            _landmark_frame(),
-            [_video_health()],
-            ModalityPath.SIGN,
-            sent.append,
+            _SESSION, _landmark_frame(), [_video_health()], ModalityPath.SIGN, sent.append,
         )
+        assert len(sent) == 1
+        assert sent[0].status == SegmentStatus.PARTIAL
+        assert sent[0].text == "MERHABA"
+
+    async def test_started_event_same_as_active(self):
+        """STARTED (rising edge) feeds the window just like ACTIVE."""
+        orch = _sign_orch(
+            tsl_result=_result(ModalityType.TSL_RECOGNITION, "GİT", 0.75),
+            ad_events=[ADEvent.STARTED],
+        )
+        sent: list[TranscriptSegment] = []
+        await orch.process(
+            _SESSION, _landmark_frame(), [_video_health()], ModalityPath.SIGN, sent.append,
+        )
+        assert len(sent) == 1
+        assert sent[0].status == SegmentStatus.PARTIAL
+        assert sent[0].text == "GİT"
+
+    async def test_two_active_windows_emit_growing_phrase(self):
+        """Second ACTIVE window appends a new word → second PARTIAL replaces first."""
+        tsl1 = _result(ModalityType.TSL_RECOGNITION, "YEMEK", 0.80)
+        tsl2 = _result(ModalityType.TSL_RECOGNITION, "OKUL", 0.75)
+        tsl_stub = _StubEngine(tsl1, model_id="tsl")
+        tsl_stub._loaded = True
+
+        mock_ad = _MockAD([ADEvent.ACTIVE, ADEvent.ACTIVE])
+        orch = FusionOrchestrator(window_size=1, activity_detector=mock_ad)
+        orch.register_policy(ModalityPath.SIGN, SignFusionPolicy())
+        orch.register_engine(ModalityPath.SIGN, ModalityType.TSL_RECOGNITION, tsl_stub, _cfg("tsl"))
+
+        sent: list[TranscriptSegment] = []
+        await orch.process(_SESSION, _landmark_frame(timestamp_ms=0), [_video_health()], ModalityPath.SIGN, sent.append)
+        # Swap TSL result for second window.
+        tsl_stub._result = tsl2
+        await orch.process(_SESSION, _landmark_frame(timestamp_ms=1), [_video_health()], ModalityPath.SIGN, sent.append)
+
+        assert len(sent) == 2
+        assert sent[0].text == "YEMEK"
+        assert sent[1].text == "YEMEK OKUL"
+        assert sent[1].replaces_segment_id == sent[0].segment_id
+
+    async def test_dedup_same_gloss_no_second_partial(self):
+        """Consecutive identical TSL glosses are deduped — no second PARTIAL."""
+        tsl_result = _result(ModalityType.TSL_RECOGNITION, "YEMEK", 0.70)
+        tsl_stub = _StubEngine(tsl_result, model_id="tsl")
+        tsl_stub._loaded = True
+
+        mock_ad = _MockAD([ADEvent.ACTIVE, ADEvent.ACTIVE])
+        orch = FusionOrchestrator(window_size=1, activity_detector=mock_ad)
+        orch.register_policy(ModalityPath.SIGN, SignFusionPolicy())
+        orch.register_engine(ModalityPath.SIGN, ModalityType.TSL_RECOGNITION, tsl_stub, _cfg("tsl"))
+
+        sent: list[TranscriptSegment] = []
+        await orch.process(_SESSION, _landmark_frame(timestamp_ms=0), [_video_health()], ModalityPath.SIGN, sent.append)
+        await orch.process(_SESSION, _landmark_frame(timestamp_ms=1), [_video_health()], ModalityPath.SIGN, sent.append)
+
+        assert len(sent) == 1  # Second window deduped.
+
+    async def test_ended_high_llm_confidence_emits_final_from_llm(self):
+        """ACTIVE accumulates a word, ENDED triggers GlossToText FINAL."""
+        gloss_res = _result(ModalityType.GLOSS_TO_TEXT, "Merhaba.", 0.88)
+        orch = _sign_orch(
+            tsl_result=_result(ModalityType.TSL_RECOGNITION, "MERHABA", 0.80),
+            gloss_result=gloss_res,
+            ad_events=[ADEvent.ACTIVE, ADEvent.ENDED],
+        )
+        sent: list[TranscriptSegment] = []
+        # Frame 1: ACTIVE → window fills → TSL → PARTIAL
+        await orch.process(_SESSION, _landmark_frame(timestamp_ms=0), [_video_health()], ModalityPath.SIGN, sent.append)
+        # Frame 2: ENDED → flush → GlossToText → FINAL
+        await orch.process(_SESSION, _landmark_frame(timestamp_ms=1), [_video_health()], ModalityPath.SIGN, sent.append)
+
+        assert len(sent) == 2
         partial = next(s for s in sent if s.status == SegmentStatus.PARTIAL)
         final = next(s for s in sent if s.status == SegmentStatus.FINAL)
-        assert partial.text == "MERHABA DUNYA"
-        assert final.text == "Merhaba dünya."
-        # replaces_segment_id linking tested after orchestrator _process_sign rewrite.
+        assert final.text == "Merhaba."
+        assert final.source == ModalityType.GLOSS_TO_TEXT
+        assert final.replaces_segment_id == partial.segment_id
 
-    async def test_tsl_timeout_emits_nothing(self):
-        tsl = _StubEngine(None, raise_timeout=True, model_id="tsl")
-        tsl._loaded = True
-
-        orch = FusionOrchestrator(window_size=1)
-        orch.register_policy(ModalityPath.SIGN, SignFusionPolicy())
-        orch.register_engine(
-            ModalityPath.SIGN, ModalityType.TSL_RECOGNITION, tsl, _cfg("tsl")
+    async def test_ended_low_llm_confidence_emits_final_from_gloss(self):
+        """LLM confidence below 0.40 → raw gloss becomes FINAL."""
+        gloss_res = _result(ModalityType.GLOSS_TO_TEXT, "Merhaba.", confidence=0.20)
+        orch = _sign_orch(
+            tsl_result=_result(ModalityType.TSL_RECOGNITION, "MERHABA", 0.80),
+            gloss_result=gloss_res,
+            ad_events=[ADEvent.ACTIVE, ADEvent.ENDED],
         )
+        sent: list[TranscriptSegment] = []
+        await orch.process(_SESSION, _landmark_frame(timestamp_ms=0), [_video_health()], ModalityPath.SIGN, sent.append)
+        await orch.process(_SESSION, _landmark_frame(timestamp_ms=1), [_video_health()], ModalityPath.SIGN, sent.append)
 
+        final = next(s for s in sent if s.status == SegmentStatus.FINAL)
+        assert final.text == "MERHABA"
+        assert final.source == ModalityType.TSL_RECOGNITION
+
+    async def test_ended_gloss_timeout_emits_penalised_final(self):
+        """GlossToText timeout on ENDED → raw gloss FINAL with confidence penalty."""
+        orch = _sign_orch(
+            tsl_result=_result(ModalityType.TSL_RECOGNITION, "MERHABA", 0.80),
+            gloss_timeout=True,
+            ad_events=[ADEvent.ACTIVE, ADEvent.ENDED],
+        )
+        sent: list[TranscriptSegment] = []
+        await orch.process(_SESSION, _landmark_frame(timestamp_ms=0), [_video_health()], ModalityPath.SIGN, sent.append)
+        await orch.process(_SESSION, _landmark_frame(timestamp_ms=1), [_video_health()], ModalityPath.SIGN, sent.append)
+
+        final = next(s for s in sent if s.status == SegmentStatus.FINAL)
+        assert final.text == "MERHABA"
+        assert final.confidence < 0.80  # Penalised.
+        partial = next(s for s in sent if s.status == SegmentStatus.PARTIAL)
+        assert final.replaces_segment_id == partial.segment_id
+
+    async def test_ended_empty_accumulator_produces_nothing(self):
+        """ENDED with no accumulated glosses emits nothing."""
+        orch = _sign_orch(
+            gloss_result=_result(ModalityType.GLOSS_TO_TEXT, "x", 0.88),
+            ad_events=[ADEvent.ENDED],
+        )
         sent: list[TranscriptSegment] = []
         await orch.process(
-            _SESSION,
-            _landmark_frame(),
-            [_video_health()],
-            ModalityPath.SIGN,
-            sent.append,
+            _SESSION, _landmark_frame(), [_video_health()], ModalityPath.SIGN, sent.append,
         )
         assert sent == []
 
-    async def test_gloss_timeout_promotes_tsl_partial_to_final(self):
-        tsl = _StubEngine(
-            _result(ModalityType.TSL_RECOGNITION, "MERHABA", 0.80), model_id="tsl"
-        )
-        tsl._loaded = True
-        gloss = _StubEngine(None, raise_timeout=True, model_id="gemma")
-        gloss._loaded = True
-
-        orch = FusionOrchestrator(window_size=1)
-        orch.register_policy(ModalityPath.SIGN, SignFusionPolicy())
-        orch.register_engine(
-            ModalityPath.SIGN, ModalityType.TSL_RECOGNITION, tsl, _cfg("tsl")
-        )
-        orch.register_engine(
-            ModalityPath.SIGN, ModalityType.GLOSS_TO_TEXT, gloss, _cfg("gemma")
-        )
-
+    async def test_tsl_timeout_on_active_discards_window(self):
+        """TSL timeout during ACTIVE — no PARTIAL emitted, no crash."""
+        orch = _sign_orch(tsl_timeout=True, ad_events=[ADEvent.ACTIVE])
         sent: list[TranscriptSegment] = []
         await orch.process(
-            _SESSION,
-            _landmark_frame(),
-            [_video_health()],
-            ModalityPath.SIGN,
-            sent.append,
+            _SESSION, _landmark_frame(), [_video_health()], ModalityPath.SIGN, sent.append,
         )
+        assert sent == []
 
-        # PARTIAL (TSL gloss) + FINAL (promoted from TSL on gloss timeout)
-        assert len(sent) == 2
-        partial = next(s for s in sent if s.status == SegmentStatus.PARTIAL)
-        final = next(s for s in sent if s.status == SegmentStatus.FINAL)
-        # FINAL replaces the PARTIAL
-        assert final.replaces_segment_id == partial.segment_id
-        # FINAL carries TSL raw gloss text (fallback)
-        assert final.text == "MERHABA"
-        # Confidence penalised
-        assert final.confidence < 0.80
-
-    async def test_suppressed_tsl_emits_nothing(self):
-        tsl = _StubEngine(
-            _result(ModalityType.TSL_RECOGNITION, "x", 0.10), model_id="tsl"
+    async def test_suppressed_tsl_produces_nothing(self):
+        """TSL confidence below 0.55 → suppressed, no PARTIAL."""
+        orch = _sign_orch(
+            tsl_result=_result(ModalityType.TSL_RECOGNITION, "noise", 0.10),
+            ad_events=[ADEvent.ACTIVE],
         )
-        tsl._loaded = True
-
-        orch = FusionOrchestrator(window_size=1)
-        orch.register_policy(ModalityPath.SIGN, SignFusionPolicy())
-        orch.register_engine(
-            ModalityPath.SIGN, ModalityType.TSL_RECOGNITION, tsl, _cfg("tsl")
-        )
-
         sent: list[TranscriptSegment] = []
         await orch.process(
-            _SESSION,
-            _landmark_frame(),
-            [_video_health()],
-            ModalityPath.SIGN,
-            sent.append,
+            _SESSION, _landmark_frame(), [_video_health()], ModalityPath.SIGN, sent.append,
         )
+        assert sent == []
+
+    async def test_window_not_full_produces_nothing(self):
+        """ACTIVE but window not yet full — no inference, no PARTIAL."""
+        orch = _sign_orch(ad_events=[ADEvent.ACTIVE, ADEvent.ACTIVE], window_size=3)
+        sent: list[TranscriptSegment] = []
+        for i in range(2):
+            await orch.process(
+                _SESSION, _landmark_frame(timestamp_ms=i),
+                [_video_health()], ModalityPath.SIGN, sent.append,
+            )
         assert sent == []
 
     async def test_audio_chunk_on_sign_path_is_noop(self):
@@ -821,29 +891,48 @@ class TestResetSession:
         assert all(seg.source == ModalityType.ASR for seg in sent)
 
     async def test_reset_clears_accumulator_buffer(self):
-        """After reset, frame count restarts from zero."""
-        orch = _make_orchestrator(window_size=3, with_sign=True)
+        """After reset, frame count restarts from zero (verified via ACTIVE events)."""
+        # AD always returns ACTIVE so frames reach the accumulator.
+        mock_ad = _MockAD([], default=ADEvent.ACTIVE)
+        tsl = _StubEngine(
+            _result(ModalityType.TSL_RECOGNITION, "MERHABA", 0.80), model_id="tsl"
+        )
+        tsl._loaded = True
+
+        orch = FusionOrchestrator(window_size=3, activity_detector=mock_ad)
+        orch.register_policy(ModalityPath.SIGN, SignFusionPolicy())
+        orch.register_engine(ModalityPath.SIGN, ModalityType.TSL_RECOGNITION, tsl, _cfg("tsl"))
+
         # Push 2 of 3 frames (window not yet full).
         for i in range(2):
             await orch.process(
-                _SESSION,
-                _landmark_frame(timestamp_ms=i),
-                [_video_health()],
-                ModalityPath.SIGN,
-                lambda _: None,
+                _SESSION, _landmark_frame(timestamp_ms=i),
+                [_video_health()], ModalityPath.SIGN, lambda _: None,
             )
         orch.reset_session(_SESSION)
-        # Push 2 more — should still not hit the window (buffer was cleared).
+
+        # After reset, 2 more frames should still not fill the window.
         sent: list[TranscriptSegment] = []
         for i in range(2):
             await orch.process(
-                _SESSION,
-                _landmark_frame(timestamp_ms=i + 10),
-                [_video_health()],
-                ModalityPath.SIGN,
-                sent.append,
+                _SESSION, _landmark_frame(timestamp_ms=i + 10),
+                [_video_health()], ModalityPath.SIGN, sent.append,
             )
         assert sent == []
+
+    async def test_reset_clears_gloss_accumulator(self):
+        """After reset, GlossAccumulator state is cleared for the session."""
+        from sozia.server.fusion.gloss_accumulator import GlossAccumulator, GlossEntry
+
+        gloss_acc = GlossAccumulator()
+        orch = FusionOrchestrator(gloss_accumulator=gloss_acc)
+
+        # Manually seed a gloss entry for the session.
+        gloss_acc.push(_SESSION, GlossEntry("MERHABA", 0.80, 1000, 500))
+        assert not gloss_acc.is_empty(_SESSION)
+
+        orch.reset_session(_SESSION)
+        assert gloss_acc.is_empty(_SESSION)
 
     def test_reset_unknown_session_is_safe(self):
         """reset_session on a session with no state does not raise."""

--- a/tests/fusion/test_orchestrator_process.py
+++ b/tests/fusion/test_orchestrator_process.py
@@ -697,7 +697,7 @@ class TestProcessSign:
         final = next(s for s in sent if s.status == SegmentStatus.FINAL)
         assert partial.text == "MERHABA DUNYA"
         assert final.text == "Merhaba dünya."
-        assert final.replaces_segment_id == partial.segment_id
+        # replaces_segment_id linking tested after orchestrator _process_sign rewrite.
 
     async def test_tsl_timeout_emits_nothing(self):
         tsl = _StubEngine(None, raise_timeout=True, model_id="tsl")

--- a/tests/fusion/test_sign_fusion_policy.py
+++ b/tests/fusion/test_sign_fusion_policy.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import uuid
+
 from sozia.common.models import (
     ModalityResult,
     ModalityType,
@@ -15,6 +17,7 @@ from sozia.server.fusion.sign_fusion_policy import SignFusionPolicy
 # ---------------------------------------------------------------------------
 
 _SESSION = "550e8400-e29b-41d4-a716-446655440000"
+_PREV_PARTIAL_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
 
 
 def _tsl(text: str = "MERHABA DUNYA", confidence: float = 0.80) -> ModalityResult:
@@ -40,19 +43,21 @@ def _gloss(text: str = "Merhaba dünya.", confidence: float = 0.85) -> ModalityR
 
 
 def _health() -> list[PipelineHealth]:
-    return [PipelineHealth(
-        session_id=_SESSION,
-        pipeline="video",
-        available=True,
-        fps=30.0,
-        snr=None,
-        face_detected=True,
-        last_updated_ms=1000,
-    )]
+    return [
+        PipelineHealth(
+            session_id=_SESSION,
+            pipeline="video",
+            available=True,
+            fps=30.0,
+            snr=None,
+            face_detected=True,
+            last_updated_ms=1000,
+        )
+    ]
 
 
 # ---------------------------------------------------------------------------
-# Tests
+# TSL suppress gate (threshold = 0.55)
 # ---------------------------------------------------------------------------
 
 
@@ -61,13 +66,208 @@ class TestShouldSuppress:
         policy = SignFusionPolicy()
         assert policy.should_suppress(_tsl(confidence=0.20)) is True
 
+    def test_at_threshold_not_suppressed(self):
+        policy = SignFusionPolicy()
+        assert policy.should_suppress(_tsl(confidence=0.55)) is False
+
     def test_above_threshold_not_suppressed(self):
         policy = SignFusionPolicy()
-        assert policy.should_suppress(_tsl(confidence=0.50)) is False
+        assert policy.should_suppress(_tsl(confidence=0.70)) is False
 
-    def test_confidence_threshold_value(self):
+    def test_tsl_confidence_threshold_value(self):
         policy = SignFusionPolicy()
-        assert policy.get_confidence_threshold() == 0.30
+        assert policy.get_confidence_threshold() == 0.55
+
+    def test_custom_tsl_threshold_respected(self):
+        policy = SignFusionPolicy(confidence_threshold=0.60)
+        assert policy.should_suppress(_tsl(confidence=0.58)) is True
+        assert policy.should_suppress(_tsl(confidence=0.61)) is False
+
+
+# ---------------------------------------------------------------------------
+# LLM suppress gate (threshold = 0.40)
+# ---------------------------------------------------------------------------
+
+
+class TestShouldSuppressLlm:
+    def test_below_llm_threshold_suppressed(self):
+        policy = SignFusionPolicy()
+        assert policy.should_suppress_llm(_gloss(confidence=0.30)) is True
+
+    def test_at_llm_threshold_not_suppressed(self):
+        policy = SignFusionPolicy()
+        assert policy.should_suppress_llm(_gloss(confidence=0.40)) is False
+
+    def test_above_llm_threshold_not_suppressed(self):
+        policy = SignFusionPolicy()
+        assert policy.should_suppress_llm(_gloss(confidence=0.85)) is False
+
+    def test_llm_threshold_value(self):
+        policy = SignFusionPolicy()
+        assert policy.get_llm_confidence_threshold() == 0.40
+
+    def test_custom_llm_threshold_respected(self):
+        policy = SignFusionPolicy(llm_confidence_threshold=0.50)
+        assert policy.should_suppress_llm(_gloss(confidence=0.45)) is True
+        assert policy.should_suppress_llm(_gloss(confidence=0.55)) is False
+
+    def test_llm_threshold_lower_than_tsl_threshold(self):
+        policy = SignFusionPolicy()
+        # LLM conf-exp scores are lower than TSL softmax; verify ordering.
+        assert policy.get_llm_confidence_threshold() < policy.get_confidence_threshold()
+
+
+# ---------------------------------------------------------------------------
+# emit_partial helper
+# ---------------------------------------------------------------------------
+
+
+class TestEmitPartial:
+    def test_returns_partial_segment(self):
+        policy = SignFusionPolicy()
+        seg = policy.emit_partial(_SESSION, "MERHABA DUNYA", _tsl(), replaces_id=None)
+        assert seg.status == SegmentStatus.PARTIAL
+
+    def test_text_is_gloss_phrase_not_raw_result(self):
+        # Phrase passed in may be multi-word accumulated phrase.
+        policy = SignFusionPolicy()
+        seg = policy.emit_partial(_SESSION, "YEMEK OKUL", _tsl(text="OKUL"), replaces_id=None)
+        assert seg.text == "YEMEK OKUL"
+
+    def test_source_is_tsl_recognition(self):
+        policy = SignFusionPolicy()
+        seg = policy.emit_partial(_SESSION, "X", _tsl(), replaces_id=None)
+        assert seg.source == ModalityType.TSL_RECOGNITION
+
+    def test_confidence_from_tsl_result(self):
+        policy = SignFusionPolicy()
+        seg = policy.emit_partial(_SESSION, "X", _tsl(confidence=0.72), replaces_id=None)
+        assert seg.confidence == 0.72
+
+    def test_session_id_set(self):
+        policy = SignFusionPolicy()
+        seg = policy.emit_partial(_SESSION, "X", _tsl(), replaces_id=None)
+        assert seg.session_id == _SESSION
+
+    def test_segment_id_is_valid_uuid_v4(self):
+        policy = SignFusionPolicy()
+        seg = policy.emit_partial(_SESSION, "X", _tsl(), replaces_id=None)
+        assert uuid.UUID(seg.segment_id).version == 4
+
+    def test_replaces_id_none_when_no_prior_partial(self):
+        policy = SignFusionPolicy()
+        seg = policy.emit_partial(_SESSION, "X", _tsl(), replaces_id=None)
+        assert seg.replaces_segment_id is None
+
+    def test_replaces_id_forwarded_when_provided(self):
+        policy = SignFusionPolicy()
+        seg = policy.emit_partial(_SESSION, "X", _tsl(), replaces_id=_PREV_PARTIAL_ID)
+        assert seg.replaces_segment_id == _PREV_PARTIAL_ID
+
+    def test_two_calls_return_different_segment_ids(self):
+        policy = SignFusionPolicy()
+        s1 = policy.emit_partial(_SESSION, "A", _tsl(), replaces_id=None)
+        s2 = policy.emit_partial(_SESSION, "B", _tsl(), replaces_id=None)
+        assert s1.segment_id != s2.segment_id
+
+
+# ---------------------------------------------------------------------------
+# emit_final_from_llm helper
+# ---------------------------------------------------------------------------
+
+
+class TestEmitFinalFromLlm:
+    def test_returns_final_segment(self):
+        policy = SignFusionPolicy()
+        seg = policy.emit_final_from_llm(_SESSION, "MERHABA", _gloss(), replaces_id=None)
+        assert seg.status == SegmentStatus.FINAL
+
+    def test_text_is_llm_output(self):
+        policy = SignFusionPolicy()
+        seg = policy.emit_final_from_llm(_SESSION, "MERHABA", _gloss(text="Merhaba dünya."), replaces_id=None)
+        assert seg.text == "Merhaba dünya."
+
+    def test_source_is_gloss_to_text(self):
+        policy = SignFusionPolicy()
+        seg = policy.emit_final_from_llm(_SESSION, "X", _gloss(), replaces_id=None)
+        assert seg.source == ModalityType.GLOSS_TO_TEXT
+
+    def test_confidence_from_llm_result(self):
+        policy = SignFusionPolicy()
+        seg = policy.emit_final_from_llm(_SESSION, "X", _gloss(confidence=0.73), replaces_id=None)
+        assert seg.confidence == 0.73
+
+    def test_replaces_id_forwarded(self):
+        policy = SignFusionPolicy()
+        seg = policy.emit_final_from_llm(_SESSION, "X", _gloss(), replaces_id=_PREV_PARTIAL_ID)
+        assert seg.replaces_segment_id == _PREV_PARTIAL_ID
+
+    def test_replaces_id_none_when_omitted(self):
+        policy = SignFusionPolicy()
+        seg = policy.emit_final_from_llm(_SESSION, "X", _gloss(), replaces_id=None)
+        assert seg.replaces_segment_id is None
+
+
+# ---------------------------------------------------------------------------
+# emit_final_from_gloss helper (timeout / low-confidence LLM fallback)
+# ---------------------------------------------------------------------------
+
+
+class TestEmitFinalFromGloss:
+    def test_returns_final_segment(self):
+        policy = SignFusionPolicy()
+        seg = policy.emit_final_from_gloss(
+            _SESSION, "YEMEK OKUL", aggregate_conf=0.60,
+            timestamp_ms=1000, duration_ms=2000, replaces_id=None,
+        )
+        assert seg.status == SegmentStatus.FINAL
+
+    def test_text_is_raw_gloss_phrase(self):
+        policy = SignFusionPolicy()
+        seg = policy.emit_final_from_gloss(
+            _SESSION, "YEMEK OKUL", aggregate_conf=0.60,
+            timestamp_ms=1000, duration_ms=2000, replaces_id=None,
+        )
+        assert seg.text == "YEMEK OKUL"
+
+    def test_source_is_tsl_recognition(self):
+        # Raw-gloss fallback still originates from TSL, not GlossToText.
+        policy = SignFusionPolicy()
+        seg = policy.emit_final_from_gloss(
+            _SESSION, "X", aggregate_conf=0.60,
+            timestamp_ms=1000, duration_ms=2000, replaces_id=None,
+        )
+        assert seg.source == ModalityType.TSL_RECOGNITION
+
+    def test_aggregate_confidence_used(self):
+        policy = SignFusionPolicy()
+        seg = policy.emit_final_from_gloss(
+            _SESSION, "X", aggregate_conf=0.58,
+            timestamp_ms=1000, duration_ms=2000, replaces_id=None,
+        )
+        assert seg.confidence == 0.58
+
+    def test_timestamp_and_duration_forwarded(self):
+        policy = SignFusionPolicy()
+        seg = policy.emit_final_from_gloss(
+            _SESSION, "X", aggregate_conf=0.60,
+            timestamp_ms=5000, duration_ms=3000, replaces_id=None,
+        )
+        assert seg.timestamp_ms == 5000
+        assert seg.duration_ms == 3000
+
+    def test_replaces_id_forwarded(self):
+        policy = SignFusionPolicy()
+        seg = policy.emit_final_from_gloss(
+            _SESSION, "X", aggregate_conf=0.60,
+            timestamp_ms=1000, duration_ms=2000, replaces_id=_PREV_PARTIAL_ID,
+        )
+        assert seg.replaces_segment_id == _PREV_PARTIAL_ID
+
+
+# ---------------------------------------------------------------------------
+# fuse() — kept for backward compat / integration; no longer tracks partial IDs
+# ---------------------------------------------------------------------------
 
 
 class TestFuseEmpty:
@@ -111,47 +311,17 @@ class TestFuseGlossToText:
         assert seg.text == "Merhaba dünya."
 
     def test_gloss_confidence_used_directly(self):
-        """No weighted merge — GlossToText confidence is used as-is."""
         policy = SignFusionPolicy()
         segments = policy.fuse([_gloss(confidence=0.90)], _health())
         assert segments[0].confidence == 0.90
 
     def test_both_present_gloss_wins(self):
-        """When both TSL and GlossToText are valid, FINAL with GlossToText."""
         policy = SignFusionPolicy()
         segments = policy.fuse([_tsl(), _gloss()], _health())
 
         assert len(segments) == 1
         assert segments[0].status == SegmentStatus.FINAL
         assert segments[0].text == "Merhaba dünya."
-
-
-class TestFuseReplacesSegmentId:
-    def test_partial_then_final_links_via_replaces(self):
-        policy = SignFusionPolicy()
-
-        # Step 1: TSL only → PARTIAL
-        partials = policy.fuse([_tsl()], _health())
-        partial_id = partials[0].segment_id
-
-        # Step 2: GlossToText → FINAL should reference the PARTIAL
-        finals = policy.fuse([_gloss()], _health())
-        assert finals[0].replaces_segment_id == partial_id
-
-    def test_final_without_prior_partial_has_no_replaces(self):
-        policy = SignFusionPolicy()
-        segments = policy.fuse([_gloss()], _health())
-        assert segments[0].replaces_segment_id is None
-
-    def test_replaces_consumed_only_once(self):
-        policy = SignFusionPolicy()
-
-        policy.fuse([_tsl()], _health())
-        policy.fuse([_gloss()], _health())
-
-        # Second FINAL should have no replaces
-        segments = policy.fuse([_gloss()], _health())
-        assert segments[0].replaces_segment_id is None
 
 
 class TestFuseSuppressedModality:
@@ -174,7 +344,6 @@ class TestFuseSuppressedModality:
         assert segments[0].source == ModalityType.GLOSS_TO_TEXT
 
     def test_unrelated_modality_returns_empty(self):
-        """Sign policy must ignore non-sign modalities (ASR/LipReading)."""
         policy = SignFusionPolicy()
         asr_like = ModalityResult(
             modality_type=ModalityType.ASR,
@@ -186,16 +355,21 @@ class TestFuseSuppressedModality:
         )
         assert policy.fuse([asr_like], _health()) == []
 
+    def test_gloss_between_llm_and_tsl_thresholds_not_suppressed(self):
+        # Confidence 0.45: above LLM threshold (0.40) but below TSL threshold (0.55).
+        # fuse() uses should_suppress_llm() for gloss results, so it should pass.
+        policy = SignFusionPolicy()
+        segments = policy.fuse([_gloss(confidence=0.45)], _health())
+        assert len(segments) == 1
+        assert segments[0].status == SegmentStatus.FINAL
+
 
 class TestSegmentIdFormat:
     def test_segment_id_is_dashed_uuid_v4(self):
-        """segment_id must be a canonical UUID v4 string (with dashes)."""
-        import uuid as _uuid
-
         policy = SignFusionPolicy()
         segments = policy.fuse([_tsl()], _health())
         assert len(segments) == 1
 
         seg_id = segments[0].segment_id
         assert "-" in seg_id
-        assert _uuid.UUID(seg_id).version == 4
+        assert uuid.UUID(seg_id).version == 4

--- a/tests/fusion/test_sign_fusion_policy.py
+++ b/tests/fusion/test_sign_fusion_policy.py
@@ -131,7 +131,9 @@ class TestEmitPartial:
     def test_text_is_gloss_phrase_not_raw_result(self):
         # Phrase passed in may be multi-word accumulated phrase.
         policy = SignFusionPolicy()
-        seg = policy.emit_partial(_SESSION, "YEMEK OKUL", _tsl(text="OKUL"), replaces_id=None)
+        seg = policy.emit_partial(
+            _SESSION, "YEMEK OKUL", _tsl(text="OKUL"), replaces_id=None
+        )
         assert seg.text == "YEMEK OKUL"
 
     def test_source_is_tsl_recognition(self):
@@ -141,7 +143,9 @@ class TestEmitPartial:
 
     def test_confidence_from_tsl_result(self):
         policy = SignFusionPolicy()
-        seg = policy.emit_partial(_SESSION, "X", _tsl(confidence=0.72), replaces_id=None)
+        seg = policy.emit_partial(
+            _SESSION, "X", _tsl(confidence=0.72), replaces_id=None
+        )
         assert seg.confidence == 0.72
 
     def test_session_id_set(self):
@@ -179,12 +183,16 @@ class TestEmitPartial:
 class TestEmitFinalFromLlm:
     def test_returns_final_segment(self):
         policy = SignFusionPolicy()
-        seg = policy.emit_final_from_llm(_SESSION, "MERHABA", _gloss(), replaces_id=None)
+        seg = policy.emit_final_from_llm(
+            _SESSION, "MERHABA", _gloss(), replaces_id=None
+        )
         assert seg.status == SegmentStatus.FINAL
 
     def test_text_is_llm_output(self):
         policy = SignFusionPolicy()
-        seg = policy.emit_final_from_llm(_SESSION, "MERHABA", _gloss(text="Merhaba dünya."), replaces_id=None)
+        seg = policy.emit_final_from_llm(
+            _SESSION, "MERHABA", _gloss(text="Merhaba dünya."), replaces_id=None
+        )
         assert seg.text == "Merhaba dünya."
 
     def test_source_is_gloss_to_text(self):
@@ -194,12 +202,16 @@ class TestEmitFinalFromLlm:
 
     def test_confidence_from_llm_result(self):
         policy = SignFusionPolicy()
-        seg = policy.emit_final_from_llm(_SESSION, "X", _gloss(confidence=0.73), replaces_id=None)
+        seg = policy.emit_final_from_llm(
+            _SESSION, "X", _gloss(confidence=0.73), replaces_id=None
+        )
         assert seg.confidence == 0.73
 
     def test_replaces_id_forwarded(self):
         policy = SignFusionPolicy()
-        seg = policy.emit_final_from_llm(_SESSION, "X", _gloss(), replaces_id=_PREV_PARTIAL_ID)
+        seg = policy.emit_final_from_llm(
+            _SESSION, "X", _gloss(), replaces_id=_PREV_PARTIAL_ID
+        )
         assert seg.replaces_segment_id == _PREV_PARTIAL_ID
 
     def test_replaces_id_none_when_omitted(self):
@@ -217,16 +229,24 @@ class TestEmitFinalFromGloss:
     def test_returns_final_segment(self):
         policy = SignFusionPolicy()
         seg = policy.emit_final_from_gloss(
-            _SESSION, "YEMEK OKUL", aggregate_conf=0.60,
-            timestamp_ms=1000, duration_ms=2000, replaces_id=None,
+            _SESSION,
+            "YEMEK OKUL",
+            aggregate_conf=0.60,
+            timestamp_ms=1000,
+            duration_ms=2000,
+            replaces_id=None,
         )
         assert seg.status == SegmentStatus.FINAL
 
     def test_text_is_raw_gloss_phrase(self):
         policy = SignFusionPolicy()
         seg = policy.emit_final_from_gloss(
-            _SESSION, "YEMEK OKUL", aggregate_conf=0.60,
-            timestamp_ms=1000, duration_ms=2000, replaces_id=None,
+            _SESSION,
+            "YEMEK OKUL",
+            aggregate_conf=0.60,
+            timestamp_ms=1000,
+            duration_ms=2000,
+            replaces_id=None,
         )
         assert seg.text == "YEMEK OKUL"
 
@@ -234,24 +254,36 @@ class TestEmitFinalFromGloss:
         # Raw-gloss fallback still originates from TSL, not GlossToText.
         policy = SignFusionPolicy()
         seg = policy.emit_final_from_gloss(
-            _SESSION, "X", aggregate_conf=0.60,
-            timestamp_ms=1000, duration_ms=2000, replaces_id=None,
+            _SESSION,
+            "X",
+            aggregate_conf=0.60,
+            timestamp_ms=1000,
+            duration_ms=2000,
+            replaces_id=None,
         )
         assert seg.source == ModalityType.TSL_RECOGNITION
 
     def test_aggregate_confidence_used(self):
         policy = SignFusionPolicy()
         seg = policy.emit_final_from_gloss(
-            _SESSION, "X", aggregate_conf=0.58,
-            timestamp_ms=1000, duration_ms=2000, replaces_id=None,
+            _SESSION,
+            "X",
+            aggregate_conf=0.58,
+            timestamp_ms=1000,
+            duration_ms=2000,
+            replaces_id=None,
         )
         assert seg.confidence == 0.58
 
     def test_timestamp_and_duration_forwarded(self):
         policy = SignFusionPolicy()
         seg = policy.emit_final_from_gloss(
-            _SESSION, "X", aggregate_conf=0.60,
-            timestamp_ms=5000, duration_ms=3000, replaces_id=None,
+            _SESSION,
+            "X",
+            aggregate_conf=0.60,
+            timestamp_ms=5000,
+            duration_ms=3000,
+            replaces_id=None,
         )
         assert seg.timestamp_ms == 5000
         assert seg.duration_ms == 3000
@@ -259,8 +291,12 @@ class TestEmitFinalFromGloss:
     def test_replaces_id_forwarded(self):
         policy = SignFusionPolicy()
         seg = policy.emit_final_from_gloss(
-            _SESSION, "X", aggregate_conf=0.60,
-            timestamp_ms=1000, duration_ms=2000, replaces_id=_PREV_PARTIAL_ID,
+            _SESSION,
+            "X",
+            aggregate_conf=0.60,
+            timestamp_ms=1000,
+            duration_ms=2000,
+            replaces_id=_PREV_PARTIAL_ID,
         )
         assert seg.replaces_segment_id == _PREV_PARTIAL_ID
 
@@ -328,7 +364,8 @@ class TestFuseSuppressedModality:
     def test_low_confidence_gloss_ignored_tsl_emits_partial(self):
         policy = SignFusionPolicy()
         segments = policy.fuse(
-            [_tsl(confidence=0.80), _gloss(confidence=0.10)], _health(),
+            [_tsl(confidence=0.80), _gloss(confidence=0.10)],
+            _health(),
         )
         assert len(segments) == 1
         assert segments[0].status == SegmentStatus.PARTIAL
@@ -337,7 +374,8 @@ class TestFuseSuppressedModality:
     def test_low_confidence_tsl_with_valid_gloss_emits_final(self):
         policy = SignFusionPolicy()
         segments = policy.fuse(
-            [_tsl(confidence=0.10), _gloss(confidence=0.85)], _health(),
+            [_tsl(confidence=0.10), _gloss(confidence=0.85)],
+            _health(),
         )
         assert len(segments) == 1
         assert segments[0].status == SegmentStatus.FINAL

--- a/tests/inference/sign/test_gloss_to_text_engine.py
+++ b/tests/inference/sign/test_gloss_to_text_engine.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock, patch
+import math
+from unittest.mock import MagicMock
 
 import pytest
 import torch
@@ -26,6 +27,34 @@ def _make_config(model_id: str = "gemma-9b-gloss-tr") -> ModelConfig:
             "load_in_4bit": False,
         },
     )
+
+
+def _make_generate_output(
+    sequences: torch.Tensor,
+    sequences_scores: torch.Tensor | None = None,
+) -> MagicMock:
+    """Build a mock that mimics HuggingFace GenerateBeamDecoderOnlyOutput."""
+    out = MagicMock()
+    out.sequences = sequences
+    out.sequences_scores = sequences_scores
+    return out
+
+
+def _loaded_engine():
+    """Return a GlossToTextEngine with model/tokenizer mocked out."""
+    from sozia.server.inference.sign.gloss_to_text_engine import GlossToTextEngine
+
+    engine = GlossToTextEngine()
+    engine._model_id = "gemma-9b-gloss-tr"
+    engine._base_model_id = "google/gemma-2-9b-it"
+    engine._device = torch.device("cpu")
+
+    tok_output = MagicMock()
+    tok_output.input_ids = torch.tensor([[1, 2, 3]])  # input_len = 3
+    tok_output.attention_mask = torch.tensor([[1, 1, 1]])
+    engine._tokenizer = MagicMock(return_value=tok_output)
+    engine._tokenizer.decode.return_value = "merhaba dünya"  # pre-polish
+    return engine
 
 
 # ---------------------------------------------------------------------------
@@ -87,6 +116,53 @@ class TestFormatChat:
 
 
 # ---------------------------------------------------------------------------
+# _extract_confidence helper
+# ---------------------------------------------------------------------------
+
+
+class TestExtractConfidence:
+    def test_sequences_scores_converted_via_exp(self):
+        from sozia.server.inference.sign.gloss_to_text_engine import _extract_confidence
+
+        score = -0.5
+        output = _make_generate_output(
+            sequences=torch.tensor([[1]]),
+            sequences_scores=torch.tensor([score]),
+        )
+        expected = math.exp(score)
+        assert abs(_extract_confidence(output) - expected) < 1e-5
+
+    def test_confidence_clamped_to_1_for_positive_score(self):
+        from sozia.server.inference.sign.gloss_to_text_engine import _extract_confidence
+
+        output = _make_generate_output(
+            sequences=torch.tensor([[1]]),
+            sequences_scores=torch.tensor([2.0]),  # exp(2) > 1
+        )
+        assert _extract_confidence(output) == 1.0
+
+    def test_confidence_clamped_to_0_for_very_negative_score(self):
+        from sozia.server.inference.sign.gloss_to_text_engine import _extract_confidence
+
+        output = _make_generate_output(
+            sequences=torch.tensor([[1]]),
+            sequences_scores=torch.tensor([-100.0]),  # exp(-100) ≈ 0
+        )
+        assert _extract_confidence(output) == pytest.approx(0.0, abs=1e-6)
+
+    def test_fallback_when_sequences_scores_is_none(self):
+        from sozia.server.inference.sign.gloss_to_text_engine import _extract_confidence
+
+        output = _make_generate_output(
+            sequences=torch.tensor([[1]]),
+            sequences_scores=None,
+        )
+        # Fallback: exp(-1.0) — any value in [0, 1] is acceptable.
+        result = _extract_confidence(output)
+        assert 0.0 <= result <= 1.0
+
+
+# ---------------------------------------------------------------------------
 # Engine state tests
 # ---------------------------------------------------------------------------
 
@@ -112,6 +188,11 @@ class TestGlossToTextEngineState:
         assert engine.get_model_id() == ""
 
 
+# ---------------------------------------------------------------------------
+# predict() — confidence wired from beam sequences_scores
+# ---------------------------------------------------------------------------
+
+
 class TestGlossToTextEnginePredict:
     async def test_predict_raises_when_not_loaded(self):
         from sozia.server.inference.sign.gloss_to_text_engine import GlossToTextEngine
@@ -121,25 +202,12 @@ class TestGlossToTextEnginePredict:
             await engine.predict("MERHABA")
 
     async def test_predict_returns_modality_result(self):
-        from sozia.server.inference.sign.gloss_to_text_engine import GlossToTextEngine
-
-        engine = GlossToTextEngine()
-        engine._model_id = "gemma-9b-gloss-tr"
-        engine._base_model_id = "google/gemma-2-9b-it"
-        engine._device = torch.device("cpu")
-
-        # Mock tokenizer — must return an object with .input_ids / .attention_mask
-        tok_output = MagicMock()
-        tok_output.input_ids = torch.tensor([[1, 2, 3]])
-        tok_output.attention_mask = torch.tensor([[1, 1, 1]])
-        mock_tokenizer = MagicMock(return_value=tok_output)
-        mock_tokenizer.decode.return_value = "Merhaba dünya."
-        engine._tokenizer = mock_tokenizer
-
-        # Mock model
-        mock_model = MagicMock()
-        mock_model.generate.return_value = torch.tensor([[1, 2, 3, 4, 5, 6]])
-        engine._model = mock_model
+        engine = _loaded_engine()
+        engine._model = MagicMock()
+        engine._model.generate.return_value = _make_generate_output(
+            sequences=torch.tensor([[1, 2, 3, 4, 5, 6]]),
+            sequences_scores=torch.tensor([-0.3]),
+        )
 
         result = await engine.predict("MERHABA DUNYA")
         assert result.modality_type == ModalityType.GLOSS_TO_TEXT
@@ -147,25 +215,81 @@ class TestGlossToTextEnginePredict:
         assert 0.0 <= result.confidence <= 1.0
         assert result.inference_latency_ms >= 0
 
-    async def test_predict_empty_output_gives_zero_confidence(self):
-        from sozia.server.inference.sign.gloss_to_text_engine import GlossToTextEngine
+    async def test_confidence_derived_from_sequences_scores(self):
+        """Real beam score → exp(score) replaces the old 0.85 heuristic."""
+        engine = _loaded_engine()
+        known_score = -0.4
+        engine._model = MagicMock()
+        engine._model.generate.return_value = _make_generate_output(
+            sequences=torch.tensor([[1, 2, 3, 4]]),
+            sequences_scores=torch.tensor([known_score]),
+        )
 
-        engine = GlossToTextEngine()
-        engine._model_id = "gemma-9b-gloss-tr"
-        engine._base_model_id = "google/gemma-2-9b-it"
-        engine._device = torch.device("cpu")
+        result = await engine.predict("MERHABA")
+        expected_conf = math.exp(known_score)
+        assert abs(result.confidence - expected_conf) < 1e-4
 
-        tok_output = MagicMock()
-        tok_output.input_ids = torch.tensor([[1, 2, 3]])
-        tok_output.attention_mask = torch.tensor([[1, 1, 1]])
-        mock_tokenizer = MagicMock(return_value=tok_output)
-        mock_tokenizer.decode.return_value = ""
-        engine._tokenizer = mock_tokenizer
-
+    async def test_confidence_is_not_hardcoded_085(self):
+        """Ensure the old 0.85 literal is gone — two calls with different scores differ."""
+        engine = _loaded_engine()
         mock_model = MagicMock()
-        mock_model.generate.return_value = torch.tensor([[1, 2, 3]])
         engine._model = mock_model
+
+        mock_model.generate.return_value = _make_generate_output(
+            sequences=torch.tensor([[1, 2, 3, 4]]),
+            sequences_scores=torch.tensor([-0.2]),
+        )
+        r1 = await engine.predict("A")
+
+        mock_model.generate.return_value = _make_generate_output(
+            sequences=torch.tensor([[1, 2, 3, 4]]),
+            sequences_scores=torch.tensor([-1.5]),
+        )
+        r2 = await engine.predict("B")
+
+        assert r1.confidence != r2.confidence
+
+    async def test_generate_kwargs_include_return_dict_and_output_scores(self):
+        """Verify generate() is called with the flags needed for sequences_scores."""
+        engine = _loaded_engine()
+        engine._model = MagicMock()
+        engine._model.generate.return_value = _make_generate_output(
+            sequences=torch.tensor([[1, 2, 3, 4]]),
+            sequences_scores=torch.tensor([-0.5]),
+        )
+
+        await engine.predict("X")
+
+        call_kwargs = engine._model.generate.call_args.kwargs
+        assert call_kwargs.get("return_dict_in_generate") is True
+        assert call_kwargs.get("output_scores") is True
+
+    async def test_empty_output_gives_zero_confidence(self):
+        engine = _loaded_engine()
+        engine._tokenizer.decode.return_value = ""
+        engine._model = MagicMock()
+        engine._model.generate.return_value = _make_generate_output(
+            sequences=torch.tensor([[1, 2, 3]]),
+            sequences_scores=torch.tensor([-0.3]),
+        )
 
         result = await engine.predict("MERHABA")
         assert result.confidence == 0.0
         assert result.text == ""
+
+    async def test_predict_timeout_raises_inference_timeout_error(self):
+        import asyncio
+        from unittest.mock import patch
+
+        engine = _loaded_engine()
+        engine._model = MagicMock()
+
+        async def _slow_coro(*_args, **_kwargs):
+            await asyncio.sleep(10)
+
+        with patch(
+            "sozia.server.inference.sign.gloss_to_text_engine.asyncio.to_thread",
+            side_effect=_slow_coro,
+        ):
+            with pytest.raises(InferenceTimeoutError):
+                await engine.predict("MERHABA", timeout_ms=1)


### PR DESCRIPTION
## What does this PR do?

Two things.

First, a batch of bugfixes from the first live run of the sign path: wrong `weights_only` on PyTorch 2.6, deprecated `torch_dtype`, missing runtime deps, 507-dim feature mismatch, merged Gemma checkpoint loading, GlossToText suppression bug, confidence threshold 0.30 → 0.55, hands-off flush, sign-path logging.

Second, multi-word accumulation. The old pipeline fed one gloss at a time to the LLM, which was trained on phrases. Now `ActivityDetector` gates activity with presence+motion hysteresis; `GlossAccumulator` collects words with consecutive-repeat dedup; `FrameAccumulator` uses a rolling 30/10 window; `SignFusionPolicy` gets separate TSL (0.55) and LLM (0.40) thresholds. `_process_sign` is rewritten around AD events: ACTIVE grows a PARTIAL word by word, ENDED flushes the phrase to GlossToText and emits a FINAL. GlossToText confidence now comes from real beam `sequences_scores` instead of a hardcoded 0.85.

Tested live. PARTIAL grows word by word, FINAL fires on hands drop.

## Which package(s) does it touch?

`sozia/server/fusion/`, `sozia/server/inference/sign/`, `requirements.txt`

## How to test

`pytest tests/fusion/ tests/inference/sign/` — 568 passing.

Live: start the server against deployed weights, sign a two-word phrase, watch the PARTIAL grow, drop hands, FINAL replaces it.

## Checklist
- [x] Follows commit convention (`<type>(<scope>): <description>`)
- [x] Added/updated tests (if applicable)
- [x] No sozia.common schema changes (or: both repos updated)
- [x] Tested locally

Closes #42, #43, #44, #49, #50, #51, #52