### PR TITLE
fix(models): accept 4-component pose landmarks and fix TSL dtype bugs

### DIFF
--- a/sozia/common/models.py
+++ b/sozia/common/models.py
@@ -91,22 +91,25 @@ def _validate_landmark_array(
     expected_len: int,
     name: str,
     check_xy_unit_range: bool = False,
+    components: int = 3,
 ) -> None:
     """Validate a landmark array's length and point dimensions.
 
     Args:
-        arr: 2-D list of landmark points, each [x, y, z].
+        arr: 2-D list of landmark points.
         expected_len: Required number of points.
         name: Field name for error messages.
         check_xy_unit_range: If True, enforce x and y coords in [0.0, 1.0].
             z is always unconstrained (MediaPipe relative depth).
+        components: Expected number of values per point. 3 for face/hand
+            ([x, y, z]), 4 for pose ([x, y, z, visibility]).
     """
     if len(arr) != expected_len:
         raise ValueError(f"{name} must have {expected_len} points, got {len(arr)}")
     for i, point in enumerate(arr):
-        if len(point) != 3:
+        if len(point) != components:
             raise ValueError(
-                f"{name}[{i}] must have 3 coordinates [x, y, z], got {len(point)}"
+                f"{name}[{i}] must have {components} coordinates, got {len(point)}"
             )
         if check_xy_unit_range:
             x, y = point[0], point[1]
@@ -276,7 +279,7 @@ class LandmarkFrame:
             detected.
         left_hand_landmarks: 21 × [x, y, z]. None if not detected.
         right_hand_landmarks: 21 × [x, y, z]. None if not detected.
-        pose_landmarks: 33 × [x, y, z]. None if not detected.
+        pose_landmarks: 33 × [x, y, z, visibility]. None if not detected.
     """
 
     session_id: str
@@ -328,6 +331,7 @@ class LandmarkFrame:
                 POSE_LANDMARK_COUNT,
                 "pose_landmarks",
                 check_xy_unit_range=False,
+                components=4,
             )
 
 

--- a/sozia/server/inference/sign/tsl_recognition_engine.py
+++ b/sozia/server/inference/sign/tsl_recognition_engine.py
@@ -229,8 +229,11 @@ class TslRecognitionEngine(InferenceEngine):
         x = torch.tensor(kp_array, dtype=torch.float32).unsqueeze(0).to(self._device)
         lengths = torch.tensor([actual_length], dtype=torch.long).to(self._device)
 
-        with torch.no_grad():
-            logits = self._model(x, lengths=lengths)
+        # Disable autocast: GlossToTextEngine runs bfloat16 autocast on shared
+        # thread-pool threads; without this guard the TSL BatchNorm receives
+        # BFloat16 tensors and raises a dtype mismatch.
+        with torch.no_grad(), torch.amp.autocast("cuda", enabled=False):
+            logits = self._model(x.float(), lengths=lengths)
             probs = torch.softmax(logits, dim=1).cpu().numpy()[0]
 
         top_k = min(5, len(probs))

--- a/sozia/server/inference/sign/tsl_recognition_engine.py
+++ b/sozia/server/inference/sign/tsl_recognition_engine.py
@@ -281,6 +281,7 @@ class TslRecognitionEngine(InferenceEngine):
         state_dict = torch.load(ckpt_path, map_location=device, weights_only=False)
         model.load_state_dict(state_dict)
         model.to(device)
+        model.float()  # checkpoint may be BFloat16 on RTX 5090; normalise to float32
         model.eval()
 
         # Load scaler.

--- a/tests/common/test_models.py
+++ b/tests/common/test_models.py
@@ -268,7 +268,7 @@ class TestLandmarkFrame:
     def _make(self, **kwargs):
         face = [[0.5, 0.5, 0.0]] * 83
         hand = [[0.5, 0.5, 0.0]] * 21
-        pose = [[0.5, 0.5, 0.0]] * 33
+        pose = [[0.5, 0.5, 0.0, 0.9]] * 33
         defaults = dict(
             session_id="550e8400-e29b-41d4-a716-446655440000",
             timestamp_ms=0,
@@ -322,7 +322,11 @@ class TestLandmarkFrame:
 
     def test_pose_wrong_length_raises(self):
         with pytest.raises(ValueError):
-            self._make(pose_landmarks=[[0.5, 0.5, 0.0]] * 10)
+            self._make(pose_landmarks=[[0.5, 0.5, 0.0, 0.9]] * 10)
+
+    def test_pose_missing_visibility_raises(self):
+        with pytest.raises(ValueError):
+            self._make(pose_landmarks=[[0.5, 0.5, 0.0]] * 33)
 
     def test_point_wrong_dims_raises(self):
         bad = [[0.5, 0.5]] * 83  # missing z

--- a/tests/fusion/test_activity_detector.py
+++ b/tests/fusion/test_activity_detector.py
@@ -28,11 +28,11 @@ def _pose_at(wx: float = 0.5, wy: float = 0.5) -> list[list[float]]:
     Indices 15 (left wrist) and 16 (right wrist) are set to (wx, wy, 0.0).
     All other points are (0.0, 0.0, 0.0).
     """
