### PR TITLE
test(fusion): cover TC-24 lip-reliance leg in degraded integration

### DIFF
--- a/tests/fusion/test_integration_with_engines.py
+++ b/tests/fusion/test_integration_with_engines.py
@@ -287,6 +287,35 @@ class TestDegradedIntegration:
         # 0.70 - 0.15 = 0.55
         assert abs(segments[0].confidence - 0.55) < 0.001
 
+    async def test_low_snr_with_lip_reading_fusion_favours_lip(self):
+        """Low SNR + both modalities: fusion runs without penalty, lip text wins.
+
+        With two results process_features bypasses the degraded handler and calls
+        policy.fuse directly.  The higher-confidence lip result should win, which
+        is exactly the 'increased lip-reading reliance' leg of TC-24.
+        """
+        asr = _StubEngine(_result(ModalityType.ASR, "gürültü", 0.60))
+        lip = _StubEngine(_result(ModalityType.LIP_READING, "net konuşma", 0.75))
+        await asr.load_model(_config("whisper-small-tr"))
+        await lip.load_model(_config("lip-reading-v1"))
+
+        asr_out = await asr.predict(features=None)
+        lip_out = await lip.predict(features=None)
+
+        orch = _build_orchestrator()
+        segments = await orch.process_features(
+            _SESSION,
+            [asr_out, lip_out],
+            [_audio_health(snr=2.0)],
+            ModalityPath.SPEECH,
+        )
+
+        assert len(segments) == 1
+        seg = segments[0]
+        assert seg.status == SegmentStatus.FINAL
+        assert seg.text == "net konuşma"
+        assert seg.source == ModalityType.LIP_READING
+
 
 # ---------------------------------------------------------------------------
 # Engine lifecycle + fusion contract


### PR DESCRIPTION
## What does this PR do?

Adds an integration test for the high-noise degradation scenario (TC-24) where both ASR and lip-reading results are available. Verifies that when SNR is below threshold and two modalities are present, `process_features` routes to `policy.fuse` (not the degraded handler), and the higher-confidence lip result wins.

## Which package(s) does it touch?

`tests/fusion`

## How to test

```
python -m pytest tests/fusion/test_integration_with_engines.py::TestDegradedIntegration -q
```

## Checklist
- [x] Follows commit convention (`<type>(<scope>): <description>`)
- [x] Added/updated tests (if applicable)
- [x] No sozia.common schema changes (or: both repos updated)
- [x] Tested locally

Closes #61