-    points = [[0.0, 0.0, 0.0]] * POSE_LANDMARK_COUNT
+    points = [[0.0, 0.0, 0.0, 1.0]] * POSE_LANDMARK_COUNT
     # list is shared — replace with distinct lists to avoid aliasing
     points = [list(p) for p in points]
-    points[15] = [wx, wy, 0.0]
-    points[16] = [wx, wy, 0.0]
+    points[15] = [wx, wy, 0.0, 1.0]
+    points[16] = [wx, wy, 0.0, 1.0]
     return points
 
 

--- a/tests/fusion/test_frame_accumulator.py
+++ b/tests/fusion/test_frame_accumulator.py
@@ -23,9 +23,7 @@ _SESSION_B = "660e8400-e29b-41d4-a716-446655440000"
 
 def _pose() -> list[list[float]]:
     n = POSE_LANDMARK_COUNT
-    # LandmarkFrame validates exactly 3 coordinates per point; _flatten_pose
-    # pads visibility=1.0 internally when the 4th component is absent.
-    return [[i / n, (n - 1 - i) / n, float(i)] for i in range(n)]
+    return [[i / n, (n - 1 - i) / n, float(i), 0.9] for i in range(n)]
 
 
 def _face() -> list[list[float]]:
@@ -352,19 +350,18 @@ class TestNumpyValues:
         assert np.all(right_slice == 0.0)
 
     def test_pose_xyz_values_match(self):
-        # _flatten_pose interleaves visibility=1.0 after each (x, y, z).
         frame = _frame(with_face=False, with_left=False, with_right=False)
         result = _single_frame_acc().add(frame)
-        raw = np.asarray(_pose(), dtype=np.float32)  # shape (33, 3)
+        raw = np.asarray(_pose(), dtype=np.float32)  # shape (33, 4)
         xyz_indices = [i * 4 + c for i in range(POSE_LANDMARK_COUNT) for c in range(3)]
-        np.testing.assert_array_almost_equal(result[0, xyz_indices], raw.ravel())
+        np.testing.assert_array_almost_equal(result[0, xyz_indices], raw[:, :3].ravel())
 
-    def test_pose_visibility_padded_to_1(self):
-        # _flatten_pose pads visibility=1.0 when only (x, y, z) are provided.
+    def test_pose_visibility_forwarded(self):
+        # _flatten_pose passes through the real visibility value from the client.
         frame = _frame(with_face=False, with_left=False, with_right=False)
         result = _single_frame_acc().add(frame)
         visibility_indices = [3 + i * 4 for i in range(POSE_LANDMARK_COUNT)]
-        assert np.all(result[0, visibility_indices] == 1.0)
+        np.testing.assert_array_almost_equal(result[0, visibility_indices], 0.9)
 
     def test_dtype_is_float32(self):
         result = _single_frame_acc().add(_frame())

--- a/tests/fusion/test_orchestrator_process.py
+++ b/tests/fusion/test_orchestrator_process.py
@@ -97,7 +97,7 @@ def _landmark_frame(
         face_landmarks=[[0.1, 0.2, 0.3]] * FACE_LANDMARK_COUNT,
         left_hand_landmarks=[[0.5, 0.5, 0.5]] * HAND_LANDMARK_COUNT,
         right_hand_landmarks=[[0.5, 0.5, 0.5]] * HAND_LANDMARK_COUNT,
-        pose_landmarks=[[i / n, (n - 1 - i) / n, float(i)] for i in range(n)],
+        pose_landmarks=[[i / n, (n - 1 - i) / n, float(i), 1.0] for i in range(n)],
     )
 
 


### PR DESCRIPTION
## What does this PR do?

Pose landmarks now require four components per point (`[x, y, z, visibility]`) instead of three. Before this, the server always padded visibility to `1.0` regardless of what the client sent. Two TSL inference bugs are also fixed here: BFloat16 autocast from the GlossToText thread was bleeding into TSL BatchNorm, and RTX 5090 checkpoints can be saved in BFloat16 even for float32 models.

Companion PR on sozia-client: `fix/landmark-feature-layout` (closes #111). Both should merge together.

Closes #64

## Which package(s) does it touch?

`sozia/common`, `sozia/server/inference/sign`

## How to test

Run `pytest`. All fixtures across `tests/common`, `tests/fusion`, and `tests/server` now use 4-component pose landmarks. Pass a `[x, y, z]` pose point to `LandmarkFrame` and confirm it raises `ValueError`.

On the integration side: connect the updated sozia-client build and confirm the server log shows non-`1.0` visibility values coming through on the sign path.

## Checklist
- [x] Follows commit convention (`<type>(<scope>): <description>`)
- [x] Added/updated tests (if applicable)
- [x] No sozia.common schema changes (or: both repos updated) — companion client PR is `fix/landmark-feature-layout`
- [x] Tested locally